### PR TITLE
[tuify] Add tests to select_from_list()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,10 @@
     command runs.
   - `Ctrl + c` now behaves just like the `Escape` key. In the past, pressing `Ctrl + c`
     would do nothing the user could not exit the app by pressing this shortcut.
+  - More code quality and ability to test the main event loop, by creating a new
+    `TestVecKeyPressReader` struct, and abstracting the `read()` (from `stdin`) into a
+    `KeyPressReader` trait. This is similar to what is done for `TestStringWriter` (to
+    `stdout`).
 
 ### v0.1.21 (2023-10-21)
 <a id="markdown-v0.1.21-2023-10-21" name="v0.1.21-2023-10-21"></a>

--- a/tuify/src/components/select_component.rs
+++ b/tuify/src/components/select_component.rs
@@ -228,46 +228,11 @@ fn clip_string_to_width_with_ellipsis(line: String, viewport_width: ChUnit) -> S
 
 #[cfg(test)]
 mod tests {
-    use std::io::{Result, Write};
-
     use pretty_assertions::assert_eq;
     use r3bl_ansi_color::global_color_support::{clear_override, set_override};
     use serial_test::serial;
 
     use super::*;
-
-    struct StringWriter {
-        buffer: String,
-    }
-
-    impl StringWriter {
-        fn new() -> Self {
-            StringWriter {
-                buffer: String::new(),
-            }
-        }
-
-        fn get_buffer(&self) -> &str {
-            &self.buffer
-        }
-    }
-
-    impl Write for StringWriter {
-        fn write(&mut self, buf: &[u8]) -> Result<usize> {
-            let result = std::str::from_utf8(buf);
-            match result {
-                Ok(value) => {
-                    self.buffer.push_str(value);
-                    Ok(buf.len())
-                }
-                Err(_) => Ok(0),
-            }
-        }
-
-        fn flush(&mut self) -> Result<()> {
-            Ok(())
-        }
-    }
 
     #[test]
     fn test_clip_string_to_width_with_ellipsis() {
@@ -302,7 +267,7 @@ mod tests {
 
         state.scroll_offset_row_index = ch!(0);
 
-        let mut writer = StringWriter::new();
+        let mut writer = TestStringWriter::new();
 
         let mut component = SelectComponent {
             write: &mut writer,

--- a/tuify/src/event_loop.rs
+++ b/tuify/src/event_loop.rs
@@ -35,6 +35,7 @@ pub fn enter_event_loop<W: Write, S: CalculateResizeHint>(
     state: &mut S,
     function_component: &mut impl FunctionComponent<W, S>,
     on_keypress: impl Fn(&mut S, KeyPress) -> EventLoopResult,
+    reader: &mut impl KeyPressReader,
 ) -> Result<EventLoopResult> {
     execute!(function_component.get_write(), Hide)?;
     enable_raw_mode()?;
@@ -46,9 +47,9 @@ pub fn enter_event_loop<W: Write, S: CalculateResizeHint>(
     function_component.render(state)?;
 
     loop {
-        let key_event = read_key_press();
-        let it = on_keypress(state, key_event);
-        match it {
+        let key_press = reader.read_key_press();
+        let result = on_keypress(state, key_press);
+        match result {
             EventLoopResult::ContinueAndRerenderAndClear => {
                 // Clear the viewport.
                 function_component.clear_viewport_for_resize(state)?;

--- a/tuify/src/keypress.rs
+++ b/tuify/src/keypress.rs
@@ -18,6 +18,10 @@
 use crossterm::event::{read, Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
 use r3bl_rs_utils_core::*;
 
+pub trait KeyPressReader {
+    fn read_key_press(&mut self) -> KeyPress;
+}
+
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum KeyPress {
     Up,
@@ -32,7 +36,14 @@ pub enum KeyPress {
     CtrlC,
 }
 
-pub fn read_key_press() -> KeyPress {
+pub struct CrosstermKeyPressReader {}
+impl KeyPressReader for CrosstermKeyPressReader {
+    fn read_key_press(&mut self) -> KeyPress {
+        read_key_press()
+    }
+}
+
+fn read_key_press() -> KeyPress {
     if cfg!(windows) {
         // Windows.
         read_key_press_windows()

--- a/tuify/src/lib.rs
+++ b/tuify/src/lib.rs
@@ -440,6 +440,7 @@ pub mod react;
 pub mod scroll;
 pub mod state;
 pub mod term;
+pub mod test_utils;
 
 pub use components::*;
 pub use constants::*;
@@ -451,6 +452,7 @@ pub use react::*;
 pub use scroll::*;
 pub use state::*;
 pub use term::*;
+pub use test_utils::*;
 
 /// Enable file logging. You can use `tail -f log.txt` to watch the logs.
 pub const DEVELOPMENT_MODE: bool = true;

--- a/tuify/src/test_utils.rs
+++ b/tuify/src/test_utils.rs
@@ -1,0 +1,81 @@
+/*
+ *   Copyright (c) 2023 R3BL LLC
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+use std::io::{Result, Write};
+
+use crate::{KeyPress, KeyPressReader};
+
+pub struct TestStringWriter {
+    buffer: String,
+}
+
+impl TestStringWriter {
+    pub fn new() -> Self {
+        TestStringWriter {
+            buffer: String::new(),
+        }
+    }
+
+    pub fn get_buffer(&self) -> &str {
+        &self.buffer
+    }
+}
+
+impl Write for TestStringWriter {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        let result = std::str::from_utf8(buf);
+        match result {
+            Ok(value) => {
+                self.buffer.push_str(value);
+                Ok(buf.len())
+            }
+            Err(_) => Ok(0),
+        }
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub struct TestVecKeyPressReader {
+    pub key_press_vec: Vec<KeyPress>,
+    pub index: Option<usize>,
+}
+
+impl KeyPressReader for TestVecKeyPressReader {
+    fn read_key_press(&mut self) -> KeyPress {
+        // Increment index every time this function is called until the end of the vector
+        // and then wrap around.
+        match self.index {
+            Some(index) => {
+                if index < self.key_press_vec.len() - 1 {
+                    self.index = Some(index + 1);
+                } else {
+                    self.index = Some(0);
+                }
+            }
+            None => {
+                self.index = Some(0);
+            }
+        }
+
+        let index = self.index.unwrap();
+
+        self.key_press_vec[index]
+    }
+}


### PR DESCRIPTION
Add ability to test read from stdin. Provide wrapper for crossterm read() and also test mock that simulates KeyPresses.

Support for write and stdout mocking is already present.