### PR TITLE
[tui] Adding macro to perform mpsc signal sending

### DIFF
--- a/core/src/decl_macros.rs
+++ b/core/src/decl_macros.rs
@@ -387,3 +387,23 @@ macro_rules! assert_eq2 {
         pretty_assertions::assert_eq!($($params)*)
     };
 }
+
+/// Send a signal to the main thread of app to render. The two things to pass in this macro are
+/// 1. Sender
+/// 2. AppEvent (Signal to MPSC channel)
+#[macro_export]
+macro_rules! send_signal {
+    (
+        $main_thread_channel_sender : expr,
+        $signal : expr
+    ) => {{
+        let sender_clone = $main_thread_channel_sender.clone();
+
+        // Note: make sure to wrap the call to `send` in a `tokio::spawn()` so
+        // that it doesn't block the calling thread. More info:
+        // <https://tokio.rs/tokio/tutorial/channels>.
+        tokio::spawn(async move {
+            let _ = sender_clone.send($signal).await;
+        });
+    }};
+}

--- a/tui/examples/demo/ex_app_no_layout/app_main.rs
+++ b/tui/examples/demo/ex_app_no_layout/app_main.rs
@@ -80,15 +80,10 @@ mod animator_task {
                         telemetry_global_static::set_start_ts();
 
                         // Send a signal to the main thread to render.
-                        let main_thread_channel_sender_clone = main_thread_channel_sender.clone();
-                        // Note: make sure to wrap the call to `send` in a `tokio::spawn()` so
-                        // that it doesn't block the calling thread. More info:
-                        // <https://tokio.rs/tokio/tutorial/channels>.
-                        tokio::spawn(async move {
-                            let _ = main_thread_channel_sender_clone
-                            .send(TerminalWindowMainThreadSignal::ApplyAction(AppSignal::Add))
-                            .await;
-                        });
+                        send_signal!(
+                            main_thread_channel_sender,
+                            TerminalWindowMainThreadSignal::ApplyAction(AppSignal::Add)
+                        );
 
                         // Wire into the timing telemetry.
                         telemetry_global_static::set_end_ts();
@@ -292,27 +287,21 @@ mod app_main_impl_trait_app {
                         match typed_char {
                             '+' => {
                                 event_consumed = true;
-                                tokio::spawn(async move {
-                                    let _ = sender
-                                        .send(
-                                            TerminalWindowMainThreadSignal::ApplyAction(
-                                                AppSignal::Add,
-                                            ),
-                                        )
-                                        .await;
-                                });
+                                send_signal!(
+                                    sender,
+                                    TerminalWindowMainThreadSignal::ApplyAction(
+                                        AppSignal::Add,
+                                    )
+                                );
                             }
                             '-' => {
                                 event_consumed = true;
-                                tokio::spawn(async move {
-                                    let _ = sender
-                                        .send(
-                                            TerminalWindowMainThreadSignal::ApplyAction(
-                                                AppSignal::Sub,
-                                            ),
-                                        )
-                                        .await;
-                                });
+                                send_signal!(
+                                    sender,
+                                    TerminalWindowMainThreadSignal::ApplyAction(
+                                        AppSignal::Sub,
+                                    )
+                                );
                             }
                             // Override default behavior of 'x' key.
                             'x' => {
@@ -329,27 +318,21 @@ mod app_main_impl_trait_app {
                         match special_key {
                             SpecialKey::Up => {
                                 event_consumed = true;
-                                tokio::spawn(async move {
-                                    let _ = sender
-                                        .send(
-                                            TerminalWindowMainThreadSignal::ApplyAction(
-                                                AppSignal::Add,
-                                            ),
-                                        )
-                                        .await;
-                                });
+                                send_signal!(
+                                    sender,
+                                    TerminalWindowMainThreadSignal::ApplyAction(
+                                        AppSignal::Add,
+                                    )
+                                );
                             }
                             SpecialKey::Down => {
                                 event_consumed = true;
-                                tokio::spawn(async move {
-                                    let _ = sender
-                                        .send(
-                                            TerminalWindowMainThreadSignal::ApplyAction(
-                                                AppSignal::Sub,
-                                            ),
-                                        )
-                                        .await;
-                                });
+                                send_signal!(
+                                    sender,
+                                    TerminalWindowMainThreadSignal::ApplyAction(
+                                        AppSignal::Sub,
+                                    )
+                                );
                             }
                             _ => {}
                         }

--- a/tui/examples/demo/ex_app_with_1col_layout/single_column_component.rs
+++ b/tui/examples/demo/ex_app_with_1col_layout/single_column_component.rs
@@ -74,39 +74,26 @@ mod single_column_component_impl_component_trait {
                 let mut event_consumed = false;
 
                 if let InputEvent::Keyboard(KeyPress::Plain { key }) = input_event {
-                    let sender = global_data.main_thread_channel_sender.clone();
                     // Check for + or - key.
                     if let Key::Character(typed_char) = key {
                         match typed_char {
                             '+' => {
                                 event_consumed = true;
-                                // Note: make sure to wrap the call to `send` in a `tokio::spawn()` so
-                                // that it doesn't block the calling thread. More info:
-                                // <https://tokio.rs/tokio/tutorial/channels>.
-                                tokio::spawn(async move {
-                                    let _ = sender
-                                        .send(
-                                            TerminalWindowMainThreadSignal::ApplyAction(
-                                                AppSignal::AddPop(1),
-                                            ),
-                                        )
-                                        .await;
-                                });
+                                send_signal!(
+                                    global_data.main_thread_channel_sender,
+                                    TerminalWindowMainThreadSignal::ApplyAction(
+                                        AppSignal::AddPop(1),
+                                    )
+                                );
                             }
                             '-' => {
                                 event_consumed = true;
-                                // Note: make sure to wrap the call to `send` in a `tokio::spawn()` so
-                                // that it doesn't block the calling thread. More info:
-                                // <https://tokio.rs/tokio/tutorial/channels>.
-                                tokio::spawn(async move {
-                                    let _ = sender
-                                        .send(
-                                            TerminalWindowMainThreadSignal::ApplyAction(
-                                                AppSignal::SubPop(1),
-                                            ),
-                                        )
-                                        .await;
-                                });
+                                send_signal!(
+                                    global_data.main_thread_channel_sender,
+                                    TerminalWindowMainThreadSignal::ApplyAction(
+                                        AppSignal::SubPop(1),
+                                    )
+                                );
                             }
                             _ => {}
                         }
@@ -114,37 +101,24 @@ mod single_column_component_impl_component_trait {
 
                     // Check for up or down arrow key.
                     if let Key::SpecialKey(special_key) = key {
-                        let sender = global_data.main_thread_channel_sender.clone();
                         match special_key {
                             SpecialKey::Up => {
                                 event_consumed = true;
-                                // Note: make sure to wrap the call to `send` in a `tokio::spawn()` so
-                                // that it doesn't block the calling thread. More info:
-                                // <https://tokio.rs/tokio/tutorial/channels>.
-                                tokio::spawn(async move {
-                                    let _ = sender
-                                        .send(
-                                            TerminalWindowMainThreadSignal::ApplyAction(
-                                                AppSignal::AddPop(1),
-                                            ),
-                                        )
-                                        .await;
-                                });
+                                send_signal!(
+                                    global_data.main_thread_channel_sender,
+                                    TerminalWindowMainThreadSignal::ApplyAction(
+                                        AppSignal::AddPop(1),
+                                    )
+                                );
                             }
                             SpecialKey::Down => {
                                 event_consumed = true;
-                                // Note: make sure to wrap the call to `send` in a `tokio::spawn()` so
-                                // that it doesn't block the calling thread. More info:
-                                // <https://tokio.rs/tokio/tutorial/channels>.
-                                tokio::spawn(async move {
-                                    let _ = sender
-                                        .send(
-                                            TerminalWindowMainThreadSignal::ApplyAction(
-                                                AppSignal::SubPop(1),
-                                            ),
-                                        )
-                                        .await;
-                                });
+                                send_signal!(
+                                    global_data.main_thread_channel_sender,
+                                    TerminalWindowMainThreadSignal::ApplyAction(
+                                        AppSignal::SubPop(1),
+                                    )
+                                );
                             }
                             _ => {}
                         }

--- a/tui/examples/demo/ex_app_with_2col_layout/column_render_component.rs
+++ b/tui/examples/demo/ex_app_with_2col_layout/column_render_component.rs
@@ -74,39 +74,29 @@ mod column_render_component_impl_component_trait {
                 let mut event_consumed = false;
 
                 if let InputEvent::Keyboard(KeyPress::Plain { key }) = input_event {
-                    let sender = global_data.main_thread_channel_sender.clone();
                     // Check for + or - key.
                     if let Key::Character(typed_char) = key {
                         match typed_char {
                             '+' => {
                                 event_consumed = true;
-                                // Note: make sure to wrap the call to `send` in a `tokio::spawn()` so
-                                // that it doesn't block the calling thread. More info:
-                                // <https://tokio.rs/tokio/tutorial/channels>.
-                                tokio::spawn(async move {
-                                    let _ = sender
-                                        .send(
-                                            TerminalWindowMainThreadSignal::ApplyAction(
-                                                AppSignal::AddPop(1),
-                                            ),
-                                        )
-                                        .await;
-                                });
+                                send_signal!(
+                                    global_data.main_thread_channel_sender,
+                                    TerminalWindowMainThreadSignal::ApplyAction(
+                                        AppSignal::AddPop(1),
+                                    )
+                                );
                             }
                             '-' => {
                                 event_consumed = true;
                                 // Note: make sure to wrap the call to `send` in a `tokio::spawn()` so
                                 // that it doesn't block the calling thread. More info:
                                 // <https://tokio.rs/tokio/tutorial/channels>.
-                                tokio::spawn(async move {
-                                    let _ = sender
-                                        .send(
-                                            TerminalWindowMainThreadSignal::ApplyAction(
-                                                AppSignal::SubPop(1),
-                                            ),
-                                        )
-                                        .await;
-                                });
+                                send_signal!(
+                                    global_data.main_thread_channel_sender,
+                                    TerminalWindowMainThreadSignal::ApplyAction(
+                                        AppSignal::SubPop(1),
+                                    )
+                                );
                             }
                             _ => {}
                         }
@@ -114,37 +104,24 @@ mod column_render_component_impl_component_trait {
 
                     // Check for up or down arrow key.
                     if let Key::SpecialKey(special_key) = key {
-                        let sender = global_data.main_thread_channel_sender.clone();
                         match special_key {
                             SpecialKey::Up => {
                                 event_consumed = true;
-                                // Note: make sure to wrap the call to `send` in a `tokio::spawn()` so
-                                // that it doesn't block the calling thread. More info:
-                                // <https://tokio.rs/tokio/tutorial/channels>.
-                                tokio::spawn(async move {
-                                    let _ = sender
-                                        .send(
-                                            TerminalWindowMainThreadSignal::ApplyAction(
-                                                AppSignal::AddPop(1),
-                                            ),
-                                        )
-                                        .await;
-                                });
+                                send_signal!(
+                                    global_data.main_thread_channel_sender,
+                                    TerminalWindowMainThreadSignal::ApplyAction(
+                                        AppSignal::AddPop(1),
+                                    )
+                                );
                             }
                             SpecialKey::Down => {
                                 event_consumed = true;
-                                // Note: make sure to wrap the call to `send` in a `tokio::spawn()` so
-                                // that it doesn't block the calling thread. More info:
-                                // <https://tokio.rs/tokio/tutorial/channels>.
-                                tokio::spawn(async move {
-                                    let _ = sender
-                                        .send(
-                                            TerminalWindowMainThreadSignal::ApplyAction(
-                                                AppSignal::SubPop(1),
-                                            ),
-                                        )
-                                        .await;
-                                });
+                                send_signal!(
+                                    global_data.main_thread_channel_sender,
+                                    TerminalWindowMainThreadSignal::ApplyAction(
+                                        AppSignal::SubPop(1),
+                                    )
+                                );
                             }
                             _ => {}
                         }

--- a/tui/examples/demo/ex_editor/app_main.rs
+++ b/tui/examples/demo/ex_editor/app_main.rs
@@ -523,11 +523,10 @@ mod populate_component_registry {
                     TerminalWindowMainThreadSignal<AppSignal>,
                 >,
             ) {
-                tokio::spawn(async move {
-                    let _ = main_thread_channel_sender
-                        .send(TerminalWindowMainThreadSignal::Render(Some(my_id)))
-                        .await;
-                });
+                send_signal!(
+                    main_thread_channel_sender,
+                    TerminalWindowMainThreadSignal::Render(Some(my_id))
+                );
             }
 
             let config_options = EditorEngineConfig::default();

--- a/tui/examples/demo/ex_pitch/app_main.rs
+++ b/tui/examples/demo/ex_pitch/app_main.rs
@@ -121,18 +121,10 @@ mod app_main_impl_app_trait {
                 mask: ModifierKeysMask::new().with_ctrl(),
             }) {
                 // Spawn previous slide action.
-                let main_thread_sender_clone =
-                    global_data.main_thread_channel_sender.clone();
-                // Note: make sure to wrap the call to `send` in a `tokio::spawn()` so
-                // that it doesn't block the calling thread. More info:
-                // <https://tokio.rs/tokio/tutorial/channels>.
-                tokio::spawn(async move {
-                    let _ = main_thread_sender_clone
-                        .send(TerminalWindowMainThreadSignal::ApplyAction(
-                            AppSignal::PreviousSlide,
-                        ))
-                        .await;
-                });
+                send_signal!(
+                    global_data.main_thread_channel_sender,
+                    TerminalWindowMainThreadSignal::ApplyAction(AppSignal::PreviousSlide)
+                );
                 return Ok(EventPropagation::Consumed);
             };
 
@@ -285,11 +277,10 @@ mod populate_component_registry {
                     TerminalWindowMainThreadSignal<AppSignal>,
                 >,
             ) {
-                tokio::spawn(async move {
-                    let _ = main_thread_channel_sender
-                        .send(TerminalWindowMainThreadSignal::Render(Some(my_id)))
-                        .await;
-                });
+                send_signal!(
+                    main_thread_channel_sender,
+                    TerminalWindowMainThreadSignal::Render(Some(my_id))
+                );
             }
 
             let config_options = EditorEngineConfig {

--- a/tuify/examples/main_interactive.rs
+++ b/tuify/examples/main_interactive.rs
@@ -150,15 +150,13 @@ fn main() -> Result<()> {
                                 max_width_col_count,
                                 style,
                             );
-                        } else if *user_input == SINGLE_SELECT_2_ITEMS_VPH_5.to_string() 
-                        {
+                        } else if *user_input == SINGLE_SELECT_2_ITEMS_VPH_5.to_string() {
                             single_select_2_items_vph_5(
                                 max_height_row_count,
                                 max_width_col_count,
                                 style,
                             );
-                        } else if *user_input == SINGLE_SELECT_QUIZ_GAME.to_string() 
-                        {
+                        } else if *user_input == SINGLE_SELECT_QUIZ_GAME.to_string() {
                             let _ = single_select_quiz_game();
                         } else {
                             println!("User did not select anything")


### PR DESCRIPTION
With these changes, We are introducing a new macro called `send_signal!` which will take in the sender and the event. This will make code more clean by removal of repeated tokio spawn blocks.

Closes #219 