### PR TITLE
[tuify] [WIP] OffscreenBuffer based rendering for select_from_list

### DIFF
--- a/tuify/Cargo.toml
+++ b/tuify/Cargo.toml
@@ -44,6 +44,10 @@ log = { version = "0.4.20", features = ["std"] }
 # More info: https://stackoverflow.com/a/76131914/2085356
 clap = { version = "4.4.6", features = ["derive", "wrap_help"] }
 reedline = "0.25.0"
+serde = { version = "1.0.189", features = ["derive"] }
+
+# Get size
+get-size = { version = "0.1.4", features = ["derive"] }
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/tuify/src/components/style.rs
+++ b/tuify/src/components/style.rs
@@ -14,8 +14,7 @@
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-
-use r3bl_ansi_color::Color;
+use r3bl_rs_utils_core::*;
 
 #[derive(Copy, Clone, Debug)]
 pub struct StyleSheet {
@@ -26,15 +25,32 @@ pub struct StyleSheet {
 
 impl Default for StyleSheet {
     fn default() -> Self {
-        let normal_style = Style::default();
+        let normal_style = Style {
+            color_fg: Some(TuiColor::Rgb(RgbValue {
+                red: 200, green: 200, blue:1
+            })),
+            color_bg: Some(TuiColor::Rgb(RgbValue {
+                red: 100, green: 60, blue: 150
+            })),
+            ..Style::default()
+
+        };
         let selected_style = Style {
-            fg_color: Color::Rgb(250, 250, 250),
-            bg_color: Color::Rgb(39, 45, 239),
+            color_fg: Some(TuiColor::Rgb(RgbValue {
+                red:250, green:250, blue:250
+            })),
+            color_bg: Some(TuiColor::Rgb(RgbValue {
+                red:39, green:45, blue:239
+            })),
             ..Style::default()
         };
         let header_style = Style {
-            fg_color: Color::Rgb(50, 50, 50),
-            bg_color: Color::Rgb(150, 150, 150),
+            color_fg: Some(TuiColor::Rgb(RgbValue {
+                red:50, green:50, blue:50
+            })),
+            color_bg: Some(TuiColor::Rgb(RgbValue {
+                red:150, green:150, blue:150
+            })),
             bold: true,
             ..Style::default()
         };
@@ -42,35 +58,6 @@ impl Default for StyleSheet {
             normal_style,
             selected_style,
             header_style,
-        }
-    }
-}
-
-#[derive(Copy, Clone, Debug)]
-pub struct Style {
-    pub bold: bool,
-    pub italic: bool,
-    pub dim: bool,
-    pub underline: bool,
-    pub reverse: bool,
-    pub hidden: bool,
-    pub strikethrough: bool,
-    pub fg_color: Color,
-    pub bg_color: Color,
-}
-
-impl Default for Style {
-    fn default() -> Self {
-        Style {
-            bold: false,
-            italic: false,
-            dim: false,
-            underline: false,
-            reverse: false,
-            hidden: false,
-            strikethrough: false,
-            fg_color: Color::Rgb(200, 200, 1),
-            bg_color: Color::Rgb(100, 60, 150),
         }
     }
 }

--- a/tuify/src/lib.rs
+++ b/tuify/src/lib.rs
@@ -308,6 +308,9 @@ pub mod react;
 pub mod scroll;
 pub mod state;
 pub mod term;
+pub mod terminal_window;
+pub mod misc_types;
+mod terminal_lib_backends;
 
 pub use components::*;
 pub use event_loop::*;
@@ -317,6 +320,33 @@ pub use react::*;
 pub use scroll::*;
 pub use state::*;
 pub use term::*;
+pub use terminal_window::*;
+pub use misc_types::*;
+pub use terminal_lib_backends::*;
+
+/// This is the global `DEBUG` const. It is possible to create local (module scoped) `DEBUG` const.
+/// However, you would have to use that symbol explicitly in the relevant module, eg:
+/// - `use $crate::terminal_lib_backends::DEBUG_TUI...;`
+///
+/// If set to `true`:
+/// 1. Enables file logging for entire module.
+/// 2. If a call to [r3bl_rs_utils_core::log_info], [r3bl_rs_utils_core::log_debug],
+///    [r3bl_rs_utils_core::log_warn], [r3bl_rs_utils_core::log_trace],
+///    [r3bl_rs_utils_core::log_error] fails, then it will print the error to stderr.
+pub const TRACE: bool = true;
+pub const HEADER_HEIGHT : usize = 1;
 
 /// Enable file logging. You can use `tail -f log.txt` to watch the logs.
-pub const TRACE: bool = true;
+pub const DEBUG_TUIFY_MOD: bool = true;
+
+/// Enable or disable compositor debug logging.
+pub const DEBUG_TUIFY_COMPOSITOR: bool = false;
+
+/// Controls input event debugging [crate::EventStreamExt], and execution of render ops [crate::exec_render_op!] debugging
+/// output.
+pub const DEBUG_TUIFY_SHOW_TERMINAL_BACKEND: bool = false;
+
+// Enable or disable debug logging for this `terminal_lib_backends` module.
+pub const DEBUG_TUIFY_SHOW_PIPELINE: bool = false;
+pub const DEBUG_TUIFY_SHOW_PIPELINE_EXPANDED: bool = false;
+

--- a/tuify/src/misc_types.rs
+++ b/tuify/src/misc_types.rs
@@ -1,0 +1,82 @@
+use std::{ops::{AddAssign, Deref, DerefMut}};
+
+pub mod global_constants {
+
+    pub const SPACER: &str = " ";
+
+}
+pub use global_constants::*;
+
+pub mod list_of {
+    use get_size::GetSize;
+    use serde::{Deserialize, Serialize};
+
+    use super::*;
+
+    #[macro_export]
+    macro_rules! list {
+        (
+            $($item: expr),*
+            $(,)* /* Optional trailing comma https://stackoverflow.com/a/43143459/2085356. */
+        ) => {
+            {
+                #[allow(unused_mut)]
+                let mut it = List::new();
+                $(
+                    it.items.push($item);
+                )*
+                it
+            }
+        };
+    }
+
+    /// Redundant struct to [Vec]. Added so that [From] trait can be implemented for for [List] of
+    /// `T`. Where `T` is any number of types in the tui crate.
+    #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, GetSize)]
+    pub struct List<T> {
+        pub items: Vec<T>,
+    }
+
+    impl<T> List<T> {
+        pub fn with_capacity(size: usize) -> Self {
+            Self {
+                items: Vec::with_capacity(size),
+            }
+        }
+
+        pub fn new() -> Self { Self { items: Vec::new() } }
+    }
+
+    /// Add (other) item to list (self).
+    impl<T> AddAssign<T> for List<T> {
+        fn add_assign(&mut self, other_item: T) { self.push(other_item); }
+    }
+
+    /// Add (other) list to list (self).
+    impl<T> AddAssign<List<T>> for List<T> {
+        fn add_assign(&mut self, other_list: List<T>) { self.extend(other_list.items); }
+    }
+
+    /// Add (other) vec to list (self).
+    impl<T> AddAssign<Vec<T>> for List<T> {
+        fn add_assign(&mut self, other_vec: Vec<T>) { self.extend(other_vec); }
+    }
+
+    impl<T> From<List<T>> for Vec<T> {
+        fn from(list: List<T>) -> Self { list.items }
+    }
+
+    impl<T> From<Vec<T>> for List<T> {
+        fn from(other: Vec<T>) -> Self { Self { items: other } }
+    }
+
+    impl<T> Deref for List<T> {
+        type Target = Vec<T>;
+        fn deref(&self) -> &Self::Target { &self.items }
+    }
+
+    impl<T> DerefMut for List<T> {
+        fn deref_mut(&mut self) -> &mut Self::Target { &mut self.items }
+    }
+}
+pub use list_of::*;

--- a/tuify/src/public_api.rs
+++ b/tuify/src/public_api.rs
@@ -44,8 +44,8 @@ pub fn select_from_list(
     }
 
     // There are fewer items than viewport height. So make viewport shorter.
-    let max_height_row_count = if items.len() <= max_height_row_count {
-        items.len()
+    let max_height_row_count = if items.len()+HEADER_HEIGHT <= max_height_row_count {
+        items.len()+HEADER_HEIGHT
     } else {
         max_height_row_count
     };

--- a/tuify/src/scroll.rs
+++ b/tuify/src/scroll.rs
@@ -63,7 +63,7 @@
 use crossterm::style::Stylize;
 use r3bl_rs_utils_core::*;
 
-use crate::TRACE;
+use crate::{HEADER_HEIGHT, TRACE};
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum CaretVerticalViewportLocation {
@@ -113,64 +113,14 @@ pub fn locate_cursor_in_viewport(
     }
     // When comparing height or width or size to index, we need to subtract 1.
     else if abs_row_index > scroll_offset_row_index
-        && abs_row_index < (scroll_offset_row_index + display_height - 1)
+        && abs_row_index < (scroll_offset_row_index + display_height-2)
     {
         CaretVerticalViewportLocation::InMiddleOfViewport
-    } else if abs_row_index == (scroll_offset_row_index + display_height - 1) {
+    } else if abs_row_index == (scroll_offset_row_index + display_height - ch!(HEADER_HEIGHT) - 1) {
         CaretVerticalViewportLocation::AtBottomOfViewport
-    } else if abs_row_index > (scroll_offset_row_index + display_height - 1) {
+    } else if abs_row_index > (scroll_offset_row_index + display_height - ch!(HEADER_HEIGHT) - 1) {
         CaretVerticalViewportLocation::BelowBottomOfViewport
     } else {
         CaretVerticalViewportLocation::NotFound
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use pretty_assertions::assert_eq;
-
-    use super::*;
-    #[test]
-    fn test_get_scroll_adjusted_row_index() {
-        assert_eq!(get_scroll_adjusted_row_index(ch!(0), ch!(0)), ch!(0));
-        assert_eq!(get_scroll_adjusted_row_index(ch!(1), ch!(0)), ch!(1));
-        assert_eq!(get_scroll_adjusted_row_index(ch!(0), ch!(1)), ch!(1));
-        assert_eq!(get_scroll_adjusted_row_index(ch!(2), ch!(3)), ch!(5));
-    }
-
-    #[test]
-    fn test_locate_cursor_in_viewport() {
-        assert_eq!(
-            locate_cursor_in_viewport(ch!(0), ch!(0), ch!(10), ch!(20)),
-            CaretVerticalViewportLocation::AtAbsoluteTop
-        );
-        assert_eq!(
-            locate_cursor_in_viewport(ch!(19), ch!(0), ch!(10), ch!(20)),
-            CaretVerticalViewportLocation::AtAbsoluteBottom
-        );
-        assert_eq!(
-            locate_cursor_in_viewport(ch!(5), ch!(0), ch!(10), ch!(20)),
-            CaretVerticalViewportLocation::InMiddleOfViewport
-        );
-        assert_eq!(
-            locate_cursor_in_viewport(ch!(0), ch!(5), ch!(10), ch!(20)),
-            CaretVerticalViewportLocation::AtTopOfViewport
-        );
-        assert_eq!(
-            locate_cursor_in_viewport(ch!(5), ch!(5), ch!(10), ch!(20)),
-            CaretVerticalViewportLocation::InMiddleOfViewport
-        );
-        assert_eq!(
-            locate_cursor_in_viewport(ch!(14), ch!(5), ch!(10), ch!(20)),
-            CaretVerticalViewportLocation::AtAbsoluteBottom
-        );
-        assert_eq!(
-            locate_cursor_in_viewport(ch!(15), ch!(5), ch!(10), ch!(20)),
-            CaretVerticalViewportLocation::BelowBottomOfViewport
-        );
-        assert_eq!(
-            locate_cursor_in_viewport(ch!(21), ch!(5), ch!(10), ch!(20)),
-            CaretVerticalViewportLocation::BelowBottomOfViewport
-        );
     }
 }

--- a/tuify/src/state.rs
+++ b/tuify/src/state.rs
@@ -19,6 +19,11 @@ use r3bl_rs_utils_core::*;
 
 use crate::*;
 
+pub trait ViewportHeight {
+    fn get_viewport_height(&self) -> ChUnit;
+}
+
+
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone)]
 pub struct State {
     /// Does not include the header row.
@@ -32,6 +37,12 @@ pub struct State {
     pub selected_items: Vec<String>,
     pub header: String,
     pub selection_mode: SelectionMode,
+}
+
+impl ViewportHeight for State {
+    fn get_viewport_height(&self) -> ChUnit {
+        self.max_display_height
+    }
 }
 
 impl State {

--- a/tuify/src/terminal_lib_backends/color_converter.rs
+++ b/tuify/src/terminal_lib_backends/color_converter.rs
@@ -1,0 +1,136 @@
+use r3bl_ansi_color::{global_color_support, ColorSupport, TransformColor};
+use r3bl_rs_utils_core::*;
+#[rustfmt::skip]
+pub fn from_crossterm_color(value: crossterm::style::Color) -> TuiColor {
+    match value {
+        // Basic colors.
+        crossterm::style::Color::Reset       => TuiColor::Reset,
+        crossterm::style::Color::Black       => TuiColor::Basic(ANSIBasicColor::Black),
+        crossterm::style::Color::DarkGrey    => TuiColor::Basic(ANSIBasicColor::DarkGrey),
+        crossterm::style::Color::Red         => TuiColor::Basic(ANSIBasicColor::Red),
+        crossterm::style::Color::DarkRed     => TuiColor::Basic(ANSIBasicColor::DarkRed),
+        crossterm::style::Color::Green       => TuiColor::Basic(ANSIBasicColor::Green),
+        crossterm::style::Color::DarkGreen   => TuiColor::Basic(ANSIBasicColor::DarkGreen),
+        crossterm::style::Color::Yellow      => TuiColor::Basic(ANSIBasicColor::Yellow),
+        crossterm::style::Color::DarkYellow  => TuiColor::Basic(ANSIBasicColor::DarkYellow),
+        crossterm::style::Color::Blue        => TuiColor::Basic(ANSIBasicColor::Blue),
+        crossterm::style::Color::DarkBlue    => TuiColor::Basic(ANSIBasicColor::DarkBlue),
+        crossterm::style::Color::Magenta     => TuiColor::Basic(ANSIBasicColor::Magenta),
+        crossterm::style::Color::DarkMagenta => TuiColor::Basic(ANSIBasicColor::DarkMagenta),
+        crossterm::style::Color::Cyan        => TuiColor::Basic(ANSIBasicColor::Cyan),
+        crossterm::style::Color::DarkCyan    => TuiColor::Basic(ANSIBasicColor::DarkCyan),
+        crossterm::style::Color::White       => TuiColor::Basic(ANSIBasicColor::White),
+        crossterm::style::Color::Grey        => TuiColor::Basic(ANSIBasicColor::Grey),
+
+        // RGB colors.
+        crossterm::style::Color::Rgb { r, g, b } => TuiColor::Rgb(RgbValue {
+            red: r,
+            green: g,
+            blue: b,
+        }),
+
+        // ANSI colors.
+        crossterm::style::Color::AnsiValue(number) => {
+            TuiColor::Ansi(AnsiValue::new(number))
+        }
+    }
+}
+
+/// Respect the color support of the terminal and downgrade the color if needed. This really only
+/// applies to the [TuiColor::Rgb] variant.
+pub fn to_crossterm_color(from_tui_color: TuiColor) -> crossterm::style::Color {
+    match from_tui_color {
+        TuiColor::Reset => crossterm::style::Color::Reset,
+
+        TuiColor::Basic(from_basic_color) => match global_color_support::detect() {
+            // Convert to grayscale.
+            #[rustfmt::skip]
+            ColorSupport::NoColor | ColorSupport::Grayscale => match from_basic_color {
+                ANSIBasicColor::Black =>       crossterm::style::Color::Black,
+                ANSIBasicColor::White =>       crossterm::style::Color::White,
+                ANSIBasicColor::Grey =>        convert_rgb_to_ansi_grayscale(192, 192, 192),
+                ANSIBasicColor::DarkGrey =>    convert_rgb_to_ansi_grayscale(128, 128, 128),
+                ANSIBasicColor::Red =>         convert_rgb_to_ansi_grayscale(255, 0,   0),
+                ANSIBasicColor::DarkRed =>     convert_rgb_to_ansi_grayscale(128, 0,   0),
+                ANSIBasicColor::Green =>       convert_rgb_to_ansi_grayscale(0,   255, 0),
+                ANSIBasicColor::DarkGreen =>   convert_rgb_to_ansi_grayscale(0,   128, 0),
+                ANSIBasicColor::Yellow =>      convert_rgb_to_ansi_grayscale(255, 255, 0),
+                ANSIBasicColor::DarkYellow =>  convert_rgb_to_ansi_grayscale(128, 128, 0),
+                ANSIBasicColor::Blue =>        convert_rgb_to_ansi_grayscale(0,   0,   255),
+                ANSIBasicColor::DarkBlue =>    convert_rgb_to_ansi_grayscale(0,   0,   128),
+                ANSIBasicColor::Magenta =>     convert_rgb_to_ansi_grayscale(255, 0,   255),
+                ANSIBasicColor::DarkMagenta => convert_rgb_to_ansi_grayscale(128, 0,   128),
+                ANSIBasicColor::Cyan =>        convert_rgb_to_ansi_grayscale(0,   255, 255),
+                ANSIBasicColor::DarkCyan =>    convert_rgb_to_ansi_grayscale(0,   128, 128),
+            },
+
+            // Keep it as is.
+            #[rustfmt::skip]
+            ColorSupport::Ansi256 | ColorSupport::Truecolor => match from_basic_color {
+                ANSIBasicColor::Black =>        crossterm::style::Color::Black,
+                ANSIBasicColor::White =>        crossterm::style::Color::White,
+                ANSIBasicColor::Grey =>         crossterm::style::Color::Grey,
+                ANSIBasicColor::DarkGrey =>     crossterm::style::Color::DarkGrey,
+                ANSIBasicColor::Red =>          crossterm::style::Color::Red,
+                ANSIBasicColor::DarkRed =>      crossterm::style::Color::DarkRed,
+                ANSIBasicColor::Green =>        crossterm::style::Color::Green,
+                ANSIBasicColor::DarkGreen =>    crossterm::style::Color::DarkGreen,
+                ANSIBasicColor::Yellow =>       crossterm::style::Color::Yellow,
+                ANSIBasicColor::DarkYellow =>   crossterm::style::Color::DarkYellow,
+                ANSIBasicColor::Blue =>         crossterm::style::Color::Blue,
+                ANSIBasicColor::DarkBlue =>     crossterm::style::Color::DarkBlue,
+                ANSIBasicColor::Magenta =>      crossterm::style::Color::Magenta,
+                ANSIBasicColor::DarkMagenta =>  crossterm::style::Color::DarkMagenta,
+                ANSIBasicColor::Cyan =>         crossterm::style::Color::Cyan,
+                ANSIBasicColor::DarkCyan =>     crossterm::style::Color::DarkCyan,
+            },
+        },
+
+        TuiColor::Ansi(from_ansi_value) => {
+            match global_color_support::detect() {
+                // Keep it as is.
+                ColorSupport::Truecolor | ColorSupport::Ansi256 => {
+                    crossterm::style::Color::AnsiValue(from_ansi_value.color)
+                }
+
+                // Convert to grayscale.
+                ColorSupport::Grayscale | ColorSupport::NoColor => {
+                    let ansi_grayscale_color =
+                        r3bl_ansi_color::Color::Ansi256(from_ansi_value.color)
+                            .as_grayscale();
+                    crossterm::style::Color::AnsiValue(ansi_grayscale_color.index)
+                }
+            }
+        }
+
+        // Downgrade the color if needed.
+        TuiColor::Rgb(from_rgb_value) => {
+            let RgbValue {
+                red: r,
+                green: g,
+                blue: b,
+            } = from_rgb_value;
+
+            match global_color_support::detect() {
+                // Keep it as is.
+                ColorSupport::Truecolor => crossterm::style::Color::Rgb { r, g, b },
+
+                // Convert to ANSI256.
+                ColorSupport::Ansi256 => {
+                    let ansi_value = AnsiValue::from(from_rgb_value).color;
+                    crossterm::style::Color::AnsiValue(ansi_value)
+                }
+
+                // Convert to grayscale.
+                ColorSupport::NoColor | ColorSupport::Grayscale => {
+                    convert_rgb_to_ansi_grayscale(r, g, b)
+                }
+            }
+        }
+    }
+}
+
+fn convert_rgb_to_ansi_grayscale(r: u8, g: u8, b: u8) -> crossterm::style::Color {
+    let ansi_grayscale_color = r3bl_ansi_color::Color::Rgb(r, g, b).as_grayscale();
+    crossterm::style::Color::AnsiValue(ansi_grayscale_color.index)
+}

--- a/tuify/src/terminal_lib_backends/crossterm_backend/debug.rs
+++ b/tuify/src/terminal_lib_backends/crossterm_backend/debug.rs
@@ -1,0 +1,54 @@
+use std::fmt::{Formatter, Result};
+use r3bl_rs_utils_core::*;
+use crate::*;
+pub struct CrosstermDebugFormatRenderOp;
+
+fn format_print_text(
+    op_name: &str,
+    text: &String,
+    maybe_style: &Option<Style>,
+) -> String {
+    match maybe_style {
+        Some(style) => {
+            format!("{op_name}({} bytes, {style:?})", text.len())
+        }
+        None => format!("{op_name}({} bytes, None)", text.len()),
+    }
+}
+
+impl DebugFormatRenderOp for CrosstermDebugFormatRenderOp {
+    fn debug_format(&self, this: &RenderOp, f: &mut Formatter<'_>) -> Result {
+        write!(
+            f,
+            "{}",
+            match this {
+                RenderOp::Noop => "Noop".into(),
+                RenderOp::EnterRawMode => "EnterRawMode".into(),
+                RenderOp::ExitRawMode => "ExitRawMode".into(),
+                RenderOp::MoveCursorPositionAbs(pos) =>
+                    format!("MoveCursorPositionAbs({pos:?})"),
+                RenderOp::MoveCursorPositionRelTo(box_origin_pos, content_rel_pos) =>
+                    format!(
+                        "MoveCursorPositionRelTo({box_origin_pos:?}, {content_rel_pos:?})"
+                    ),
+                RenderOp::ClearScreen => "ClearScreen".into(),
+                RenderOp::SetFgColor(fg_color) => format!("SetFgColor({fg_color:?})"),
+                RenderOp::SetBgColor(bg_color) => format!("SetBgColor({bg_color:?})"),
+                RenderOp::ResetColor => "ResetColor".into(),
+                RenderOp::ApplyColors(maybe_style) => match maybe_style {
+                    Some(style) => format!("ApplyColors({style:?})"),
+                    None => "ApplyColors(None)".into(),
+                },
+                RenderOp::CompositorNoClipTruncPaintTextWithAttributes(
+                    text,
+                    maybe_style,
+                ) => {
+                    format_print_text("Compositor..PrintText...", text, maybe_style)
+                }
+                RenderOp::PaintTextWithAttributes(text, maybe_style) => {
+                    format_print_text("PrintTextWithAttributes", text, maybe_style)
+                }
+            }
+        )
+    }
+}

--- a/tuify/src/terminal_lib_backends/crossterm_backend/mod.rs
+++ b/tuify/src/terminal_lib_backends/crossterm_backend/mod.rs
@@ -1,0 +1,7 @@
+pub mod render_op_impl;
+pub mod offscreen_buffer_paint_impl;
+pub mod debug;
+
+pub use render_op_impl::*;
+pub use offscreen_buffer_paint_impl::*;
+pub use debug::*;

--- a/tuify/src/terminal_lib_backends/crossterm_backend/offscreen_buffer_paint_impl.rs
+++ b/tuify/src/terminal_lib_backends/crossterm_backend/offscreen_buffer_paint_impl.rs
@@ -1,0 +1,507 @@
+pub struct OffscreenBufferPaintImplCrossterm;
+use r3bl_rs_utils_core::*;
+
+use crate::*;
+
+impl OffscreenBufferPaint for OffscreenBufferPaintImplCrossterm {
+    fn paint(
+        &mut self,
+        render_ops: RenderOps,
+        flush_kind: FlushKind,
+        shared_global_data: &SharedGlobalData,
+    ) {
+        let mut skip_flush = false;
+
+        if let FlushKind::ClearBeforeFlush = flush_kind {
+            RenderOp::default().clear_before_flush(); }
+
+        // Execute each RenderOp.
+        render_ops
+            .execute_all(&mut skip_flush, shared_global_data);
+
+        // Flush everything to the terminal.
+        if !skip_flush {
+            RenderOp::default().flush()
+        };
+        // Debug output.
+        call_if_true!(DEBUG_TUIFY_SHOW_PIPELINE, {
+            let msg = format!(
+                "🎨 offscreen_buffer_paint_impl_crossterm::paint() ok ✅: render_ops: \n{render_ops:?}",
+            );
+            log_info(msg);
+        });
+    }
+
+    fn paint_diff(
+        &mut self,
+        render_ops: RenderOps,
+        shared_global_data: &SharedGlobalData,
+    ) {
+        let mut skip_flush = false;
+
+        // Execute each RenderOp.
+        render_ops
+            .execute_all(&mut skip_flush, shared_global_data);
+
+        // Flush everything to the terminal.
+        if !skip_flush {
+            RenderOp::default().flush()
+        };
+
+        // Debug output.
+        call_if_true!(DEBUG_TUIFY_SHOW_PIPELINE, {
+            let msg = format!(
+                "🎨 offscreen_buffer_paint_impl_crossterm::paint() ok ✅: render_ops: \n{render_ops:?}"
+            );
+            log_info(msg);
+        });
+    }
+
+    /// Process each [PixelChar] in [OffscreenBuffer] and generate a [RenderOp] for it. Return a
+    /// [RenderOps] containing all the [RenderOp]s.
+    ///
+    /// > Note that each [PixelChar] gets the full [Style] embedded in it (not just a part of it
+    /// > that is different than the previous char). This means that it is possible to quickly
+    /// > "diff" between 2 of them, since the [Style] is part of the [PixelChar]. This is important
+    /// > for selective re-rendering of the [OffscreenBuffer].
+    ///
+    /// Here's the algorithm used in this function using pseudo-code:
+    /// - When going thru every `PixelChar` in a line:
+    ///   - if the `PixelChar` is `Void`, `Spacer`, or `PlainText` then handle it like now
+    ///     - `temp_line_buffer`: accumulates over loop iterations
+    ///     - `flush_temp_line_buffer()`: flushes
+    ///   - if the `PixelChar` is `AnsiText`
+    ///     - `temp_ansi_line_buffer`: accumulates over loop iterations
+    ///     - `flush_temp_ansi_line_buffer()`: flushes
+    ///   - make sure to flush at the
+    ///     - end of line
+    ///     - when style changes
+    ///     - when switchover from ANSI <-> PLAIN happens
+    fn render(&mut self, offscreen_buffer: &OffscreenBuffer) -> RenderOps {
+        use render_helpers::*;
+
+        let mut context = Context::new();
+
+        // For each line in the offscreen buffer.
+        for (row_index, line) in offscreen_buffer.buffer.iter().enumerate() {
+            context.clear_for_new_line(row_index);
+
+            // For each pixel char in the line.
+            for (pixel_char_index, pixel_char) in line.iter().enumerate() {
+                let (pixel_char_str, pixel_char_style): (&str, Option<Style>) =
+                    match pixel_char {
+                        PixelChar::Void => continue,
+                        PixelChar::Spacer => (SPACER, None),
+                        PixelChar::PlainText {
+                            content,
+                            maybe_style,
+                        } => (&content.string, *maybe_style),
+                    };
+
+                let is_style_same_as_prev =
+                    render_helpers::style_eq(&pixel_char_style, &context.prev_style);
+                let is_at_end_of_line = ch!(pixel_char_index) == (ch!(line.len() - 1));
+                let is_first_loop_iteration = row_index == 0 && pixel_char_index == 0;
+
+                // Deal w/: fg and bg colors | text attrib style | ANSI <-> PLAIN switchover.
+                if !is_style_same_as_prev {
+                    // The style changed / render path has changed and something is already in the
+                    // buffer, so flush it!
+                    render_helpers::flush_all_buffers(&mut context);
+                }
+
+                // Deal w/: fg and bg colors | text attrib style
+                if is_first_loop_iteration || !is_style_same_as_prev {
+                    context.render_ops.push(RenderOp::ResetColor);
+                    if let Some(style) = pixel_char_style {
+                        if let Some(color) = style.color_fg {
+                            context.render_ops.push(RenderOp::SetFgColor(color));
+                        }
+                    }
+                    if let Some(style) = pixel_char_style {
+                        if let Some(color) = style.color_bg {
+                            context.render_ops.push(RenderOp::SetBgColor(color));
+                        }
+                    }
+                    // Update prev_style.
+                    context.prev_style = pixel_char_style;
+                }
+
+                // Buffer it.
+                context.buffer_plain_text.push_str(pixel_char_str);
+
+                // Flush it.
+                if is_at_end_of_line {
+                    render_helpers::flush_all_buffers(&mut context);
+                }
+            } // End for each pixel char in the line.
+        } // End for each line in the offscreen buffer.
+
+        // This handles the edge case when there is still something in the temp buffer, but the loop
+        // has exited.
+        if !context.buffer_plain_text.is_empty() {
+            render_helpers::flush_all_buffers(&mut context);
+        }
+        context.render_ops
+    }
+
+    fn render_diff(&mut self, diff_chunks: &PixelCharDiffChunks) -> RenderOps {
+        call_if_true!(DEBUG_TUIFY_COMPOSITOR, {
+            let msg = format!("🎨 offscreen_buffer_paint_impl_crossterm::render_diff() ok ✅: \ndiff_chunks: \n{}",
+            diff_chunks.pretty_print());
+            log_info(msg);
+        });
+
+        let mut it = render_ops!();
+
+        for (position, pixel_char) in diff_chunks.iter() {
+            it.push(RenderOp::MoveCursorPositionAbs(*position));
+            it.push(RenderOp::ResetColor);
+            match pixel_char {
+                PixelChar::Void => continue,
+                PixelChar::Spacer => {
+                    it.push(RenderOp::CompositorNoClipTruncPaintTextWithAttributes(
+                        SPACER.into(),
+                        None,
+                    ))
+                }
+                PixelChar::PlainText {
+                    content,
+                    maybe_style,
+                } => {
+                    it.push(RenderOp::ApplyColors(*maybe_style));
+                    it.push(RenderOp::CompositorNoClipTruncPaintTextWithAttributes(
+                        content.string.clone(),
+                        *maybe_style,
+                    ))
+                }
+            }
+        }
+
+        it
+    }
+}
+
+
+/// Render plain to an offscreen buffer. This will modify the `my_offscreen_buffer` argument.  For
+/// plain text it supports counting [GraphemeClusterSegment]s. The display width of each segment is
+/// taken into account when filling the offscreen buffer.
+pub fn print_text_with_attributes(
+    _shared_global_data: &SharedGlobalData,
+    arg_text_ref: &str,
+    maybe_style_ref: &Option<Style>,
+    my_offscreen_buffer: &mut OffscreenBuffer,
+    maybe_max_display_col_count: Option<ChUnit>,
+) -> CommonResult<Position> {
+    print_plain_text(
+        arg_text_ref,
+        maybe_style_ref,
+        my_offscreen_buffer,
+        maybe_max_display_col_count,
+    )
+}
+
+
+/// This diagram shows what happens per line of text.
+///
+/// `my_offscreen_buffer[my_pos.row_index]` is the line.
+/// ```text
+///             my_pos.col_index
+///             ↓
+///             <------------------ usable space ----------------->
+/// <---------------- maybe_max_display_col_count ---------------->
+/// C0123456789012345678901234567890123456789012345678901234567890
+/// ```
+pub fn print_plain_text(
+    arg_text_ref: &str,
+    maybe_style_ref: &Option<Style>,
+    my_offscreen_buffer: &mut OffscreenBuffer,
+    maybe_max_display_col_count: Option<ChUnit>,
+) -> CommonResult<Position> {
+    // Get col and row index from `my_pos`.
+    let display_col_index = ch!(@to_usize my_offscreen_buffer.my_pos.col_index);
+    let display_row_index = ch!(@to_usize my_offscreen_buffer.my_pos.row_index);
+
+    // If `maybe_max_display_col_count` is `None`, then clip to the max bounds of the window
+    // 1. take the pos into account when determining clip
+    // 2. even if `maybe_max_display_col_count` is `None`, still clip to the max bounds of the
+    //    window
+
+    // ✂️Clip `arg_text_ref` (if needed) and make `text`.
+    let mut text: UnicodeString =
+        if let Some(max_display_col_count) = maybe_max_display_col_count {
+            let adj_max = max_display_col_count - (ch!(display_col_index));
+            let unicode_string = arg_text_ref.unicode_string();
+            let trunc_unicode_str = unicode_string.truncate_end_to_fit_width(adj_max);
+            trunc_unicode_str.unicode_string()
+        } else {
+            arg_text_ref.unicode_string()
+        };
+
+    // ✂️Clip `text` (if needed) to the max display col count of the window.
+    let window_max_display_col_count = my_offscreen_buffer.window_size.col_count;
+    let text_fits_in_window =
+        text.display_width <= window_max_display_col_count - (ch!(display_col_index));
+    if !text_fits_in_window {
+        let adj_max = window_max_display_col_count - (ch!(display_col_index));
+        let trunc_unicode_str = text.truncate_end_to_fit_width(adj_max);
+        text = trunc_unicode_str.unicode_string();
+    }
+
+    call_if_true!(DEBUG_TUIFY_COMPOSITOR, {
+        let msg = format!(
+            "\n🚀🚀🚀 print_plain_text():
+            insertion at: display_row_index: {}, display_col_index: {}, window_size: {:?},
+            text: '{}',
+            width: {}",
+            display_row_index,
+            display_col_index,
+            my_offscreen_buffer.window_size,
+            text.string,
+            text.display_width
+        );
+        log_debug(msg);
+    });
+
+    // Try to get the line at `row_index`.
+    let mut line_copy = {
+        if my_offscreen_buffer.buffer.get(display_row_index).is_none() {
+            // Clip vertically.
+            CommonError::new_err_with_only_type(CommonErrorType::DisplaySizeTooSmall)
+        } else {
+            let line_copy = my_offscreen_buffer
+                .buffer
+                .get(display_row_index)
+                .unwrap()
+                .clone();
+            Ok(line_copy)
+        }
+    }?;
+
+    // Insert clipped `text_ref_us` into `line` at `insertion_col_index`. Ok to use
+    // `line_copy[insertion_col_index]` syntax because we know that row and col indices are valid.
+    let mut insertion_col_index = display_col_index;
+    let mut already_inserted_display_width = ch!(0);
+
+    let maybe_style: Option<Style> = {
+        if let Some(maybe_style) = maybe_style_ref {
+            // We get the attributes from `maybe_style_ref`.
+            let mut it = *maybe_style;
+            // We get the colors from `my_fg_color` and `my_bg_color`.
+            it.color_fg = my_offscreen_buffer.my_fg_color;
+            it.color_bg = my_offscreen_buffer.my_bg_color;
+            Some(it)
+        } else if my_offscreen_buffer.my_fg_color.is_some()
+            || my_offscreen_buffer.my_bg_color.is_some()
+        {
+            Some(Style {
+                color_fg: my_offscreen_buffer.my_fg_color,
+                color_bg: my_offscreen_buffer.my_bg_color,
+                ..Default::default()
+            })
+        } else {
+            None
+        }
+    };
+
+    call_if_true!(
+        DEBUG_TUIFY_COMPOSITOR,
+        if maybe_style.is_some() {
+            let msg = format!(
+                "\n🔴🔴🔴\n[row: {display_row_index}, col: {display_col_index}] - style: {maybe_style:?}",
+            );
+            log_debug(msg);
+        } else {
+            let msg = format!(
+                "\n🟣🟣🟣\n[row: {display_row_index}, col: {display_col_index}] - style: None",
+            );
+            log_debug(msg);
+        }
+    );
+
+    // Loop over each grapheme cluster segment (the character) in `text_ref_us` (text in a line).
+    // For each GraphemeClusterSegment, create a PixelChar.
+    for gc_segment in text.iter() {
+        let segment_display_width = ch!(@to_usize gc_segment.unicode_width);
+        if segment_display_width == 0 {
+            continue;
+        }
+
+        // Set the `PixelChar` at `insertion_col_index`.
+        if line_copy.get(insertion_col_index).is_some() {
+            let pixel_char = {
+                let new_gc_segment =
+                    GraphemeClusterSegment::from(gc_segment.string.as_ref());
+                match (&maybe_style, new_gc_segment.string.as_str()) {
+                    (None, SPACER) => PixelChar::Spacer,
+                    _ => PixelChar::PlainText {
+                        content: new_gc_segment,
+                        maybe_style,
+                    },
+                }
+            };
+
+            if line_copy.get(insertion_col_index).is_some() {
+                line_copy[insertion_col_index] = pixel_char;
+            }
+
+            // Deal w/ the display width of the `PixelChar` > 1. This is the equivalent of
+            // `jump_cursor()` in RenderOpImplCrossterm.
+            //
+            // Move cursor "manually" to cover "extra" (display) width of a single character. This
+            // is a necessary precautionary measure, to make sure the behavior is the same on all
+            // terminals. In practice this means that terminals will be "broken" in the same way
+            // across multiple terminal emulators and OSes.
+            // 1. Terminals vary in their support of complex grapheme clusters (joined emoji). This
+            //    code uses the crate unicode_width to display a given UTF-8 character "correctly"
+            //    in all terminals. The number reported by this crate and the actual display width
+            //    that the specific terminal emulator + OS combo will display may be different.
+            // 2. This means that in some terminals, the caret itself has to be manually "jumped" to
+            //    covert the special case of a really wide UTF-8 character. This happens by adding
+            //    Void pixel chars.
+            // 3. The insertion_col_index is calculated & updated based on the unicode_width crate
+            //    values.
+            let segment_display_width = ch!(@to_usize gc_segment.unicode_width);
+            if segment_display_width > 1 {
+                // Deal w/ `gc_segment` display width that is > 1 => pad w/ Void.
+                let num_of_extra_display_cols_to_inject_void_into =
+                    segment_display_width - 1; // Safe subtract.
+                for _ in 0..num_of_extra_display_cols_to_inject_void_into {
+                    // Make sure insertion_col_index is safe to access.
+                    if line_copy.get(insertion_col_index + 1).is_some() {
+                        // Move insertion_col_index forward & inject a PixelChar::Void.
+                        insertion_col_index += 1;
+                        line_copy[insertion_col_index] = PixelChar::Void;
+                    }
+                }
+                // Move insertion_col_index forward.
+                insertion_col_index += 1;
+            } else {
+                // `gc_segment` width is 1 => move `insertion_col_index` forward by 1.
+                insertion_col_index += 1;
+            }
+
+            already_inserted_display_width += gc_segment.unicode_width;
+        } else {
+            // Run out of space in the line of the offscreen buffer.
+            break;
+        }
+    }
+
+    // Mimic what stdout does and move the position.col_index forward by the width of the text that
+    // was added to display.
+    let new_pos = my_offscreen_buffer
+        .my_pos
+        .add_col(ch!(@to_usize already_inserted_display_width));
+
+    // 🥊Deal w/ padding SPACERs padding to end of line (if `maybe_max_display_col_count` is some).
+    if let Some(max_display_col_count) = maybe_max_display_col_count {
+        let adj_max = max_display_col_count - (ch!(display_col_index));
+        while already_inserted_display_width < adj_max {
+            if line_copy.get(insertion_col_index).is_some() {
+                line_copy[insertion_col_index] = PixelChar::Spacer;
+                insertion_col_index += 1;
+                already_inserted_display_width += 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    // Replace the line in `my_offscreen_buffer` with the new line.
+    my_offscreen_buffer.buffer[display_row_index] = line_copy;
+
+    Ok(new_pos)
+}
+
+
+mod render_helpers {
+    use super::*;
+
+    #[derive(Debug, Clone)]
+    pub struct Context {
+        pub display_col_index_for_line: ChUnit,
+        pub display_row_index: ChUnit,
+        pub buffer_plain_text: String,
+        pub prev_style: Option<Style>,
+        pub render_ops: RenderOps,
+    }
+
+    impl Context {
+        pub fn new() -> Self {
+            Context {
+                display_col_index_for_line: ch!(0),
+                buffer_plain_text: String::new(),
+                render_ops: render_ops!(),
+                display_row_index: ch!(0),
+                prev_style: None,
+            }
+        }
+
+        pub fn clear_for_new_line(&mut self, row_index: usize) {
+            self.buffer_plain_text.clear();
+            self.display_col_index_for_line = ch!(0);
+            self.display_row_index = ch!(row_index);
+        }
+    }
+
+    /// `this` is eq to `other` if they are both `Some` and their following fields are eq:
+    /// - `color_fg`
+    /// - `color_bg`
+    /// - `bold`
+    /// - `dim`
+    /// - `underline`
+    /// - `reverse`
+    /// - `hidden`
+    /// - `strikethrough`
+    pub fn style_eq(this: &Option<Style>, other: &Option<Style>) -> bool {
+        match (this.is_some(), other.is_some()) {
+            (false, false) => true,
+            (true, true) => {
+                let this = (*this).unwrap();
+                let other = (*other).unwrap();
+                this.color_fg == other.color_fg
+                    && this.color_bg == other.color_bg
+                    && this.bold == other.bold
+                    && this.dim == other.dim
+                    && this.underline == other.underline
+                    && this.reverse == other.reverse
+                    && this.hidden == other.hidden
+                    && this.strikethrough == other.strikethrough
+            }
+            (_, _) => false,
+        }
+    }
+
+    pub fn flush_all_buffers(context: &mut Context) {
+        if !context.buffer_plain_text.is_empty() {
+            render_helpers::flush_plain_text_line_buffer(context);
+        }
+    }
+
+    pub fn flush_plain_text_line_buffer(context: &mut Context) {
+        // Generate `RenderOps` for each `PixelChar` and add it to `render_ops`.
+        let pos = position! { col_index: context.display_col_index_for_line, row_index: context.display_row_index};
+
+        // Deal w/ position.
+        context
+            .render_ops
+            .push(RenderOp::MoveCursorPositionAbs(pos));
+
+        // Deal w/ style attribs & actually paint the `temp_line_buffer`.
+        context
+            .render_ops
+            .push(RenderOp::CompositorNoClipTruncPaintTextWithAttributes(
+                context.buffer_plain_text.to_string(),
+                context.prev_style,
+            ));
+
+        // Update `display_col_index_for_line`.
+        let plain_text_display_width =
+            UnicodeString::from(context.buffer_plain_text.as_str()).display_width;
+        context.display_col_index_for_line += plain_text_display_width;
+
+        // Clear the buffer!
+        context.buffer_plain_text.clear()
+    }
+}

--- a/tuify/src/terminal_lib_backends/crossterm_backend/render_op_impl.rs
+++ b/tuify/src/terminal_lib_backends/crossterm_backend/render_op_impl.rs
@@ -1,0 +1,407 @@
+use std::{borrow::Cow,
+          io::{stderr, stdout, Write}};
+use crossterm::{cursor::*,
+                event::*,
+                queue,
+                style::{Attribute,*},
+                terminal::{self,*}};
+use r3bl_rs_utils_core::*;
+use crate::*;
+
+/// Struct representing the implementation of [RenderOp] for crossterm terminal backend. This empty
+/// struct is needed since the [Flush] trait needs to be implemented.
+pub struct RenderOpImplCrossterm;
+
+mod render_op_impl_crossterm_impl_trait_paint_render_op {
+    use super::*;
+
+    impl PaintRenderOp for RenderOpImplCrossterm {
+        fn paint(
+            &mut self,
+            skip_flush: &mut bool,
+            command_ref: &RenderOp,
+            shared_global_data: &SharedGlobalData,
+            local_data: &mut RenderOpsLocalData,
+        ) {
+            match command_ref {
+                RenderOp::Noop => {}
+                RenderOp::EnterRawMode => {
+                    RenderOpImplCrossterm::raw_mode_enter(skip_flush, shared_global_data);
+                }
+                RenderOp::ExitRawMode => {
+                    RenderOpImplCrossterm::raw_mode_exit(skip_flush);
+                }
+                RenderOp::MoveCursorPositionAbs(abs_pos) => {
+                    RenderOpImplCrossterm::move_cursor_position_abs(
+                        abs_pos,
+                        shared_global_data,
+                        local_data,
+                    );
+                }
+                RenderOp::MoveCursorPositionRelTo(box_origin_pos, content_rel_pos) => {
+                    RenderOpImplCrossterm::move_cursor_position_rel_to(
+                        box_origin_pos,
+                        content_rel_pos,
+                        shared_global_data,
+                        local_data,
+                    );
+                }
+                RenderOp::ClearScreen => {
+                    exec_render_op!(
+                        queue!(stdout(), Clear(ClearType::All)),
+                        "ClearScreen"
+                    )
+                }
+                RenderOp::SetFgColor(color) => {
+                    RenderOpImplCrossterm::set_fg_color(color);
+                }
+                RenderOp::SetBgColor(color) => {
+                    RenderOpImplCrossterm::set_bg_color(color);
+                }
+                RenderOp::ResetColor => {
+                    exec_render_op!(queue!(stdout(), ResetColor), "ResetColor")
+                }
+                RenderOp::ApplyColors(style) => {
+                    RenderOpImplCrossterm::apply_colors(style);
+                }
+                RenderOp::CompositorNoClipTruncPaintTextWithAttributes(
+                    text,
+                    maybe_style,
+                ) => {
+                    RenderOpImplCrossterm::paint_text_with_attributes(
+                        text,
+                        maybe_style,
+                        shared_global_data,
+                        local_data,
+                    );
+                }
+                RenderOp::PaintTextWithAttributes(_text, _maybe_style) => {
+                    // This should never be executed! The compositor always renders to an offscreen
+                    // buffer first, then that is diff'd and then painted via calls to
+                    // CompositorNoClipTruncPaintTextWithAttributes.
+                }
+            }
+        }
+    }
+}
+
+pub mod render_op_impl_crossterm_impl_trait_flush {
+    use super::*;
+
+    impl Flush for RenderOpImplCrossterm {
+        fn flush(&mut self) { flush(); }
+        fn clear_before_flush(&mut self) { clear_before_flush(); }
+    }
+
+    fn clear_before_flush() {
+        exec_render_op! {
+          queue!(stdout(),
+            ResetColor,
+            Clear(ClearType::All),
+          ),
+        "flush() -> after ResetColor, Clear"
+        }
+    }
+
+    pub fn flush() {
+        exec_render_op!(stdout().flush(), "flush() -> stdout");
+        exec_render_op!(stderr().flush(), "flush() -> stderr");
+    }
+}
+
+mod render_op_impl_crossterm_impl {
+    use super::*;
+
+    impl RenderOpImplCrossterm {
+        pub fn move_cursor_position_rel_to(
+            box_origin_pos: &Position,
+            content_rel_pos: &Position,
+            shared_global_data: &SharedGlobalData,
+            local_data: &mut RenderOpsLocalData,
+        ) {
+            let new_abs_pos = *box_origin_pos + *content_rel_pos;
+            Self::move_cursor_position_abs(&new_abs_pos, shared_global_data, local_data);
+        }
+
+        pub fn move_cursor_position_abs(
+            abs_pos: &Position,
+            shared_global_data: &SharedGlobalData,
+            local_data: &mut RenderOpsLocalData,
+        ) {
+            let Position {
+                col_index: _col,
+                row_index: _row,
+            } = sanitize_and_save_abs_position(*abs_pos, shared_global_data, local_data);
+
+            let Position {
+                col_index:col,
+                row_index:row
+            } = *abs_pos;
+            exec_render_op!(
+                queue!(stdout(), MoveTo(*col, *(row + shared_global_data.inline_row_offset))),
+                format!("MoveCursorPosition(col: {}, row: {})", *col, *(row+shared_global_data.inline_row_offset))
+                // queue!(stdout(), MoveTo(*col, *row)),
+                // format!("MoveCursorPosition(col: {}, row: {})", *col, *row)
+            )
+        }
+
+        pub fn raw_mode_exit(skip_flush: &mut bool) {
+            exec_render_op! {
+              queue!(stdout(),
+                Show,
+                LeaveAlternateScreen,
+                DisableMouseCapture
+              ),
+              "ExitRawMode -> Show, LeaveAlternateScreen, DisableMouseCapture"
+            };
+            render_op_impl_crossterm_impl_trait_flush::flush();
+            exec_render_op! {terminal::disable_raw_mode(), "ExitRawMode -> disable_raw_mode()"}
+            *skip_flush = true;
+        }
+
+        pub fn raw_mode_enter(
+            skip_flush: &mut bool,
+            _shared_global_data: &SharedGlobalData,
+        ) {
+            exec_render_op! {
+              terminal::enable_raw_mode(),
+              "EnterRawMode -> enable_raw_mode()"
+            };
+            exec_render_op! {
+              queue!(stdout(),
+                EnableMouseCapture,
+                EnterAlternateScreen,
+                MoveTo(0,0),
+                Clear(ClearType::All),
+                Hide,
+              ),
+            "EnterRawMode -> EnableMouseCapture, EnterAlternateScreen, MoveTo(0,0), Clear(ClearType::All), Hide"
+            }
+            render_op_impl_crossterm_impl_trait_flush::flush();
+            *skip_flush = true;
+        }
+
+        pub fn set_fg_color(color: &TuiColor) {
+            let color = color_converter::to_crossterm_color(*color);
+            exec_render_op!(
+                queue!(stdout(), SetForegroundColor(color)),
+                format!("SetFgColor({color:?})")
+            )
+        }
+
+        pub fn set_bg_color(color: &TuiColor) {
+            let color: crossterm::style::Color =
+                color_converter::to_crossterm_color(*color);
+            exec_render_op!(
+                queue!(stdout(), SetBackgroundColor(color)),
+                format!("SetBgColor({color:?})")
+            )
+        }
+
+        pub fn paint_text_with_attributes(
+            text_arg: &String,
+            maybe_style: &Option<Style>,
+            shared_global_data: &SharedGlobalData,
+            local_data: &mut RenderOpsLocalData,
+        ) {
+            use perform_paint::*;
+
+            // Gen log_msg.
+            let log_msg = Cow::from(format!("\"{text_arg}\""));
+
+            let text: Cow<'_, str> = Cow::from(text_arg);
+
+            let mut paint_args = PaintArgs {
+                text,
+                log_msg,
+                maybe_style,
+                shared_global_data,
+            };
+
+            let needs_reset = Cow::Owned(false);
+
+            // Paint plain_text.
+            paint_style_and_text(&mut paint_args, needs_reset, local_data);
+        }
+
+        /// Use [crossterm::style::Color] to set crossterm Colors.
+        /// Docs: <https://docs.rs/crossterm/latest/crossterm/style/index.html#colors>
+        pub fn apply_colors(maybe_style: &Option<Style>) {
+            if let Some(style) = maybe_style {
+                // Handle background color.
+                if let Some(tui_color_bg) = style.color_bg {
+                    let color_bg: crossterm::style::Color =
+                        color_converter::to_crossterm_color(tui_color_bg);
+                    exec_render_op!(
+                        queue!(stdout(), SetBackgroundColor(color_bg)),
+                        format!("ApplyColors -> SetBgColor({color_bg:?})")
+                    )
+                }
+
+                // Handle foreground color.
+                if let Some(tui_color_fg) = style.color_fg {
+                    let color_fg: crossterm::style::Color =
+                        color_converter::to_crossterm_color(tui_color_fg);
+                    exec_render_op!(
+                        queue!(stdout(), SetForegroundColor(color_fg)),
+                        format!("ApplyColors -> SetFgColor({color_fg:?})")
+                    )
+                }
+            }
+        }
+    }
+}
+
+mod perform_paint {
+    use super::*;
+
+    #[derive(Debug)]
+    pub struct PaintArgs<'a> {
+        pub text: Cow<'a, str>,
+        pub log_msg: Cow<'a, str>,
+        pub maybe_style: &'a Option<Style>,
+        pub shared_global_data: &'a SharedGlobalData,
+    }
+
+    fn style_to_attribute(&style: &Style) -> Vec<Attribute> {
+        let mut it = vec![];
+        if style.bold {
+            it.push(Attribute::Bold);
+        }
+        if style.italic {
+            it.push(Attribute::Italic);
+        }
+        if style.dim {
+            it.push(Attribute::Dim);
+        }
+        if style.underline {
+            it.push(Attribute::Underlined);
+        }
+        if style.reverse {
+            it.push(Attribute::Reverse);
+        }
+        if style.hidden {
+            it.push(Attribute::Hidden);
+        }
+        if style.strikethrough {
+            it.push(Attribute::Fraktur);
+        }
+        it
+    }
+
+    /// Use [Style] to set crossterm [Attributes] ([docs](
+    /// https://docs.rs/crossterm/latest/crossterm/style/index.html#attributes)).
+    pub fn paint_style_and_text<'a>(
+        paint_args: &mut PaintArgs<'a>,
+        mut needs_reset: Cow<'_, bool>,
+        local_data: &mut RenderOpsLocalData,
+    ) {
+        let PaintArgs { maybe_style, .. } = paint_args;
+
+        if let Some(style) = maybe_style {
+            let attrib_vec = style_to_attribute(style);
+            attrib_vec.iter().for_each(|attr| {
+                exec_render_op!(
+                    queue!(stdout(), SetAttribute(*attr)),
+                    format!("PaintWithAttributes -> SetAttribute({attr:?})")
+                );
+                needs_reset = Cow::Owned(true);
+            });
+        }
+
+        paint_text(paint_args, local_data);
+
+        if *needs_reset {
+            exec_render_op!(
+                queue!(stdout(), SetAttribute(Attribute::Reset)),
+                format!("PaintWithAttributes -> SetAttribute(Reset))")
+            );
+        }
+    }
+
+    pub fn paint_text<'a>(
+        paint_args: &PaintArgs<'a>,
+        local_data: &mut RenderOpsLocalData,
+    ) {
+        let PaintArgs {
+            text,
+            log_msg,
+            shared_global_data,
+            ..
+        } = paint_args;
+
+        let unicode_string: UnicodeString = text.as_ref().into();
+        let mut cursor_position_copy = local_data.cursor_position;
+
+
+        // Actually paint text.
+        {
+            let text = Cow::Borrowed(text);
+            let log_msg: &str = log_msg;
+            exec_render_op!(
+                queue!(stdout(), Print(&text)),
+                format!("Print( {} {log_msg})", &text)
+            );
+        };
+
+        // Update cursor position after paint.
+        let display_width = unicode_string.display_width;
+
+        cursor_position_copy.col_index += display_width;
+        sanitize_and_save_abs_position(
+            cursor_position_copy,
+            shared_global_data,
+            local_data,
+        );
+    }
+}
+
+/// Given a crossterm command, this will run it and [log_error] or [log_info] the [Result] that is
+/// returned.
+///
+/// Paste docs: <https://github.com/dtolnay/paste>
+#[macro_export]
+macro_rules! exec_render_op {
+    (
+        $arg_cmd: expr,
+        $arg_log_msg: expr
+    ) => {{
+        // Generate a new function that returns [CommonResult]. This needs to be called. The only
+        // purpose of this generated method is to handle errors that may result from calling log! macro
+        // when there are issues accessing the log file for whatever reason.
+        use $crate::DEBUG_TUIFY_SHOW_TERMINAL_BACKEND;
+
+        let _fn_wrap_for_logging_err = || -> CommonResult<()> {
+            throws!({
+                // Execute the command.
+                if let Err(err) = $arg_cmd {
+                    let msg = format!("crossterm: ❌ Failed to {} due to {}", $arg_log_msg, err);
+                    call_if_true!(
+                        DEBUG_TUIFY_SHOW_TERMINAL_BACKEND,
+                        log_error(msg)
+                    );
+                } else {
+                    let msg = format!("crossterm: ✅ {} successfully", $arg_log_msg);
+                    call_if_true! {
+                      DEBUG_TUIFY_SHOW_TERMINAL_BACKEND,
+                      log_info(msg)
+                    };
+                }
+            })
+        };
+
+        // Call this generated function. It will fail if there are problems w/ log!(). In this case, if
+        // `DEBUG_TUIFY_SHOW_TERMINAL_BACKEND` is true, then it will dump the error to stderr.
+        if let Err(logging_err) = _fn_wrap_for_logging_err() {
+            let msg = format!(
+                "❌ Failed to log exec output of {}, {}",
+                stringify!($arg_cmd),
+                $arg_log_msg
+            );
+            call_if_true! {
+              DEBUG_TUIFY_SHOW_TERMINAL_BACKEND,
+              debug!(ERROR_RAW &msg, logging_err)
+            };
+        }
+    }};
+}

--- a/tuify/src/terminal_lib_backends/mod.rs
+++ b/tuify/src/terminal_lib_backends/mod.rs
@@ -1,0 +1,19 @@
+pub mod offscreen_buffer;
+pub mod paint;
+pub mod render_op;
+pub mod crossterm_backend;
+pub mod color_converter;
+pub mod terminal_lib_operations;
+
+pub enum TerminalLibBackend {
+    Crossterm,
+    Termion,
+}
+pub const TERMINAL_LIB_BACKEND: TerminalLibBackend = TerminalLibBackend::Crossterm;
+
+pub use offscreen_buffer::*;
+pub use render_op::*;
+pub use crossterm_backend::*;
+pub use paint::*;
+pub use color_converter::*;
+pub use terminal_lib_operations::*;

--- a/tuify/src/terminal_lib_backends/offscreen_buffer.rs
+++ b/tuify/src/terminal_lib_backends/offscreen_buffer.rs
@@ -1,0 +1,415 @@
+use serde::{Deserialize, Serialize};
+use r3bl_rs_utils_core::*;
+use get_size::GetSize;
+use std::{fmt::{self, Debug},
+          ops::{Deref, DerefMut}};
+
+use crate::*;
+
+/// Represents a grid of cells where the row/column index maps to the terminal screen. This works
+/// regardless of the size of each cell. Cells can contain emoji who's display width is greater than
+/// one. This complicates things since a "😃" takes up 2 display widths.
+///
+/// Let's say one cell has a "😃" in it. The cell's display width is 2. The cell's byte size is 4.
+/// The next cell after it will have to contain nothing or void.
+///
+/// Why? This is because the col & row indices of the grid map to display col & row indices of the
+/// terminal screen. By inserting a [PixelChar::Void] pixel char in the next cell, we signal the
+/// rendering logic to skip it since it has already been painted. And this is different than a
+/// [PixelChar::Spacer] which has to be painted!
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash, GetSize)]
+pub struct OffscreenBuffer {
+    pub buffer: PixelCharLines,
+    pub window_size: Size,
+    pub my_pos: Position,
+    pub my_fg_color: Option<TuiColor>,
+    pub my_bg_color: Option<TuiColor>,
+}
+
+pub enum OffscreenBufferDiffResult {
+    NotComparable,
+    Comparable(PixelCharDiffChunks),
+}
+
+pub type PixelCharDiffChunks = List<DiffChunk>;
+pub type DiffChunk = (Position, PixelChar);
+
+mod offscreen_buffer_impl {
+    use super::*;
+    impl PixelCharDiffChunks {
+        pub fn pretty_print(&self) -> String {
+            let mut it = String::new();
+            for (pos, pixel_char) in self.iter() {
+                it.push_str(&format!("\t{:?}: {}\n", pos, pixel_char.pretty_print()));
+            }
+            it
+        }
+    }
+
+    impl Deref for OffscreenBuffer {
+        type Target = PixelCharLines;
+
+        fn deref(&self) -> &Self::Target { &self.buffer }
+    }
+
+    impl DerefMut for OffscreenBuffer {
+        fn deref_mut(&mut self) -> &mut Self::Target { &mut self.buffer }
+    }
+
+    impl Debug for OffscreenBuffer {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(
+                f,
+                "window_size: {:?}, \n{}\n",
+                self.window_size,
+                self.pretty_print()
+            )
+        }
+    }
+
+    impl OffscreenBuffer {
+        /// Checks for differences between self and other. Returns a list of positions and pixel
+        /// chars if there are differences (from other).
+        pub fn diff(&self, other: &Self) -> OffscreenBufferDiffResult {
+            if self.window_size != other.window_size {
+                return OffscreenBufferDiffResult::NotComparable;
+            }
+
+            let mut it = List::default();
+            for (row, (self_row, other_row)) in
+            self.buffer.iter().zip(other.buffer.iter()).enumerate()
+            {
+                for (col, (self_pixel_char, other_pixel_char)) in
+                self_row.iter().zip(other_row.iter()).enumerate()
+                {
+                    if self_pixel_char != other_pixel_char {
+                        it.push((
+                            position!(col_index: col, row_index: row),
+                            other_pixel_char.clone(),
+                        ));
+                    }
+                }
+            }
+            OffscreenBufferDiffResult::Comparable(it)
+        }
+
+        /// Create a new buffer and fill it with empty chars.
+        pub fn new_with_capacity_initialized(window_size: Size) -> Self {
+            Self {
+                buffer: PixelCharLines::new_with_capacity_initialized(window_size),
+                window_size,
+                my_pos: Default::default(),
+                my_fg_color: None,
+                my_bg_color: None,
+            }
+        }
+
+        // Make sure each line is full of empty chars.
+        pub fn clear(&mut self) {
+            self.buffer = PixelCharLines::new_with_capacity_initialized(self.window_size);
+        }
+
+        pub fn pretty_print(&self) -> String {
+            let mut lines = vec![];
+            for row_index in 0..ch!(@to_usize self.window_size.row_count) {
+                if let Some(row) = self.buffer.get(row_index) {
+                    lines.push({
+                        let row_index_text = format!("row_index: {row_index}");
+                        let row_index_text = style_error(&row_index_text).to_string();
+                        let row_text =
+                            format!("{}\n{}", row_index_text, row.pretty_print());
+                        row_text
+                    });
+                }
+            }
+            lines.join("\n")
+        }
+    }
+
+}
+
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, GetSize)]
+pub struct PixelCharLines {
+    pub lines: Vec<PixelCharLine>,
+}
+
+
+mod pixel_char_lines_impl {
+    use super::*;
+
+    impl Deref for PixelCharLines {
+        type Target = Vec<PixelCharLine>;
+        fn deref(&self) -> &Self::Target { &self.lines }
+    }
+
+    impl DerefMut for PixelCharLines {
+        fn deref_mut(&mut self) -> &mut Self::Target { &mut self.lines }
+    }
+
+    impl PixelCharLines {
+        pub fn new_with_capacity_initialized(window_size: Size) -> Self {
+            let window_height = ch!(@to_usize window_size.row_count);
+            let window_width = ch!(@to_usize window_size.col_count);
+            Self {
+                lines: vec![
+                    PixelCharLine::new_with_capacity_initialized(window_width);
+                    window_height
+                ],
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, GetSize)]
+pub struct PixelCharLine {
+    pub pixel_chars: Vec<PixelChar>,
+}
+
+mod pixel_char_line_impl {
+    use super::*;
+
+    // This represents a single row on the screen (i.e. a line of text).
+    impl PixelCharLine {
+        pub fn pretty_print(&self) -> String {
+            let mut it = vec![];
+            let mut void_indices: Vec<usize> = vec![];
+            let mut spacer_indices: Vec<usize> = vec![];
+            let mut void_count: Vec<String> = vec![];
+            let mut spacer_count: Vec<String> = vec![];
+
+            // Pretty print only so many chars per line (depending on the terminal width in which
+            // log.fish is run).
+            const MAX_PIXEL_CHARS_PER_LINE: usize = 6;
+            let mut char_count = 0;
+
+            // Loop: for each PixelChar in a line (pixel_chars_lines[row_index]).
+            for (col_index, pixel_char) in self.iter().enumerate() {
+                match pixel_char {
+                    PixelChar::Void => {
+                        void_count.push(col_index.to_string());
+                        void_indices.push(col_index);
+                    }
+                    PixelChar::Spacer => {
+                        spacer_count.push(col_index.to_string());
+                        spacer_indices.push(col_index);
+                    }
+                    _ => {}
+                }
+
+                let index_txt = format!("{col_index:03}");
+                let pixel_char_txt = pixel_char.pretty_print();
+                let index_msg =
+                    format!("{}{}", style_dim_underline(&index_txt), pixel_char_txt);
+                it.push(index_msg);
+
+                // Add \n every MAX_CHARS_PER_LINE characters.
+                char_count += 1;
+                if char_count >= MAX_PIXEL_CHARS_PER_LINE {
+                    char_count = 0;
+                    it.push("\n".to_string());
+                }
+            }
+
+            // Pretty print the spacers & voids (of any of either or both).
+            {
+                let mut void_spacer_output = vec![];
+
+                if !void_count.is_empty() {
+                    void_spacer_output.push(format!(
+                        "void [ {} ]",
+                        PixelCharLine::pretty_print_index_values(&void_indices)
+                    ));
+                }
+
+                if !spacer_count.is_empty() {
+                    match void_spacer_output.is_empty() {
+                        true => {
+                            void_spacer_output.push(format!(
+                                "spacer [ {} ]",
+                                PixelCharLine::pretty_print_index_values(&spacer_indices)
+                            ));
+                        }
+                        false => {
+                            void_spacer_output.push(format!(
+                                ", spacer [ {} ]",
+                                PixelCharLine::pretty_print_index_values(&spacer_indices)
+                            ));
+                        }
+                    }
+                }
+
+                it.push(void_spacer_output.join(" | "));
+            }
+
+            it.join("")
+        }
+
+        pub fn pretty_print_index_values(values: &[usize]) -> String {
+            // Track state thru loop iteration.
+            let mut current_range: Vec<usize> = vec![];
+            let mut it: Vec<String> = vec![];
+
+            mod helpers {
+                pub enum Peek {
+                    NextItemContinuesRange,
+                    NextItemDoesNotContinueRange,
+                }
+
+                pub fn peek_does_next_item_continues_range(
+                    values: &[usize],
+                    index: usize,
+                ) -> Peek {
+                    if values.get(index + 1).is_none() {
+                        return Peek::NextItemDoesNotContinueRange;
+                    }
+                    if values[index + 1] == values[index] + 1 {
+                        Peek::NextItemContinuesRange
+                    } else {
+                        Peek::NextItemDoesNotContinueRange
+                    }
+                }
+
+                pub enum CurrentRange {
+                    DoesNotExist,
+                    Exists,
+                }
+
+                pub fn does_current_range_exist(
+                    current_range: &Vec<usize>,
+                ) -> CurrentRange {
+                    match current_range.is_empty() {
+                        true => CurrentRange::DoesNotExist,
+                        false => CurrentRange::Exists,
+                    }
+                }
+            }
+
+            // Main loop.
+            pub use helpers::*;
+            for (i, value) in values.iter().enumerate() {
+                match (
+                    peek_does_next_item_continues_range(values, i),
+                    does_current_range_exist(&current_range),
+                ) {
+                    (Peek::NextItemContinuesRange, CurrentRange::DoesNotExist) => {
+                        current_range.push(*value); // Start new current range.
+                    }
+                    (Peek::NextItemDoesNotContinueRange, CurrentRange::DoesNotExist) => {
+                        it.push(format!("{value}"));
+                    }
+                    // The next value continues the current range.
+                    (Peek::NextItemContinuesRange, CurrentRange::Exists) => {
+                        current_range.push(*value);
+                    }
+                    // The next value does not continue the current range.
+                    (Peek::NextItemDoesNotContinueRange, CurrentRange::Exists) => {
+                        current_range.push(*value);
+                        it.push(format!(
+                            "{}-{}",
+                            current_range[0],
+                            current_range[current_range.len() - 1]
+                        ));
+                        current_range.clear();
+                    }
+                }
+            }
+
+            it.join(", ")
+        }
+
+        /// Create a new row with the given width and fill it with the empty chars.
+        pub fn new_with_capacity_initialized(window_width: usize) -> Self {
+            Self {
+                pixel_chars: vec![PixelChar::Spacer; window_width],
+            }
+        }
+    }
+    impl Deref for PixelCharLine {
+        type Target = Vec<PixelChar>;
+        fn deref(&self) -> &Self::Target { &self.pixel_chars }
+    }
+
+    impl DerefMut for PixelCharLine {
+        fn deref_mut(&mut self) -> &mut Self::Target { &mut self.pixel_chars }
+    }
+}
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, GetSize)]
+pub enum PixelChar {
+    Void,
+    Spacer,
+    PlainText {
+        content: GraphemeClusterSegment,
+        maybe_style: Option<Style>,
+    },
+}
+
+const EMPTY_CHAR: char = '╳';
+const VOID_CHAR: char = '❯';
+
+mod pixel_char_impl {
+    use super::*;
+
+    impl Default for PixelChar {
+        fn default() -> Self { Self::Spacer }
+    }
+
+    impl PixelChar {
+        pub fn pretty_print(&self) -> String {
+            fn truncate(s: &str, max_chars: usize) -> &str {
+                match s.char_indices().nth(max_chars) {
+                    None => s,
+                    Some((idx, _)) => &s[..idx],
+                }
+            }
+
+            let width = 16;
+
+            let it = match self {
+                PixelChar::Void => {
+                    format!(" V {VOID_CHAR:░^width$}")
+                }
+                PixelChar::Spacer => {
+                    format!(" S {EMPTY_CHAR:░^width$}")
+                }
+                PixelChar::PlainText {
+                    content: character,
+                    maybe_style,
+                } => {
+                    let output = match maybe_style {
+                        // Content + style.
+                        Some(style) => {
+                            format!("'{}'→{}", character.string, style.pretty_print())
+                        }
+                        // Content, no style.
+                        _ => format!("'{}'", character.string),
+                    };
+                    let trunc_output = truncate(&output, width);
+                    format!(" {} {trunc_output: ^width$}", style_primary("P"))
+                }
+            };
+
+            it
+        }
+    }
+}
+
+pub trait OffscreenBufferPaint {
+    fn render(&mut self, offscreen_buffer: &OffscreenBuffer) -> RenderOps;
+
+    fn render_diff(&mut self, diff_chunks: &PixelCharDiffChunks) -> RenderOps;
+
+    fn paint(
+        &mut self,
+        render_ops: RenderOps,
+        flush_kind: FlushKind,
+        shared_global_data: &SharedGlobalData,
+    );
+
+    fn paint_diff(
+        &mut self,
+        render_ops: RenderOps,
+        shared_global_data: &SharedGlobalData,
+    );
+
+}

