### PR TITLE
Rewrite MD Parser and change how headings and plain text is handled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
   - [v0.2.4 2023-10-14](#v024-2023-10-14)
 - [r3bl_tui](#r3bl_tui)
   - [Next release](#next-release)
+- [- Fixed:](#--fixed)
   - [v0.3.10 2023-10-29](#v0310-2023-10-29)
   - [v0.3.9 2023-10-29](#v039-2023-10-29)
   - [v0.3.7 2023-10-21](#v037-2023-10-21)
@@ -287,6 +288,12 @@
 ### Next release
 <a id="markdown-next-release" name="next-release"></a>
 
+- Fixed:
+  - Fix the custom MD parser so that it correctly parses plain text. Also disable the
+    syntect highlighter for the editor by default and just use the custom MD parser. For
+    files that are not Markdown, we will probably need to enable syntect in the future
+    since it is not covered by the custom MD parser & highlighter combo.
+
 - Added:
   - Added undo, redo support for the editor component.
   - Added binary target for `edi` which is going to be a Markdown editor similar to `nano`
@@ -295,13 +302,13 @@
 
 - Changed:
   - Redux is no longer used in order to propagate state transitions from async middleware
-    functions to the app. This is now accomplished using
-    [async `tokio::mpsc` channels](https://tokio.rs/tokio/tutorial/channels). Here's a
-    [design doc](https://docs.google.com/document/d/1OMB1rX6cUL_Jxpl-OUWMhJijM7c4FoDrK6qDViVXBWk/edit)
+    functions to the app. This is now accomplished using [async `tokio::mpsc`
+    channels](https://tokio.rs/tokio/tutorial/channels). Here's a [design
+    doc](https://docs.google.com/document/d/1OMB1rX6cUL_Jxpl-OUWMhJijM7c4FoDrK6qDViVXBWk/edit)
     for this change. Here's the
     [issue](https://github.com/r3bl-org/r3bl-open-core/issues/196) and
-    [PR](https://github.com/r3bl-org/r3bl-open-core/pull/205) for this change. Here are some videos
-    that go over this massive change:
+    [PR](https://github.com/r3bl-org/r3bl-open-core/pull/205) for this change. Here are
+    some videos that go over this massive change:
     - <https://youtu.be/o2CVEikbEAQ>
     - <https://youtu.be/Ne5-MXxt97A>
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 > 🪷 If you are interested in contributing to this project, please read our [📒 contributing guide](https://github.com/r3bl-org/r3bl-open-core/blob/e2d0ca7fed4147c27fa2217d2e14549d3af3dc48/CONTRIBUTING.md).
 
 # Context
-<a id="markdown-context" name="context"></a>
+<a id="markdown-context-*fef*-_fewfj_" name="context-*fef*-_fewfj_"></a>
 
 <!-- R3BL TUI library & suite of apps focused on developer productivity -->
 

--- a/tui/src/tui/editor/editor_engine/editor_engine_api.rs
+++ b/tui/src/tui/editor/editor_engine/editor_engine_api.rs
@@ -173,13 +173,15 @@ impl EditorEngineApi {
         // BOOKM: Render using syntect first, then custom MD parser.
 
         // Render using syntect first.
-        syn_hi_syntect_path::render_content(
-            editor_buffer,
-            max_display_row_count,
-            render_ops,
-            editor_engine,
-            max_display_col_count,
-        );
+        call_if_true!(ENABLE_SYNTECT_MD_PARSE_AND_HIGHLIGHT, {
+            syn_hi_syntect_path::render_content(
+                editor_buffer,
+                max_display_row_count,
+                render_ops,
+                editor_engine,
+                max_display_col_count,
+            );
+        });
 
         // Any overrides can be applied here.
         syn_hi_r3bl_path::render_content(

--- a/tui/src/tui/md_parser/block/parse_block_markdown_text_until_eol.rs
+++ b/tui/src/tui/md_parser/block/parse_block_markdown_text_until_eol.rs
@@ -89,8 +89,28 @@ mod test {
                 "here is some plaintext *but what if we italicize?"
             ),
             Ok((
-                "*but what if we italicize?",
-                list![MdLineFragment::Plain("here is some plaintext "),]
+                "",
+                list![
+                    MdLineFragment::Plain("here is some plaintext "),
+                    MdLineFragment::Plain("*but what if we italicize?"),
+                ]
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_multiple_plain_text_fragments_in_single_line() {
+        let it = parse_block_markdown_text_until_eol("this _bar\n");
+        println!("it: {:#?}", it);
+        assert_eq2!(
+            it,
+            Ok((
+                /* remainder */ "",
+                /* output */
+                list![
+                    MdLineFragment::Plain("this "),
+                    MdLineFragment::Plain("_bar"),
+                ]
             ))
         );
     }

--- a/tui/src/tui/mod.rs
+++ b/tui/src/tui/mod.rs
@@ -26,7 +26,9 @@
 ///    [r3bl_rs_utils_core::log_error] fails, then it will print the error to stderr.
 pub const DEBUG_TUI_MOD: bool = true;
 
-pub const DEBUG_MD_PARSER: bool = false;
+// 00: DEBUG REMOVE SYNTECT & FIX MD PARSER
+pub const ENABLE_SYNTECT_MD_PARSE_AND_HIGHLIGHT: bool = false;
+pub const DEBUG_MD_PARSER: bool = true;
 
 /// Enable or disable syntax highlighting debug logging.
 pub const DEBUG_TUI_SYN_HI: bool = false;

--- a/tui/src/tui/syntax_highlighting/md_parser_syn_hi/md_parser_syn_hi_impl.rs
+++ b/tui/src/tui/syntax_highlighting/md_parser_syn_hi/md_parser_syn_hi_impl.rs
@@ -46,6 +46,7 @@ pub fn try_parse_and_highlight(
         line_to_str_acc.join("")
     };
 
+    // BOOKM: Parse markdown from editor and render it
     // Try and parse `editor_text_to_string` into a `Document`.
     match parse_markdown(&editor_text_to_string) {
         Ok((_remainder, document)) => Ok(StyleUSSpanLines::from_document(


### PR DESCRIPTION
- Remove use of syntect parser and syntax highlighter. This can be enabled by changing a bool const in tui/src/tui/mod.rs

Fixes: #253