### PR TITLE
[all] Upgrade reedline to its latest version

### DIFF
--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -81,6 +81,6 @@ pretty_assertions = "1.4.0"
 copypasta-ext = "0.4.4"
 
 [dev-dependencies]
-reedline = "0.25.0"
+reedline = "0.27.1"
 textwrap = "0.16.0"
 serial_test = "2.0.0"

--- a/tuify/Cargo.toml
+++ b/tuify/Cargo.toml
@@ -49,7 +49,7 @@ log = { version = "0.4.20", features = ["std"] }
 # Clap.
 # More info: https://stackoverflow.com/a/76131914/2085356
 clap = { version = "4.4.6", features = ["derive", "wrap_help"] }
-reedline = "0.25.0"
+reedline = "0.27.1"
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -64,7 +64,7 @@ pretty_assertions = "1.4.0"
 # For examples.
 # http://xion.io/post/code/rust-examples.html
 [dev-dependencies]
-reedline = "0.25.0"
+reedline = "0.27.1"
 textwrap = "0.16.0"
 # The following is needed for integration tests in the `tests` folder.
 pretty_assertions = "1.4.0"


### PR DESCRIPTION
The current version in dev-dependencies is older and thus Cargo .toml shows a cross mark. This commit upgrades it to 0.27.1 latest version.