### PR TITLE
[tuify] Change the select result type

### DIFF
--- a/tuify/examples/main_interactive.rs
+++ b/tuify/examples/main_interactive.rs
@@ -19,9 +19,7 @@ use std::io::Result;
 
 use r3bl_ansi_color::{AnsiStyledText, Color, Style as RStyle};
 use r3bl_rs_utils_core::*;
-use r3bl_tuify::{
-    components::style::StyleSheet, get_size, select_from_list, SelectionMode, DEVELOPMENT_MODE,
-};
+use r3bl_tuify::{components::style::StyleSheet, get_size, select_from_list, SelectionMode, SelectModeResult, DEVELOPMENT_MODE};
 mod single_select_quiz_game;
 use single_select_quiz_game::main as single_select_quiz_game;
 
@@ -118,53 +116,21 @@ fn main() -> Result<()> {
         );
 
         match &maybe_user_input {
-            Some(input) => {
-                let first_line = input.first();
-
-                match first_line {
-                    Some(user_input) => {
-                        if *user_input == MULTIPLE_SELECT_SINGLE_ITEM.to_string() {
-                            // Multiple select, single item.
-                            multiple_select_single_item(multi_select_instructions)
-                        } else if *user_input == MULTIPLE_SELECT_13_ITEMS_VPH_5.to_string() {
-                            // Multiple select.
-                            multiple_select_13_items_vph_5(
-                                max_height_row_count,
-                                max_width_col_count,
-                                default_style,
-                                multi_select_instructions,
-                            );
-                        } else if *user_input == MULTIPLE_SELECT_2_ITEMS_VPH_5.to_string() {
-                            multiple_select_2_items_vph_5(
-                                max_height_row_count,
-                                max_width_col_count,
-                                sea_foam_style,
-                                multi_select_instructions,
-                            );
-                        } else if *user_input == SINGLE_SELECT_13_ITEMS_VPH_5.to_string() {
-                            // Single select.
-                            single_select_13_items_vph_5(
-                                max_height_row_count,
-                                max_width_col_count,
-                                hot_pink_style,
-                            );
-                        } else if *user_input == SINGLE_SELECT_2_ITEMS_VPH_5.to_string() {
-                            single_select_2_items_vph_5(
-                                max_height_row_count,
-                                max_width_col_count,
-                                default_style,
-                            );
-                        } else if *user_input == SINGLE_SELECT_QUIZ_GAME.to_string() {
-                            let _ = single_select_quiz_game();
-                        } else {
-                            println!("User did not select anything")
-                        }
-                    }
-                    None => println!("User did not select anything"),
+            SelectModeResult::Single(input) => {
+                match input.as_str() {
+                    MULTIPLE_SELECT_SINGLE_ITEM => multiple_select_single_item(multi_select_instructions),
+                    MULTIPLE_SELECT_13_ITEMS_VPH_5 => multiple_select_13_items_vph_5(max_height_row_count, max_width_col_count, default_style, multi_select_instructions),
+                    MULTIPLE_SELECT_2_ITEMS_VPH_5 => multiple_select_2_items_vph_5(max_height_row_count, max_width_col_count, sea_foam_style, multi_select_instructions),
+                    SINGLE_SELECT_13_ITEMS_VPH_5 => single_select_13_items_vph_5(max_height_row_count, max_width_col_count, hot_pink_style),
+                    SINGLE_SELECT_2_ITEMS_VPH_5 => single_select_2_items_vph_5(max_height_row_count, max_width_col_count, default_style),
+                    SINGLE_SELECT_QUIZ_GAME => {
+                        let _ = single_select_quiz_game();
+                    },
+                    _ => println!("User did not select anything"),
                 }
             }
-            None => println!("User did not select anything"),
-        }
+            _ => println!("User did not select anything"),
+        };
 
         call_if_true!(DEVELOPMENT_MODE, {
             log_debug("Stop logging...".to_string());
@@ -189,10 +155,10 @@ fn multiple_select_single_item(multi_select_instructions: AnsiStyledText) {
         StyleSheet::default(),
     );
     match &user_input {
-        Some(it) => {
+        SelectModeResult::Multiple(it) => {
             println!("User selected: {:?}", it);
         }
-        None => println!("User did not select anything"),
+        _ => println!("User did not select anything"),
     }
 }
 
@@ -231,10 +197,10 @@ fn multiple_select_13_items_vph_5(
         style,
     );
     match &user_input {
-        Some(it) => {
+        SelectModeResult::Multiple(it) => {
             println!("User selected: {:?}", it);
         }
-        None => println!("User did not select anything"),
+        _ => println!("User did not select anything"),
     }
     call_if_true!(DEVELOPMENT_MODE, {
         log_debug(format!("user_input: {:?}", user_input).to_string());
@@ -262,10 +228,10 @@ fn multiple_select_2_items_vph_5(
         style,
     );
     match &user_input {
-        Some(it) => {
+        SelectModeResult::Multiple(it) => {
             println!("User selected: {:?}", it);
         }
-        None => println!("User did not select anything"),
+        _ => println!("User did not select anything"),
     }
     call_if_true!(DEVELOPMENT_MODE, {
         log_debug(format!("user_input: {:?}", user_input).to_string());
@@ -306,10 +272,10 @@ fn single_select_13_items_vph_5(
         style,
     );
     match &user_input {
-        Some(it) => {
+        SelectModeResult::Multiple(it) => {
             println!("User selected: {:?}", it);
         }
-        None => println!("User did not select anything"),
+        _ => println!("User did not select anything"),
     }
     call_if_true!(DEVELOPMENT_MODE, {
         log_debug(format!("user_input: {:?}", user_input).to_string());
@@ -336,10 +302,10 @@ fn single_select_2_items_vph_5(
         style,
     );
     match &user_input {
-        Some(it) => {
+        SelectModeResult::Multiple(it) => {
             println!("User selected: {:?}", it);
         }
-        None => println!("User did not select anything"),
+        _ => println!("User did not select anything"),
     }
     call_if_true!(DEVELOPMENT_MODE, {
         log_debug(format!("user_input: {:?}", user_input).to_string());

--- a/tuify/src/bin/giti.rs
+++ b/tuify/src/bin/giti.rs
@@ -72,8 +72,8 @@ fn try_run_program(giti_app_args: GitiAppArg) -> CommonResult<()> {
                     SelectionMode::Single,
                 );
 
-                if let Some(selected) = maybe_selected {
-                    match selected[0].as_str() {
+                if let SelectModeResult::Single(selected) = maybe_selected {
+                    match selected.as_str() {
                         "delete" => {
                             try_delete_branch()?;
                         }

--- a/tuify/src/bin/rt.rs
+++ b/tuify/src/bin/rt.rs
@@ -222,17 +222,14 @@ fn show_tui(
             StyleSheet::default(),
         );
 
-        let it = if let Some(user_selection) = user_selection {
-            if let Some(it) = user_selection.first() {
-                println!("selection-mode: {}", it);
-                SelectionMode::from_str(it, true).unwrap_or(SelectionMode::Single)
-            } else {
+        let it = match user_selection {
+            SelectModeResult::Single(item) => {
+                SelectionMode::from_str(&item, true).unwrap_or(SelectionMode::Single)
+            }
+            _ => {
                 print_help_for("select-from-list").ok();
                 return;
             }
-        } else {
-            print_help_for("select-from-list").ok();
-            return;
         };
 
         it
@@ -275,15 +272,14 @@ fn show_tui(
 
     // Actually get input from the user.
     let selected_items = {
-        let it = select_from_list(
+        select_from_list(
             "Select one line".to_string(),
             lines,
             max_height_row_count,
             max_width_col_count,
             selection_mode,
             StyleSheet::default(),
-        );
-        convert_user_input_into_vec_of_strings(it)
+        )
     };
 
     call_if_true!(enable_logging, {

--- a/tuify/src/components/select_component.rs
+++ b/tuify/src/components/select_component.rs
@@ -130,7 +130,15 @@ impl<W: Write> FunctionComponent<W, State> for SelectComponent<W> {
                     IsUnselected,
                 }
 
-                let is_selected = state.selected_items.contains(data_item);
+                let is_selected = match &state.selected_items {
+                    SelectModeResult::Single(item) => {
+                        item == data_item
+                    }
+                    SelectModeResult::Multiple(items) => {
+                        items.contains(data_item)
+                    }
+                    SelectModeResult::None => false
+                };
                 let is_focused = ch!(caret_row_scroll_adj) == state.get_focused_index();
 
                 let selection_state = match (is_focused, is_selected) {
@@ -295,7 +303,7 @@ mod tests {
             max_display_width: ch!(80),
             raw_caret_row_index: ch!(0),
             scroll_offset_row_index: ch!(0),
-            selected_items: vec![],
+            selected_items: SelectModeResult::Single("".to_string()),
             selection_mode: SelectionMode::Single,
             ..Default::default()
         };

--- a/tuify/src/event_loop.rs
+++ b/tuify/src/event_loop.rs
@@ -25,7 +25,7 @@ pub enum EventLoopResult {
     Continue,
     ContinueAndRerender,
     ContinueAndRerenderAndClear,
-    ExitWithResult(Vec<String>),
+    ExitWithResult(SelectModeResult),
     ExitWithoutResult,
     ExitWithError,
     Select,

--- a/tuify/src/keypress.rs
+++ b/tuify/src/keypress.rs
@@ -29,6 +29,7 @@ pub enum KeyPress {
     Error,
     Space,
     Resize(Size),
+    CtrlC,
 }
 
 pub fn read_key_press() -> KeyPress {
@@ -113,6 +114,13 @@ fn read_key_press_windows() -> KeyPress {
                     kind: KeyEventKind::Press, // This is for Windows.
                     state: KeyEventState::NONE,
                 }) => KeyPress::Esc,
+                // Ctrl + c.
+                Event::Key(KeyEvent{
+                       code: KeyCode::Char('c'),
+                       modifiers: KeyModifiers::CONTROL,
+                       kind: KeyEventKind::Press, // This is for Windows.
+                       state: KeyEventState::NONE
+                }) => KeyPress::CtrlC,
 
                 // Space.
                 Event::Key(KeyEvent {

--- a/tuify/src/lib.rs
+++ b/tuify/src/lib.rs
@@ -70,10 +70,10 @@
 //!     );
 //!
 //!     match &user_input {
-//!         Some(it) => {
+//!         SelectModeResult::Single(it) => {
 //!             println!("User selected: {:?}", it);
 //!         }
-//!         None => println!("User did not select anything"),
+//!         _ => println!("User did not select anything"),
 //!     }
 //!
 //!     Ok(())
@@ -278,10 +278,10 @@
 //!     );
 //!
 //!     match &user_input {
-//!         Some(it) => {
+//!         SelectModeResult::Single(it) => {
 //!             println!("User selected: {:?}", it);
 //!         }
-//!         None => println!("User did not select anything"),
+//!         _ => println!("User did not select anything"),
 //!     }
 //!
 //!     Ok(())
@@ -303,6 +303,7 @@
 //!    // This is how you can define your custom style.
 //!    // For each Style struct, you can define different style overrides.
 //!    // Please take a look at the Style struct to see what you can override.
+//!    use r3bl_tuify::SelectModeResult;
 //!    let my_custom_style = StyleSheet {
 //!       focused_and_selected_style: Style {
 //!             fg_color: Color::Rgb(255, 244, 0),
@@ -340,10 +341,10 @@
 //!    );
 //!
 //!    match &user_input {
-//!       Some(it) => {
+//!       SelectModeResult::Multiple(it) => {
 //!          println!("User selected: {:?}", it);
 //!       }
-//!       None => println!("User did not select anything"),
+//!       _ => println!("User did not select anything"),
 //!    }
 //!    Ok(())
 //! }

--- a/tuify/src/state.rs
+++ b/tuify/src/state.rs
@@ -29,11 +29,31 @@ pub struct State {
     pub raw_caret_row_index: ChUnit,
     pub scroll_offset_row_index: ChUnit,
     pub items: Vec<String>,
-    pub selected_items: Vec<String>,
+    pub selected_items: SelectModeResult,
     pub header: String,
     pub selection_mode: SelectionMode,
     pub resize_hint: Option<ResizeHint>,
     pub window_size: Option<Size>,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Default)]
+pub enum SelectModeResult {
+    #[default]
+    None,
+    Single(String),
+    Multiple(Vec<String>),
+}
+
+impl Iterator for SelectModeResult {
+    type Item = String;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            SelectModeResult::None => None,
+            SelectModeResult::Multiple(vec) => vec.pop(),
+            SelectModeResult::Single(s) => Some(s.to_string())
+        }
+    }
 }
 
 impl CalculateResizeHint for State {


### PR DESCRIPTION
The commit addresses issue #200 in the tuify, focusing on changing the
return type of the `select_from_list()` function. The modification
include updating function parameters and return types, adapting related
code in various files, and ensuring compatibility with the new
`SelectModeResult` enum. Additionally, adjustments are made to handle
single and multiple selection modes, improving code clarity and
maintainability.

Moreover, add Ctrl + C keybinding.