### PR TITLE
[tui][edi] Fix incorrect selection on moving to previous line

### DIFF
--- a/tui/src/tui/editor/editor_engine/editor_engine_internal_api.rs
+++ b/tui/src/tui/editor/editor_engine/editor_engine_internal_api.rs
@@ -841,7 +841,11 @@ mod caret_mut {
                             scroll_editor_buffer::dec_caret_row(caret, scroll_offset);
                         },
                     );
-                    caret_mut::to_end_of_line(editor_buffer, editor_engine, select_mode);
+                    caret_mut::to_end_of_line(
+                        editor_buffer,
+                        editor_engine,
+                        SelectMode::Disabled,
+                    );
                 }
             }
             CaretColLocationInLine::AtEnd => {


### PR DESCRIPTION
# Description
- closes #261 
- Movement from current line to previous line during selection using the left arrow key was resulting in previous line being selected in its entirety.


## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works.
     - The PR does not include test-cases for the same as those are currently being targeted as part of a larger effort to have better test-cases for editor #184 and would be added in upcoming PRs.
- [x] I have manually tested my changes and they work as intended.