--- a/tuify/src/terminal_lib_backends/paint.rs
+++ b/tuify/src/terminal_lib_backends/paint.rs
@@ -1,0 +1,147 @@
+/*
+ *   Copyright (c) 2022 R3BL LLC
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+use r3bl_rs_utils_core::*;
+use crate::*;
+
+
+/// Paint the render pipeline. The render pipeline contains a list of [RenderOps] for each [ZOrder].
+/// This function is responsible for:
+/// 1. Actually executing those [RenderOps] in the correct order.
+/// 2. And routing the execution to the correct backend specified in [TERMINAL_LIB_BACKEND].
+///
+/// See [RenderOps] for more details of "atomiC PAINT OPERATIONS".
+pub fn paint(
+    ops: RenderOps,
+    state : &State,
+    flush_kind: FlushKind,
+    shared_global_data: &mut SharedGlobalData,
+) {
+    let maybe_saved_offscreen_buffer = shared_global_data
+        .maybe_saved_offscreen_buffer
+        .clone();
+
+    let offscreen_buffer = ops.convert(state, shared_global_data);
+    match maybe_saved_offscreen_buffer {
+        None => {
+            perform_full_paint(&offscreen_buffer, flush_kind, shared_global_data);
+        }
+        Some(saved_offscreen_buffer) => {
+            // Compare offscreen buffers & paint only the diff.
+            match saved_offscreen_buffer.diff(&offscreen_buffer) {
+                OffscreenBufferDiffResult::NotComparable => {
+                    perform_full_paint(&offscreen_buffer, flush_kind, shared_global_data);
+                }
+                OffscreenBufferDiffResult::Comparable(ref diff_chunks) => {
+                    perform_diff_paint(diff_chunks, shared_global_data);
+                }
+            }
+        }
+    }
+    shared_global_data.maybe_saved_offscreen_buffer = Some(offscreen_buffer);
+
+}
+
+pub fn perform_full_paint(
+    offscreen_buffer: &OffscreenBuffer,
+    flush_kind: FlushKind,
+    shared_global_data: &SharedGlobalData,
+){
+    let mut crossterm_impl = OffscreenBufferPaintImplCrossterm {};
+    let render_ops = crossterm_impl.render(offscreen_buffer);
+    crossterm_impl
+        .paint(render_ops, flush_kind, shared_global_data);
+}
+
+
+pub fn perform_diff_paint(
+    diff_chunks: &PixelCharDiffChunks,
+    shared_global_data: &SharedGlobalData,
+) {
+
+    let mut crossterm_impl = OffscreenBufferPaintImplCrossterm {};
+    let render_ops = crossterm_impl.render_diff(diff_chunks);
+    crossterm_impl
+        .paint_diff(render_ops, shared_global_data);
+}
+
+/// 1. Ensure that the [Position] is within the bounds of the terminal window using
+///    [RenderOpsLocalData].
+/// 2. If the [Position] is outside of the bounds of the window then it is clamped to the nearest
+///    edge of the window. This clamped [Position] is returned.
+/// 3. This also saves the clamped [Position] to [RenderOpsLocalData].
+pub fn sanitize_and_save_abs_position(
+    orig_abs_pos: Position,
+    shared_global_data: &SharedGlobalData,
+    local_data: &mut RenderOpsLocalData,
+) -> Position {
+    let Size {
+        col_count: max_cols,
+        row_count: max_rows,
+    } = shared_global_data.window_size;
+
+    let mut sanitized_abs_pos: Position = orig_abs_pos;
+
+    if orig_abs_pos.col_index > max_cols {
+        sanitized_abs_pos.col_index = max_cols;
+    }
+
+    if orig_abs_pos.row_index > max_rows {
+        sanitized_abs_pos.row_index = max_rows;
+    }
+
+    // Save the cursor position to local data.
+    local_data.cursor_position = sanitized_abs_pos;
+
+    debug(orig_abs_pos, sanitized_abs_pos);
+
+    return sanitized_abs_pos;
+
+    fn debug(orig_pos: Position, sanitized_pos: Position) {
+        call_if_true!(DEBUG_TUIFY_MOD, {
+            if sanitized_pos != orig_pos {
+                let msg = format!(
+                    "pipeline : 📍🗜️ Attempt to set cursor position {orig_pos:?} \
+                    outside of terminal window; clamping to nearest edge of window {sanitized_pos:?}"
+                );
+                log_info(msg);
+            }
+        });
+
+        call_if_true!(DEBUG_TUIFY_SHOW_PIPELINE_EXPANDED, {
+            let msg = format!(
+                "pipeline : 📍 Save the cursor position {sanitized_pos:?} \
+                to SharedGlobalData"
+            );
+            log_info(msg);
+        });
+    }
+}
+pub mod paint_exports {
+    use super::*;
+
+    pub trait PaintRenderOp {
+        fn paint(
+            &mut self,
+            skip_flush: &mut bool,
+            render_op: &RenderOp,
+            shared_global_data: &SharedGlobalData,
+            local_data: &mut RenderOpsLocalData,
+        );
+    }
+}
+pub use paint_exports::*;

--- a/tuify/src/terminal_lib_backends/render_op.rs
+++ b/tuify/src/terminal_lib_backends/render_op.rs
@@ -1,0 +1,416 @@
+use std::{fmt::{Debug, Formatter, Result},
+          ops::{Deref, DerefMut}};
+use r3bl_rs_utils_core::*;
+use serde::{Deserialize, Serialize};
+
+use crate::*;
+
+/// Here's an example. Refer to [RenderOps] for more details.
+///
+/// ```rust
+/// use r3bl_tuify::*;
+///
+/// let mut render_ops = render_ops!(
+///   @new
+///   RenderOp::ClearScreen, RenderOp::ResetColor
+/// );
+/// let len = render_ops.len();
+/// let iter = render_ops.iter();
+/// ```
+#[macro_export]
+macro_rules! render_ops {
+  // Empty.
+  () => {
+    RenderOps::default()
+  };
+
+  // @new: Create a RenderOps. If any ($arg_render_op)* are passed, then add it to its list. Finally
+  // return it.
+  (
+    @new
+    $(                      /* Start a repetition. */
+      $arg_render_op: expr  /* Expression. */
+    )                       /* End repetition. */
+    ,                       /* Comma separated. */
+    *                       /* Zero or more times. */
+    $(,)*                   /* Optional trailing comma https://stackoverflow.com/a/43143459/2085356. */
+  ) => {
+    /* Enclose the expansion in a block so that we can use multiple statements. */
+    {
+      let mut render_ops = RenderOps::default();
+      /* Start a repetition. */
+      $(
+        /* Each repeat will contain the following statement, with $arg_render_op replaced. */
+        render_ops.list.push($arg_render_op);
+      )*
+      render_ops
+    }
+  };
+
+  // @add_to: If any ($arg_render_op)* are passed, then add to it.
+  (
+    @add_to
+    $arg_render_ops: expr
+    =>
+    $(                      /* Start a repetition. */
+      $arg_render_op: expr  /* Expression. */
+    )                       /* End repetition. */
+    ,                       /* Comma separated. */
+    *                       /* Zero or more times. */
+    $(,)*                   /* Optional trailing comma https://stackoverflow.com/a/43143459/2085356. */
+  ) => {
+    /* Enclose the expansion in a block so that we can use multiple statements. */
+    {
+      /* Start a repetition. */
+      $(
+        /* Each repeat will contain the following statement, with $arg_render_op replaced. */
+        $arg_render_ops.list.push($arg_render_op);
+      )*
+    }
+  };
+
+  // @render_into: If any ($arg_render_op)* are passed, then add to it.
+  (
+    @render_styled_texts_into
+    $arg_render_ops: expr
+    =>
+    $(                       /* Start a repetition. */
+      $arg_styled_texts: expr/* Expression. */
+    )                        /* End repetition. */
+    ,                        /* Comma separated. */
+    *                        /* Zero or more times. */
+    $(,)*                    /* Optional trailing comma https://stackoverflow.com/a/43143459/2085356. */
+  ) => {
+    /* Enclose the expansion in a block so that we can use multiple statements. */
+    {
+      /* Start a repetition. */
+      $(
+        /* Each repeat will contain the following statement, with $arg_render_op replaced. */
+        $arg_styled_texts.render_into(&mut $arg_render_ops);
+      )*
+    }
+  };
+}
+
+/// For ease of use, please use the [render_ops!] macro.
+///
+/// It is a collection of *atomic* paint operations (aka [`RenderOps`] at various [`ZOrder`]s); each
+/// [`RenderOps`] is made up of a [vec] of [`RenderOp`]. It contains `Map<ZOrder, Vec<RenderOps>>`,
+/// eg:
+/// - [`ZOrder::Normal`] => vec![[`RenderOp::ResetColor`], [`RenderOp::MoveCursorPositionAbs(..)`],
+///   [`RenderOp::PrintTextWithAttributes(..)`]]
+/// - [`ZOrder::Glass`] => vec![[`RenderOp::ResetColor`], [`RenderOp::MoveCursorPositionAbs(..)`],
+///   [`RenderOp::PrintTextWithAttributes(..)`]]
+/// - etc.
+///
+/// ## What is an atomic paint operation?
+/// 1. It moves the cursor using:
+///     1. [`RenderOp::MoveCursorPositionAbs`]
+///     2. [`RenderOp::MoveCursorPositionRelTo`]
+/// 2.  And it does not assume that the cursor is in the correct position from some other previously
+///     executed operation!
+/// 3. So there are no side effects when re-ordering or omitting painting an atomic paint operation
+///    (eg in the case where it has already been painted before).
+///
+/// Here's an example. Consider using the macro for convenience (see [render_ops!]).
+///
+/// ```rust
+/// use r3bl_tuify::*;
+///
+/// let mut render_ops = RenderOps::default();
+/// render_ops.push(RenderOp::ClearScreen);
+/// render_ops.push(RenderOp::ResetColor);
+/// let len = render_ops.len();
+/// let iter = render_ops.iter();
+/// ```
+///
+/// ## Paint optimization
+/// Due to the compositor [OffscreenBuffer], there is no need to optimize the individual paint
+/// operations. You don't have to manage your own whitespace or doing clear before paint! 🎉 The
+/// compositor takes care of that for you!
+#[derive(Default, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct RenderOps {
+    pub list: Vec<RenderOp>,
+}
+
+#[derive(Default, Debug)]
+pub struct RenderOpsLocalData {
+    pub cursor_position: Position,
+}
+
+pub mod render_ops_impl {
+    use std::ops::AddAssign;
+
+    use super::*;
+
+    impl RenderOps {
+        pub fn execute_all(
+            &self,
+            skip_flush: &mut bool,
+            shared_global_data: &SharedGlobalData,
+        ) {
+            let mut local_data = RenderOpsLocalData::default();
+            for render_op in self.list.iter() {
+                RenderOps::route_paint_render_op_to_backend(
+                    &mut local_data,
+                    skip_flush,
+                    render_op,
+                    shared_global_data,
+                );
+            }
+        }
+
+        pub fn route_paint_render_op_to_backend(
+            local_data: &mut RenderOpsLocalData,
+            skip_flush: &mut bool,
+            render_op: &RenderOp,
+            shared_global_data: &SharedGlobalData,
+        ) {
+            match TERMINAL_LIB_BACKEND {
+                TerminalLibBackend::Crossterm => {
+                    RenderOpImplCrossterm {}
+                        .paint(skip_flush, render_op, shared_global_data, local_data);
+                }
+                TerminalLibBackend::Termion => todo!(), // FUTURE: implement PaintRenderOp trait for termion
+            }
+        }
+        pub fn convert(
+            &self,
+            state : &State,
+            shared_global_data: &SharedGlobalData
+        ) -> OffscreenBuffer {
+
+            let window_size = size!(col_count: state.max_display_width, row_count: state.max_display_height);
+            let mut my_offscreen_buffer = OffscreenBuffer::new_with_capacity_initialized(window_size);
+            let mut local_data = RenderOpsLocalData::default();
+
+            for (_render_op_index, render_op) in self.list.iter().enumerate() {
+                process_render_op(
+                    render_op,
+                    shared_global_data,
+                    &mut my_offscreen_buffer,
+                    &mut local_data,
+                );
+            }
+            my_offscreen_buffer
+        }
+    }
+    fn process_render_op(
+        render_op: &RenderOp,
+        shared_global_data: &SharedGlobalData,
+        my_offscreen_buffer: &mut OffscreenBuffer,
+        local_data: &mut RenderOpsLocalData,
+    ) {
+        match render_op {
+            // Don't process these.
+            RenderOp::Noop | RenderOp::EnterRawMode | RenderOp::ExitRawMode => {}
+            // Do process these.
+            RenderOp::ClearScreen => {
+                my_offscreen_buffer.clear();
+            }
+            RenderOp::MoveCursorPositionAbs(new_abs_pos) => {
+                my_offscreen_buffer.my_pos = sanitize_and_save_abs_position(
+                    *new_abs_pos,
+                    shared_global_data,
+                    local_data,
+                );
+            }
+            RenderOp::MoveCursorPositionRelTo(box_origin_pos_ref, content_rel_pos_ref) => {
+                let new_abs_pos = *box_origin_pos_ref + *content_rel_pos_ref;
+                my_offscreen_buffer.my_pos = sanitize_and_save_abs_position(
+                    new_abs_pos,
+                    shared_global_data,
+                    local_data,
+                );
+            }
+            RenderOp::SetFgColor(fg_color_ref) => {
+                my_offscreen_buffer.my_fg_color = Some(*fg_color_ref);
+            }
+            RenderOp::SetBgColor(bg_color_ref) => {
+                my_offscreen_buffer.my_bg_color = Some(*bg_color_ref);
+            }
+            RenderOp::ResetColor => {
+                my_offscreen_buffer.my_fg_color = None;
+                my_offscreen_buffer.my_bg_color = None;
+            }
+            RenderOp::ApplyColors(maybe_style_ref) => {
+                if let Some(style_ref) = maybe_style_ref {
+                    my_offscreen_buffer.my_fg_color = style_ref.color_fg;
+                    my_offscreen_buffer.my_bg_color = style_ref.color_bg;
+                }
+            }
+            RenderOp::CompositorNoClipTruncPaintTextWithAttributes(
+                _arg_text_ref,
+                _maybe_style_ref,
+            ) => {
+                // This is a no-op. This operation is executed by RenderOpImplCrossterm.
+            }
+            RenderOp::PaintTextWithAttributes(arg_text_ref, maybe_style_ref) => {
+                let result_new_pos = print_text_with_attributes(
+                    shared_global_data,
+                    arg_text_ref,
+                    maybe_style_ref,
+                    my_offscreen_buffer,
+                    None,
+                );
+                if let Ok(new_pos) = result_new_pos {
+                    my_offscreen_buffer.my_pos = sanitize_and_save_abs_position(
+                        new_pos,
+                        shared_global_data,
+                        local_data,
+                    );
+                }
+            }
+        }
+    }
+
+    impl Deref for RenderOps {
+        type Target = Vec<RenderOp>;
+
+        fn deref(&self) -> &Self::Target { &self.list }
+    }
+
+    impl DerefMut for RenderOps {
+        fn deref_mut(&mut self) -> &mut Self::Target { &mut self.list }
+    }
+
+    impl AddAssign<RenderOp> for RenderOps {
+        fn add_assign(&mut self, rhs: RenderOp) { self.list.push(rhs); }
+    }
+
+    impl Debug for RenderOps {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let mut vec_lines: Vec<String> = vec![];
+
+            // First line.
+            let first_line: String = format!("RenderOps.len(): {}", self.list.len());
+            vec_lines.push(first_line);
+
+            // Subsequent lines (optional).
+            for render_op in self.iter() {
+                let line: String = format!("[{render_op:?}]");
+                vec_lines.push(line);
+            }
+
+            // Join all lines.
+            write!(f, "\n    - {}", vec_lines.join("\n      - "))
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum RenderOp {
+    EnterRawMode,
+
+    ExitRawMode,
+
+    /// This is always painted on top. [Position] is the absolute column and row on the terminal
+    /// screen. This uses [sanitize_and_save_abs_position] to clean up the given
+    /// [Position].
+    MoveCursorPositionAbs(/* absolute position */ Position),
+
+    /// This is always painted on top. 1st [Position] is the origin column and row, and the 2nd
+    /// [Position] is the offset column and row. They are added together to move the absolute position
+    /// on the terminal screen. Then [RenderOp::MoveCursorPositionAbs] is used.
+    MoveCursorPositionRelTo(
+        /* origin position */ Position,
+        /* relative position */ Position,
+    ),
+
+    ClearScreen,
+
+    /// Directly set the fg color for crossterm w/out using [Style].
+    SetFgColor(TuiColor),
+
+    /// Directly set the bg color for crossterm w/out using [Style].
+    SetBgColor(TuiColor),
+
+    ResetColor,
+
+    /// Translate [Style] into fg and bg colors for crossterm. Note that this does not
+    /// apply attributes (bold, italic, underline, strikethrough, etc). If you need to
+    /// apply attributes, use [RenderOp::PaintTextWithAttributes] instead.
+    ApplyColors(Option<Style>),
+
+    /// Translate [Style] into *only* attributes for crossterm (bold, italic, underline,
+    /// strikethrough, etc) and not colors. If you need to apply color, use
+    /// [RenderOp::ApplyColors] instead.
+    ///
+    /// 1. If the [String] argument is plain text (no ANSI sequences) then it will be
+    ///    clipped available width of the terminal screen).
+    ///
+    /// 2. If the [String] argument contains ANSI sequences then it will be printed as-is.
+    ///    You are responsible for handling clipping of the text to the bounds of the
+    ///    terminal screen.
+    PaintTextWithAttributes(String, Option<Style>),
+
+    /// This is **not** meant for use directly by apps. It is to be used only by the
+    /// [OffscreenBuffer]. This operation skips the checks for content width padding & clipping, and
+    /// window bounds clipping. These are not needed when the compositor is painting an offscreen
+    /// buffer, since when the offscreen buffer was created the two render ops above were used which
+    /// already handle the clipping and padding.
+    CompositorNoClipTruncPaintTextWithAttributes(String, Option<Style>),
+
+    /// For [Default] impl.
+    Noop,
+}
+
+mod render_op_impl {
+    use super::*;
+
+    impl Default for RenderOp {
+        fn default() -> Self { Self::Noop }
+    }
+
+    impl Debug for RenderOp {
+        /// When [RenderPipeline] is printed as debug, each [RenderOp] is printed using this method. Also
+        /// [exec_render_op!] does not use this; it has its own way of logging output.
+        fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+            match TERMINAL_LIB_BACKEND {
+                TerminalLibBackend::Crossterm => {
+                    CrosstermDebugFormatRenderOp {}.debug_format(self, f)
+                }
+                TerminalLibBackend::Termion => todo!(), // FUTURE: implement debug formatter for termion
+            }
+        }
+    }
+}
+
+mod render_op_impl_trait_flush {
+    use super::*;
+
+    impl Flush for RenderOp {
+        fn flush(&mut self) {
+            match TERMINAL_LIB_BACKEND {
+                TerminalLibBackend::Crossterm => {
+                    RenderOpImplCrossterm {}.flush();
+                }
+                TerminalLibBackend::Termion => todo!(), // FUTURE: implement flush for termion
+            }
+        }
+
+        fn clear_before_flush(&mut self) {
+            match TERMINAL_LIB_BACKEND {
+                TerminalLibBackend::Crossterm => {
+                    RenderOpImplCrossterm {}.clear_before_flush();
+                }
+                TerminalLibBackend::Termion => todo!(), // FUTURE: implement clear_before_flush for termion
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum FlushKind {
+    JustFlush,
+    ClearBeforeFlush,
+}
+
+pub trait Flush {
+    fn flush(&mut self);
+    fn clear_before_flush(&mut self);
+}
+
+pub trait DebugFormatRenderOp {
+    fn debug_format(&self, this: &RenderOp, f: &mut Formatter<'_>) -> Result;
+}

--- a/tuify/src/terminal_lib_backends/terminal_lib_operations.rs
+++ b/tuify/src/terminal_lib_backends/terminal_lib_operations.rs
@@ -1,0 +1,12 @@
+use r3bl_rs_utils_core::*;
+use crossterm::cursor;
+/// Interrogate crossterm [crossterm::terminal::size()] to get the size of the terminal window.
+pub fn lookup_size() -> CommonResult<Size> {
+    let (col, row) = crossterm::terminal::size()?;
+    let size: Size = size!(col_count: col, row_count: row);
+    Ok(size)
+}
+pub fn get_inline_row_index() -> ChUnit {
+    let (_x, y) = cursor::position().unwrap();
+    (y).into()
+}

--- a/tuify/src/terminal_window/mod.rs
+++ b/tuify/src/terminal_window/mod.rs
@@ -1,0 +1,3 @@
+pub mod shared_global_data;
+
+pub use shared_global_data::*;

--- a/tuify/src/terminal_window/shared_global_data.rs
+++ b/tuify/src/terminal_window/shared_global_data.rs
@@ -1,0 +1,100 @@
+/*
+ *   Copyright (c) 2022 R3BL LLC
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+use std::fmt::Debug;
+
+use r3bl_rs_utils_core::*;
+
+use crate::*;
+
+/// These are state values for the overall application:
+/// - The `window_size` holds the [Size] of the terminal window.
+///
+/// - The `maybe_saved_offscreen_buffer` holds the last rendered [OffscreenBuffer].
+#[derive(Clone, Default)]
+pub struct GlobalData {
+    pub window_size: Size,
+    pub maybe_saved_offscreen_buffer: Option<OffscreenBuffer>,
+    pub inline_row_offset : ChUnit
+}
+mod global_data_impl {
+    use std::fmt::Formatter;
+
+    use super::*;
+
+    impl Debug for GlobalData {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            let mut vec_lines = vec![];
+            vec_lines.push(format!("{0:?}", self.window_size));
+            vec_lines.push(format!("Inline Row Offset : {:?}", self.inline_row_offset));
+            vec_lines.push(match &self.maybe_saved_offscreen_buffer {
+                None => "no saved offscreen buffer".to_string(),
+                Some(ref offscreen_buffer) => match DEBUG_TUIFY_COMPOSITOR {
+                    false => "offscreen buffer saved from previous render".to_string(),
+                    true => offscreen_buffer.pretty_print(),
+                },
+            });
+            write!(f, "\nGlobalData\n  - {}", vec_lines.join("\n  - "))
+        }
+    }
+
+    impl GlobalData {
+        pub fn try_to_create_instance() -> CommonResult<GlobalData> {
+            let mut global_data = GlobalData::default();
+            global_data.set_size(terminal_lib_operations::lookup_size()?);
+            Ok(global_data)
+        }
+
+        pub fn try_to_create_inline_instance<T: ViewportHeight>(state : &T) -> CommonResult<GlobalData> {
+            let mut global_data = GlobalData::default();
+            let window_size = terminal_lib_operations::lookup_size()?;
+            let initial_row_offset = terminal_lib_operations::get_inline_row_index();
+            global_data.set_size(window_size);
+            // Setting up the inline row offset
+            let max_row_height = window_size.row_count;
+            let offscreen_buffer_height = state.get_viewport_height();
+            if (initial_row_offset + offscreen_buffer_height) >= max_row_height {
+                global_data.set_inline_row_offset(max_row_height - offscreen_buffer_height -1);
+            } else {
+                global_data.set_inline_row_offset(initial_row_offset);
+            }
+            Ok(global_data)
+        }
+
+        pub fn set_size(&mut self, new_size: Size) {
+            self.window_size = new_size;
+            self.dump_to_log("main_event_loop -> Resize");
+        }
+
+        pub fn get_size(&self) -> Size { self.window_size }
+
+        pub fn set_inline_row_offset(&mut self, new_offset: ChUnit) {
+            self.inline_row_offset = new_offset;
+            self.dump_to_log("main_event_loop -> Inline Row Offset");
+        }
+        pub fn get_inline_row_offset(&self) -> ChUnit {
+            self.inline_row_offset
+        }
+
+        pub fn dump_to_log(&self, msg: &str) {
+            let log_msg = format!("{msg} -> {self:?}");
+            call_if_true!(DEBUG_TUIFY_MOD, log_info(log_msg));
+        }
+    }
+}
+
+pub type SharedGlobalData = GlobalData;


### PR DESCRIPTION
## Overview
The `tui` offscreenbuffer requires minimal changes, if we can just manage  to push the rendering to an inline position of our choice. To achieve this : 
- The buffer is that of the view-port size. The idea to have the buffer for the full app was discarded as buffer creation is cheap, only printing is costly.
- An `inline_row_offset` is calculated using the following logic for the 2 cases possible.
- If the (`initial_row_offset` + `offscreenbuffer_height`( includes header) ) < the `max_height_provided`, then, we can use the initial_row_offset as is for inline_row_offset.
- If the `initial_row_offset` +  `offscreenbuffer_height` exceeds the `max_height_provided`, then the inline_row_offset would just be calculated by subtracting the buffer height from the max_height_provided. 
- Since we have added the header to the buffer, the logic for key-press affecting scroll is slightly affected.


## ToDo
- [ ] Tests.
- [ ] Linting.
- [ ] License text of tui might have been missed while reusing code.
- [ ] Probable Reorganisation.
- [ ] If `max_height_provided` is larger than the `terminal_size` then it should be just rounded down to `terminal_size`, however not done currently
- [ ] Allocation and clearing of view-port currently uses crossterm commands directly instead of using wrapped functions to support other back-end. This is temporarily done to maintain reference to original tuify code and can be easily replaced.
- [ ] Shared global data and the state can even be merged but are separated for retaining context to original offscreenbuffer implementation.
- [ ] Resizing of windows
