### PR TITLE
[tui] Add editor component text selection features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,14 +169,17 @@ Added:
     `nu run build`, or `./run build`.
   - Rename `run.nu` to `run` in the top level folder as well.
 
-- Added:
-  - Add tests to editor component for clipboard service.
-
 - Fixed:
   - Editor component now cleans up state correctly after new content loads. This includes
     the undo/redo stack, and the render ops cache (for the content).
-  - Fix tui/examples/demo/ex_pitch example to correctly move back and forward between
+  - Fix `tui/examples/demo/ex_pitch` example to correctly move back and forward between
     slides.
+
+- Added:
+  - <kbd>Escape</kbd> key now clears the selection.
+  - <kbd>Ctrl+A</kbd> now selects all text.
+  - Tests for `EditorComponent` for undo / redo history, text selection, and clipboard service.
+  - Add tests to editor component for clipboard service.
 
 ### v0.4.0 (2023-12-22)
 <a id="markdown-v0.4.0-2023-12-22" name="v0.4.0-2023-12-22"></a>

--- a/tui/src/tui/dialog/dialog_engine/dialog_engine_api.rs
+++ b/tui/src/tui/dialog/dialog_engine/dialog_engine_api.rs
@@ -195,6 +195,7 @@ impl DialogEngineApi {
             input_event,
             &mut SystemClipboard,
         )?;
