### PR TITLE
[tui] Fix caret position after `undo` to retain it

### DIFF
--- a/tui/src/tui/editor/editor_buffer/editor_buffer_struct.rs
+++ b/tui/src/tui/editor/editor_buffer/editor_buffer_struct.rs
@@ -226,8 +226,10 @@ pub mod history {
     }
 
     pub fn undo(editor_buffer: &mut EditorBuffer) {
+        let retain_caret_position = editor_buffer.editor_content.caret_display_position;
         if let Some(content) = editor_buffer.history.previous_content() {
             editor_buffer.editor_content = content;
+            editor_buffer.editor_content.caret_display_position = retain_caret_position;
         }
 
         if DEBUG_TUI_COPY_PASTE {


### PR DESCRIPTION
Close #192 

https://github.com/r3bl-org/r3bl-open-core/assets/79367883/8a719312-f2e0-4405-9a75-a37210b7e8e7

