### PR TITLE
[tui][examples] Fix caret movement on right arrow press

### DIFF
--- a/tui/src/tui/editor/editor_engine/editor_engine_internal_api.rs
+++ b/tui/src/tui/editor/editor_engine/editor_engine_internal_api.rs
@@ -1678,9 +1678,9 @@ pub mod validate_editor_buffer_change {
         let scroll_offset = editor_buffer.get_scroll_offset();
 
         // Check right side of line. Clip scroll adjusted caret to max line width.
-        let caret = editor_buffer.get_caret(CaretKind::Raw);
+        let scroll_adjusted_caret = editor_buffer.get_caret(CaretKind::ScrollAdjusted);
         let row_content_width =
-            content_get::line_display_width_at_row_index(editor_buffer, caret.row_index)
+            content_get::line_display_width_at_row_index(editor_buffer, scroll_adjusted_caret.row_index)
                 - scroll_offset.col_index;
 
         let (_, caret, _, _) = editor_buffer.get_mut();


### PR DESCRIPTION
# Description 
Right arrow key sometimes resulted in incorrect caret movement in editor. 

## Root Cause
Incorrect estimation of the line width at the caret location resulted in incorrect clipping of caret position.

Closes #256 