+
         match result {
             // If the editor engine applied the event, return the new editor buffer.
             EditorEngineApplyEventResult::Applied => {

--- a/tui/src/tui/editor/editor_engine/editor_engine_api.rs
+++ b/tui/src/tui/editor/editor_engine/editor_engine_api.rs
@@ -33,7 +33,7 @@ impl EditorEngineApi {
         editor_buffer: &mut EditorBuffer,
         editor_engine: &mut EditorEngine,
         input_event: InputEvent,
-        clipboard: &mut impl ClipboardService,
+        clipboard_service_provider: &mut impl ClipboardService,
     ) -> CommonResult<EditorEngineApplyEventResult> {
         let editor_config = &editor_engine.config_options;
 
@@ -77,7 +77,7 @@ impl EditorEngineApi {
                 editor_engine,
                 editor_buffer,
                 editor_event.clone(),
-                clipboard,
+                clipboard_service_provider,
             );
 
             match editor_event {

--- a/tui/src/tui/editor/editor_engine/editor_engine_internal_api.rs
+++ b/tui/src/tui/editor/editor_engine/editor_engine_internal_api.rs
@@ -91,6 +91,14 @@ impl EditorEngineInternalApi {
         caret_mut::to_end_of_line(buffer, engine, select_mode)
     }
 
+    pub fn select_all(buffer: &mut EditorBuffer, select_mode: SelectMode) -> Option<()> {
+        caret_mut::select_all(buffer, select_mode)
+    }
+
+    pub fn clear_selection(buffer: &mut EditorBuffer) -> Option<()> {
+        caret_mut::clear_selection(buffer)
+    }
+
     pub fn validate_scroll(args: EditorArgsMut) {
         scroll_editor_buffer::validate_scroll(args);
     }
@@ -627,6 +635,32 @@ mod caret_mut {
                 );
             }
         }
+
+        None
+    }
+
+    pub fn clear_selection(editor_buffer: &mut EditorBuffer) -> Option<()> {
+        editor_buffer.clear_selection();
+
+        None
+    }
+
+    pub fn select_all(
+        editor_buffer: &mut EditorBuffer,
+        select_mode: SelectMode,
+    ) -> Option<()> {
+        empty_check_early_return!(editor_buffer, @None);
+
+        let number_of_lines = editor_buffer.get_lines().len();
+        let max_row_index = ch!(number_of_lines, @dec);
+        let last_line_width = editor_buffer.get_line_display_width(max_row_index);
+
+        editor_buffer.clear_selection();
+        select_mode.update_selection_based_on_caret_movement_in_multiple_lines(
+            editor_buffer,
+            Some(position!(col_index: 0, row_index: 0)),
+            Some(position!(col_index: last_line_width, row_index: max_row_index)),
+        );
 
         None
     }

--- a/tui/src/tui/editor/test_editor.rs
+++ b/tui/src/tui/editor/test_editor.rs
@@ -1751,7 +1751,7 @@ mod selection_tests {
             EditorEvent::apply_editor_events::<(), ()>(
                 &mut engine,
                 &mut buffer,
-                vec![EditorEvent::Select(SelectionScope::End)],
+                vec![EditorEvent::Select(SelectionAction::End)],
                 &mut TestClipboard::default(),
             );
             // Current Caret Position : [row : 0, col : 12]
@@ -1777,7 +1777,7 @@ mod selection_tests {
             EditorEvent::apply_editor_events::<(), ()>(
                 &mut engine,
                 &mut buffer,
-                vec![EditorEvent::Select(SelectionScope::Home)], // Select text up to starting
+                vec![EditorEvent::Select(SelectionAction::Home)], // Select text up to starting
                 &mut TestClipboard::default(),
             );
             // Current Caret Position : [row : 1, col : 0]
@@ -1795,7 +1795,7 @@ mod selection_tests {
             EditorEvent::apply_editor_events::<(), ()>(
                 &mut engine,
                 &mut buffer,
-                vec![EditorEvent::Select(SelectionScope::OneCharRight)], // Move Selection to Right
+                vec![EditorEvent::Select(SelectionAction::OneCharRight)], // Move Selection to Right
                 &mut TestClipboard::default(),
             );
             // Current Caret Position : [row : 1, col : 1]
@@ -1813,7 +1813,7 @@ mod selection_tests {
             EditorEvent::apply_editor_events::<(), ()>(
                 &mut engine,
                 &mut buffer,
-                vec![EditorEvent::Select(SelectionScope::OneCharLeft)], // Move Selection to Left
+                vec![EditorEvent::Select(SelectionAction::OneCharLeft)], // Move Selection to Left
                 &mut TestClipboard::default(),
             );
             // Current Caret Position : [row : 1, col : 0]
@@ -1831,7 +1831,7 @@ mod selection_tests {
             EditorEvent::apply_editor_events::<(), ()>(
                 &mut engine,
                 &mut buffer,
-                vec![EditorEvent::Select(SelectionScope::OneLineUp)], // Select one line up
+                vec![EditorEvent::Select(SelectionAction::OneLineUp)], // Select one line up
                 &mut TestClipboard::default(),
             );
             // Current Caret Position : [row : 0, col : 0]
@@ -1850,7 +1850,7 @@ mod selection_tests {
             EditorEvent::apply_editor_events::<(), ()>(
                 &mut engine,
                 &mut buffer,
-                vec![EditorEvent::Select(SelectionScope::OneLineDown)], // De-Select one line down
+                vec![EditorEvent::Select(SelectionAction::OneLineDown)], // De-Select one line down
                 &mut TestClipboard::default(),
             );
             // Current Caret Position : [row : 1, col : 0]
@@ -1883,7 +1883,7 @@ mod selection_tests {
             EditorEvent::apply_editor_events::<(), ()>(
                 &mut engine,
                 &mut buffer,
-                vec![EditorEvent::Select(SelectionScope::PageUp)], // Select by pressing PageUp
+                vec![EditorEvent::Select(SelectionAction::PageUp)], // Select by pressing PageUp
                 &mut TestClipboard::default(),
             );
             // Current Caret Position : [row : 0, col : 1]
@@ -1898,7 +1898,6 @@ mod selection_tests {
         {
             // Current Caret Position : [row : 0, col : 1]
             // Select by pressing PageDown
-
             EditorEvent::apply_editor_events::<(), ()>(
                 &mut engine,
                 &mut buffer,
@@ -1908,7 +1907,7 @@ mod selection_tests {
             EditorEvent::apply_editor_events::<(), ()>(
                 &mut engine,
                 &mut buffer,
-                vec![EditorEvent::Select(SelectionScope::PageDown)], // Select by pressing PageDown
+                vec![EditorEvent::Select(SelectionAction::PageDown)], // Select by pressing PageDown
                 &mut TestClipboard::default(),
             );
             // Current Caret Position : [row : 1, col : 2]
@@ -1917,6 +1916,40 @@ mod selection_tests {
             let mut selection_map = HashMap::new();
             selection_map.insert(ch!(0), SelectionRange::new(ch!(2), ch!(12)));
             selection_map.insert(ch!(1), SelectionRange::new(ch!(0), ch!(2)));
+            assert_eq2!(buffer.get_selection_map().map, selection_map);
+        }
+
+        {
+            // Current Caret Position : [row : 1, col : 2]
+            // Select by pressing All
+            EditorEvent::apply_editor_events::<(), ()>(
+                &mut engine,
+                &mut buffer,
+                vec![EditorEvent::Select(SelectionAction::All)], // Select by pressing All
+                &mut TestClipboard::default(),
+            );
+            // Current Caret Position : [row : 1, col : 2]
+
+            // Selection Map : {{0, SelectionRange {start: 0, end: 12}},{1, SelectionRange {start: 0, end: 2}}}
+            let mut selection_map = HashMap::new();
+            selection_map.insert(ch!(0), SelectionRange::new(ch!(0), ch!(12)));
+            selection_map.insert(ch!(1), SelectionRange::new(ch!(0), ch!(12)));
+            assert_eq2!(buffer.get_selection_map().map, selection_map);
+        }
+
+        {
+            // Current Caret Position : [row : 1, col : 2]
+            // Select by pressing Esc
+            EditorEvent::apply_editor_events::<(), ()>(
+                &mut engine,
+                &mut buffer,
+                vec![EditorEvent::Select(SelectionAction::Esc)], // Select by pressing Esc
+                &mut TestClipboard::default(),
+            );
+            // Current Caret Position : [row : 1, col : 2]
+
+            // Selection Map : {}
+            let selection_map = HashMap::new();
             assert_eq2!(buffer.get_selection_map().map, selection_map);
         }
     }
@@ -1947,7 +1980,7 @@ mod clipboard_tests {
             EditorEvent::apply_editor_events::<(), ()>(
                 &mut engine,
                 &mut buffer,
-                vec![EditorEvent::Select(SelectionScope::End)],
+                vec![EditorEvent::Select(SelectionAction::End)],
                 &mut test_clipboard,
             );
             // Current Caret Position : [row : 0, col : 12]
@@ -1969,7 +2002,7 @@ mod clipboard_tests {
             EditorEvent::apply_editor_events::<(), ()>(
                 &mut engine,
                 &mut buffer,
-                vec![EditorEvent::Select(SelectionScope::PageDown)],
+                vec![EditorEvent::Select(SelectionAction::PageDown)],
                 &mut test_clipboard,
             );
             // Current Caret Position : [row : 1, col : 12]
@@ -2069,7 +2102,7 @@ mod clipboard_tests {
             EditorEvent::apply_editor_events::<(), ()>(
                 &mut engine,
                 &mut buffer,
-                vec![EditorEvent::Select(SelectionScope::End)],
+                vec![EditorEvent::Select(SelectionAction::End)],
                 &mut test_clipboard,
             );
             // Current Caret Position : [row : 0, col : 12]
@@ -2114,7 +2147,7 @@ mod clipboard_tests {
             EditorEvent::apply_editor_events::<(), ()>(
                 &mut engine,
                 &mut buffer,
-                vec![EditorEvent::Select(SelectionScope::PageUp)], // Select by pressing PageUp
+                vec![EditorEvent::Select(SelectionAction::PageUp)], // Select by pressing PageUp
                 &mut test_clipboard,
             );
             // Current Caret Position : [row : 0, col : 4]


### PR DESCRIPTION
- <kbd>Escape</kbd> key now clears the selection.
- <kbd>Ctrl+A</kbd> now selects all text.
- Tests for the items above.