### PR TITLE
[giti] Update giti to use multi line header component

### DIFF
--- a/cmdr/src/giti/branch/giti_ui_templates.rs
+++ b/cmdr/src/giti/branch/giti_ui_templates.rs
@@ -17,59 +17,77 @@
 
 use std::{env::var, process::Command};
 
-use r3bl_ansi_color::{AnsiStyledText, Style};
+use r3bl_ansi_color::{AnsiStyledText, Color, Style};
 use r3bl_rs_utils_core::{log_error,
                          CommonError,
                          CommonErrorType,
                          CommonResult,
                          UnicodeString};
 use r3bl_tui::{ColorWheel, GradientGenerationPolicy, TextColorizationPolicy};
-use r3bl_tuify::{select_from_list, SelectionMode, StyleSheet, LIGHT_GRAY_COLOR};
+use r3bl_tuify::LIGHT_GRAY_COLOR;
 
-pub fn multi_select_instruction_header() {
-    AnsiStyledText {
-        text: &format!(
-            "{}{}{}{}",
-            "┆ Up or Down:      navigate\n",
-            "┆ Space:           select or unselect branches\n",
-            "┆ Return:          confirm selection\n",
-            "┆ Esc:             exit program\n",
-        ),
-        style: &[Style::Foreground(LIGHT_GRAY_COLOR)],
-    }
-    .println();
+
+pub fn multi_select_instruction_header() -> Vec<Vec<AnsiStyledText<'static>>> {
+    let up_and_down = AnsiStyledText {
+        text: " Up or down:     navigate",
+        style: &[
+            Style::Foreground(LIGHT_GRAY_COLOR),
+            Style::Background(Color::Rgb(14, 17, 23)),
+        ],
+    };
+
+    let space = AnsiStyledText {
+        text: " Space:          select or deselect item",
+        style: &[
+            Style::Foreground(LIGHT_GRAY_COLOR),
+            Style::Background(Color::Rgb(14, 17, 23)),
+        ],
+    };
+
+    let esc = AnsiStyledText {
+        text: " Esc or Ctrl+C:  exit program",
+        style: &[
+            Style::Foreground(LIGHT_GRAY_COLOR),
+            Style::Background(Color::Rgb(14, 17, 23)),
+        ],
+    };
+
+    let return_key = AnsiStyledText {
+        text: " Return:         confirm selection",
+        style: &[
+            Style::Foreground(LIGHT_GRAY_COLOR),
+            Style::Background(Color::Rgb(14, 17, 23)),
+        ],
+    };
+
+    vec![vec![up_and_down], vec![space], vec![esc], vec![return_key]]
 }
 
-pub fn single_select_instruction_header() {
-    AnsiStyledText {
-        text: &format!(
-            "{}{}{}",
-            "┆ Up or Down:      navigate\n",
-            "┆ Return:          confirm selection\n",
-            "┆ Esc:             exit program\n",
-        ),
-        style: &[Style::Foreground(LIGHT_GRAY_COLOR)],
-    }
-    .println();
-}
+pub fn single_select_instruction_header() -> Vec<Vec<AnsiStyledText<'static>>> {
+    let up_or_down = AnsiStyledText {
+        text: " Up or down:     navigate",
+        style: &[
+            Style::Foreground(LIGHT_GRAY_COLOR),
+            Style::Background(Color::Rgb(14, 17, 23)),
+        ],
+    };
+    let esc = AnsiStyledText {
+        text: " Esc or Ctrl+C:  exit program",
+        style: &[
+            Style::Foreground(LIGHT_GRAY_COLOR),
+            Style::Background(Color::Rgb(14, 17, 23)),
+        ],
+    };
 
-pub fn ask_user_to_select_from_list(
-    options: Vec<String>,
-    header: String,
-    selection_mode: SelectionMode,
-) -> Option<Vec<String>> {
-    let max_height_row_count = 20;
-    let max_width_col_count = 0;
-    let style = StyleSheet::default();
-    let user_input = select_from_list(
-        header,
-        options,
-        max_height_row_count,
-        max_width_col_count,
-        selection_mode,
-        style,
-    );
-    user_input
+    let return_key = AnsiStyledText {
+        text: " Return:         confirm selection",
+        style: &[
+            Style::Foreground(LIGHT_GRAY_COLOR),
+            Style::Background(Color::Rgb(14, 17, 23)),
+        ],
+    };
+
+    vec![vec![up_or_down], vec![esc], vec![return_key]]
 }
 
 pub fn show_exit_message() {
@@ -78,7 +96,7 @@ pub fn show_exit_message() {
             Ok(username) => {
                 format!("Goodbye, {} 👋 🦜. Thanks for using giti!", username)
             }
-            Err(_) => "Thanks for using giti! 👋 🦜".to_owned(),
+            Err(_) => "  Thanks for using giti! 👋 🦜".to_owned(),
         };
 
         let please_star_us = format!(

--- a/cmdr/src/giti/mod.rs
+++ b/cmdr/src/giti/mod.rs
@@ -15,5 +15,8 @@
  *   limitations under the License.
  */
 
+// Attach.
 pub mod branch;
+
+// Re-export.
 pub use branch::*;

--- a/tuify/README.md
+++ b/tuify/README.md
@@ -22,7 +22,7 @@
   - [Create your style](#create-your-style)
 - [Build, run, test tasks](#build-run-test-tasks)
   - [Prerequisites](#prerequisites)
-  - [Nu shell scripts to build, run, test etc.](#nu-shell-scripts-to-build-run-test-etc)
+  - [Nu shell scripts to build, run, test, etc.](#nu-shell-scripts-to-build-run-test-etc)
 - [References](#references)
 
 <!-- /TOC -->
@@ -59,13 +59,13 @@ r3bl_rs_utils_core = "0.9.9" # Get the latest version at the time you get this.
 
 The following example illustrates how you can use this as a library. The function that does the work
 of rendering the UI is called [`select_from_list`](crate::select_from_list). It takes a list of
-items, and returns the selected item or items (depending on the selection mode). If the user does
-not select anything, it returns `None`. The function also takes the maximum height and width of the
+items and returns the selected item or items (depending on the selection mode). If the user does not
+select anything, it returns `None`. The function also takes the maximum height and width of the
 display, and the selection mode (single select or multiple select).
 
-It works on macOS, Linux, and Windows. And is aware of terminal color output limitations of each.
-For eg, it uses Windows API on Windows for keyboard input. And on macOS Terminal.app it restricts
-color output to a 256 color palette.
+It works on macOS, Linux, and Windows. And is aware of the terminal color output limitations of
+each. For eg, it uses Windows API on Windows for keyboard input. And on macOS Terminal.app it
+restricts color output to a 256 color palette.
 
 ## APIs
 
@@ -139,7 +139,7 @@ fn main() -> Result<()> {
 
 <a id="markdown-select_from_list_with_multi_line_header" name="select_from_list_with_multi_line_header"></a>
 
-Use `select_from_list_with_multi_line_header` API if you want to display a list of items with a
+Use the `select_from_list_with_multi_line_header` API if you want to display a list of items with a
 multi line header. The first 5 lines are all part of the multi line header.
 
 ![image](https://github.com/r3bl-org/r3bl-open-core/assets/22040032/2f82a42c-f720-4bcb-925d-0d5ad0b0a3c9)
@@ -241,7 +241,7 @@ fn multi_select_instructions() -> Vec<Vec<AnsiStyledText<'static>>> {
 }
 
 fn main() -> Result<()> {
-   let header = AnsiStyledText {
+    let header = AnsiStyledText {
         text: " Please select one or more items. This is a really long heading that just keeps going and if your terminal viewport is small enough, this heading will be clipped",
         style: &[
             RStyle::Foreground(Color::Rgb(171, 204, 242)),
@@ -249,13 +249,11 @@ fn main() -> Result<()> {
         ],
     };
 
-   let line_5 = vec![header];
-
-    let mut instructions: Vec<Vec<AnsiStyledText>> = multi_select_instructions();
-    instructions.push(line_5);
+    let mut instructions_and_header: Vec<Vec<AnsiStyledText>> = multi_select_instructions();
+    instructions_and_header.push(vec![header]);
 
     let user_input = select_from_list_with_multi_line_header(
-        vec![instructions, vec![header]],
+        instructions_and_header,
         [
             "item 1 of 13",
             "item 2 of 13",
@@ -298,9 +296,9 @@ Here's a demo of the binary target of this crate in action.
 https://github-production-user-asset-6210df.s3.amazonaws.com/2966499/267427392-2b42db72-cd62-4ea2-80ae-ccc01008190c.mp4
 
 You can install the binary using `cargo install r3bl_tuify` (from crates.io). Or
-`cargo install --path .` from source. Once installed, you can `rt` is a command line tool that
-allows you to select one of the options from the list that is passed into it via `stdin`. It
-supports both `stdin` and `stdout` piping.
+`cargo install --path .` from source. `rt` is a command line tool that allows you to select one of
+the options from the list that is passed into it via `stdin`. It supports both `stdin` and `stdout`
+piping.
 
 Here are the command line arguments that it accepts:
 
@@ -315,7 +313,7 @@ Here are the command line arguments that it accepts:
 <a id="markdown-interactive-user-experience" name="interactive-user-experience"></a>
 
 Typically a CLI app is not interactive. You can pass commands, subcommands, options, and arguments
-to it, but if you get something wrong, then you get an error, and have to start all over again. This
+to it, but if you get something wrong, then you get an error and have to start all over again. This
 "conversation" style interface might require a lot of trial and error to get the desired result.
 
 The following is an example of using the binary with many subcommands, options, and arguments.
@@ -350,12 +348,11 @@ What does this do?
    the selected item to `stdout`.
 
 Now that is a lot to remember. It is helpful to use `clap` to provide nice command line help but
-that is still quite a few things that you have to get right in order for this command to work.
+that are still quite a few things that you have to get right for this command to work.
 
-It doesn't have to be this way. It is entirely possible for the binary to be interactive along with
-the use of `clap` to specify some of the subcommands, and arguments. It doesn't have to be an all or
-nothing approach. We can have the best of both worlds. The following videos illustrate what happens
-when:
+It doesn't have to be this way. The binary can be interactive along with the use of `clap` to
+specify some of the subcommands, and arguments. It doesn't have to be an all or nothing approach. We
+can have the best of both worlds. The following videos illustrate what happens when:
 
 1. `--selection-mode` and `--command-to-run-with-each-selection` are _not_ passed in the command
    line.
@@ -367,10 +364,10 @@ when:
    Here are the 3 scenarios that can happen:
 
    - The user first chooses `single` selection mode (using a list selection component), and then
-     types in `echo %` in the terminal, as the command to run with each selection. This is the
-     really interactive scenario, since the user has to provide 2 pieces of information: the
-     selection mode, and the command to run with each selection. They didn't provide this up front
-     when they ran the command.
+     types in `echo %` in the terminal, as the command to run with each selection. This is an
+     interactive scenario since the user has to provide 2 pieces of information: the selection mode,
+     and the command to run with each selection. They didn't provide this upfront when they ran the
+     command.
      <!-- tuify-interactive-happy-path -->
 
      https://github.com/r3bl-org/r3bl-open-core/assets/2966499/51de8867-513b-429f-aff2-63dd25d71c82
@@ -428,12 +425,11 @@ Here is a list.
   1. `ls -la | rt -s multiple | xargs -0` - does not expect `stdout` to be piped out, and prints
      help.
 
-> Due to the way in which unix pipes are implemented, it is not possible to pipe the `stdout` of
-> this command to anything else. Unix pipes are non blocking. So there is no way to stop the pipe
-> "mid way". This is why `rt` displays an error when the `stdout` is piped out. It is not possible
-> to pipe the `stdout` of `rt` to another command. Instead, the `rt` binary simply takes a command
-> that it will run after the user has made their selection. Using the selected item(s) and applying
-> them to this command.
+> Due to how unix pipes are implemented, it is not possible to pipe the `stdout` of this command to
+> anything else. Unix pipes are nonblocking. So there is no way to stop the pipe "midway". This is
+> why `rt` displays an error when the `stdout` is piped out. It is not possible to pipe the `stdout`
+> of `rt` to another command. Instead, the `rt` binary simply takes a command that will run after
+> the user has made their selection. Using the selected item(s) and applying them to this command.
 
 ## Style the components
 
@@ -578,8 +574,8 @@ fn main() -> Result<()> {
 
 <a id="markdown-prerequisites" name="prerequisites"></a>
 
-🌠 In order for these to work you have to install the Rust toolchain, `nu`, `cargo-watch`, `bat`,
-and `flamegraph` on your system. Here are the instructions:
+🌠 For these to work you have to install the Rust toolchain, `nu`, `cargo-watch`, `bat`, and
+`flamegraph` on your system. Here are the instructions:
 
 1. Install the Rust toolchain using `rustup` by following the instructions
    [here](https://rustup.rs/).
@@ -589,12 +585,9 @@ and `flamegraph` on your system. Here are the instructions:
 1. Install [`nu`](https://crates.io/crates/nu) shell on your system using `cargo install nu`. It is
    available for Linux, macOS, and Windows.
 
-### Nu shell scripts to build, run, test etc.
+### Nu shell scripts to build, run, test, etc.
 
-<a id="markdown-nu-shell-scripts-to-build%2C-run%2C-test-etc." name="nu-shell-scripts-to-build%2C-run%2C-test-etc."></a>
-
-<a id="markdown-nu-shell-scripts-to-build%2C-run%2C-test-etc."
-name="nu-shell-scripts-to-build%2C-run%2C-test-etc."></a>
+<a id="markdown-nu-shell-scripts-to-build%2C-run%2C-test%2C-etc." name="nu-shell-scripts-to-build%2C-run%2C-test%2C-etc."></a>
 
 Go to the `tuify` folder and run the commands below. These commands are defined in the `./run`
 folder.
@@ -628,12 +621,12 @@ There's also a `run` script at the **top level folder** of the repo. It is inten
 CI/CD environment w/ all the required arguments supplied or in interactive mode, where the user will
 be prompted for input.
 
-| Command                      | Description                                                                                                                                                                                                                                            |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `nu run all`                 | Run all the tests, linting, formatting, etc. in one go. Used in CI/CD                                                                                                                                                                                  |
-| `nu run build-full`          | This will build all the crates in the Rust workspace. And it will install all the required pre-requisite tools needed to work with this crate (what `install-cargo-tools` does) and clear the cargo cache, cleaning, and then do a really clean build. |
-| `nu run install-cargo-tools` | This will install all the required pre-requisite tools needed to work with this crate (things like `cargo-deny`, `flamegraph` will all be installed in one go)                                                                                         |
-| `nu run check-licenses`      | Use `cargo-deny` to audit all licenses used in the Rust workspace                                                                                                                                                                                      |
+| Command                      | Description                                                                                                                                                                                                                                        |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `nu run all`                 | Run all the tests, linting, formatting, etc. in one go. Used in CI/CD                                                                                                                                                                              |
+| `nu run build-full`          | This will build all the crates in the Rust workspace. It will install all the required pre-requisite tools needed to work with this crate (what `install-cargo-tools` does) and clear the cargo cache, cleaning, and then do a really clean build. |
+| `nu run install-cargo-tools` | This will install all the required pre-requisite tools needed to work with this crate (things like `cargo-deny`, and `flamegraph` will all be installed in one go)                                                                                 |
+| `nu run check-licenses`      | Use `cargo-deny` to audit all licenses used in the Rust workspace                                                                                                                                                                                  |
 
 ## References
 

--- a/tuify/src/lib.rs
+++ b/tuify/src/lib.rs
@@ -17,7 +17,9 @@
 
 //! # r3bl-tuify
 //!
-//! This crate can be used in two ways:
+//! r3bl_tuify is a Rust crate that allows you to add simple interactivity to your CLI app.
+//!
+//! r3bl_tuify crate can be used in two ways:
 //! 1. As a library. This is useful if you want to add simple interactivity to your CLI
 //!    app written in Rust. You can see an example of this in the `examples` folder in the
 //!    `main_interactive.rs` file. You can run it using `cargo run --example
@@ -30,18 +32,26 @@
 //! Here's a demo of the library target of this crate in action.
 //!
 //! <video width="100%" controls>
-//!   <source src="https://github-production-user-asset-6210df.s3.amazonaws.com/2966499/266504562-c6717052-780f-4ae0-8ecf-e57beca49929.mp4" type="video/mp4"/>
+//!   <source src="https://github.com/r3bl-org/r3bl-open-core/assets/22040032/46850043-4973-49fa-9824-58f32f21e96e" type="video/mp4"/>
 //! </video>
+//!
+//! To install the crate as a library, add the following to your `Cargo.toml` file:
+//!
+//! ```toml
+//! [dependencies]
+//! r3bl_tuify = "0.1.21" # Get the latest version at the time you get this.
+//! r3bl_rs_utils_core = "0.9.9" # Get the latest version at the time you get this.
+//! ```
 //!
 //! The following example illustrates how you can use this as a library. The function that
 //! does the work of rendering the UI is called
-//! [`select_from_list`]. It takes a list of items, and returns
+//! [`select_from_list`]. It takes a list of items and returns
 //! the selected item or items (depending on the selection mode). If the user does not
 //! select anything, it returns `None`. The function also takes the maximum height and
 //! width of the display, and the selection mode (single select or multiple select).
 //!
 //! It works on macOS, Linux, and Windows. And is aware
-//! of terminal color output limitations of each. For eg, it uses Windows API on Windows for
+//! of the terminal color output limitations of each. For eg, it uses Windows API on Windows for
 //! keyboard input. And on macOS Terminal.app it restricts color output to a 256 color palette.
 //!
 //! ```rust
@@ -79,6 +89,195 @@
 //!     Ok(())
 //! }
 //! ```
+//! ## APIs
+//!
+//! We provide 2 APIs:
+//!
+//! - [`select_from_list`]: Use this API if you want to display a list of items with a single line header.
+//! - [`select_from_list_with_multi_line_header`]: Use this API if you want to display a list of items
+//!   with a multi line header.
+//!
+//! ### select_from_list
+//!
+//! Use this API if you want to display a list of items with a single line header.
+//!
+//! ![image](https://github.com/r3bl-org/r3bl-open-core/assets/22040032/0ae722bb-8cd1-47b1-a293-1a96e84d24d0)
+//!
+//! #### `select_from_list` signature:
+//!
+//! [select_from_list]
+//!
+//! ```rust
+//! use r3bl_rs_utils_core::*;
+//! use r3bl_tuify::*;
+//! use std::io::Result;
+//!
+//! fn main() -> Result<()> {
+//!     // Get display size.
+//!     let max_height_row_count: usize = 5;
+//!     let user_input = select_from_list(
+//!         "Select an item".to_string(),
+//!         [
+//!             "item 1", "item 2", "item 3", "item 4", "item 5", "item 6", "item 7", "item 8",
+//!             "item 9", "item 10",
+//!         ]
+//!         .iter()
+//!         .map(|it| it.to_string())
+//!         .collect(),
+//!         max_height_row_count,
+//!         0,
+//!         SelectionMode::Single,
+//!         StyleSheet::default(),
+//!     );
+//!
+//!     match &user_input {
+//!         Some(it) => {
+//!             println!("User selected: {:?}", it);
+//!         }
+//!         None => println!("User did not select anything"),
+//!     }
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ### select_from_list_with_multi_line_header
+//!
+//! Use the `select_from_list_with_multi_line_header` API if you want to display a list of items with a
+//! multi line header. The first 5 lines are all part of the multi line header.
+//!
+//! ![image](https://github.com/r3bl-org/r3bl-open-core/assets/22040032/2f82a42c-f720-4bcb-925d-0d5ad0b0a3c9)
+//!
+//! #### `select_from_list_with_multi_line_header` signature:
+//!
+//! [select_from_list_with_multi_line_header]
+//!
+//! ```rust
+//! use std::{io::Result, vec};
+//!
+//! use r3bl_ansi_color::{AnsiStyledText, Color, Style as RStyle};
+//! use r3bl_rs_utils_core::*;
+//! use r3bl_tuify::{
+//!     components::style::StyleSheet,
+//!     select_from_list_with_multi_line_header,
+//!     SelectionMode,
+//! };
+//!
+//! fn multi_select_instructions() -> Vec<Vec<AnsiStyledText<'static>>> {
+//!     let up_and_down = AnsiStyledText {
+//!         text: " Up or down:",
+//!         style: &[
+//!             RStyle::Foreground(Color::Rgb(9, 238, 211)),
+//!             RStyle::Background(Color::Rgb(14, 17, 23)),
+//!         ],
+//!     };
+//!     let navigate = AnsiStyledText {
+//!         text: "     navigate",
+//!         style: &[
+//!             RStyle::Foreground(Color::Rgb(94, 103, 111)),
+//!             RStyle::Background(Color::Rgb(14, 17, 23)),
+//!         ],
+//!     };
+//!
+//!     let line_1 = vec![up_and_down, navigate];
+//!
+//!     let space = AnsiStyledText {
+//!         text: " Space:",
+//!         style: &[
+//!             RStyle::Foreground(Color::Rgb(255, 216, 9)),
+//!             RStyle::Background(Color::Rgb(14, 17, 23)),
+//!         ],
+//!     };
+//!     let select = AnsiStyledText {
+//!         text: "          select or deselect item",
+//!         style: &[
+//!             RStyle::Foreground(Color::Rgb(94, 103, 111)),
+//!             RStyle::Background(Color::Rgb(14, 17, 23)),
+//!         ],
+//!     };
+//!
+//!     let line_2 = vec![space, select];
+//!
+//!     let esc = AnsiStyledText {
+//!         text: " Esc or Ctrl+C:",
+//!         style: &[
+//!             RStyle::Foreground(Color::Rgb(255, 132, 18)),
+//!             RStyle::Background(Color::Rgb(14, 17, 23)),
+//!         ],
+//!     };
+//!     let exit = AnsiStyledText {
+//!         text: "  exit program",
+//!         style: &[
+//!             RStyle::Foreground(Color::Rgb(94, 103, 111)),
+//!             RStyle::Background(Color::Rgb(14, 17, 23)),
+//!         ],
+//!     };
+//!
+//!     let line_3 = vec![esc, exit];
+//!     let return_key = AnsiStyledText {
+//!         text: " Return:",
+//!         style: &[
+//!             RStyle::Foreground(Color::Rgb(234, 0, 196)),
+//!             RStyle::Background(Color::Rgb(14, 17, 23)),
+//!         ],
+//!     };
+//!     let confirm = AnsiStyledText {
+//!         text: "         confirm selection",
+//!         style: &[
+//!             RStyle::Foreground(Color::Rgb(94, 103, 111)),
+//!             RStyle::Background(Color::Rgb(14, 17, 23)),
+//!         ],
+//!     };
+//!     let line_4 = vec![return_key, confirm];
+//!     vec![line_1, line_2, line_3, line_4]
+//! }
+//!
+//! fn main() -> Result<()> {
+//!    let header = AnsiStyledText {
+//!         text: " Please select one or more items. This is a really long heading that just keeps going and if your terminal viewport is small enough, this heading will be clipped",
+//!         style: &[
+//!             RStyle::Foreground(Color::Rgb(171, 204, 242)),
+//!             RStyle::Background(Color::Rgb(31, 36, 46)),
+//!         ],
+//!     };
+//!
+//!     let mut instructions_and_header: Vec<Vec<AnsiStyledText>> = multi_select_instructions();
+//!     instructions_and_header.push(vec![header]);
+//!
+//!     let user_input = select_from_list_with_multi_line_header(
+//!         instructions_and_header,
+//!         [
+//!             "item 1 of 13",
+//!             "item 2 of 13",
+//!             "item 3 of 13",
+//!             "item 4 of 13",
+//!             "item 5 of 13",
+//!             "item 6 of 13",
+//!             "item 7 of 13",
+//!             "item 8 of 13",
+//!             "item 9 of 13",
+//!             "item 10 of 13",
+//!             "item 11 of 13",
+//!             "item 12 of 13",
+//!             "item 13 of 13",
+//!         ]
+//!         .iter()
+//!         .map(|it| it.to_string())
+//!         .collect(),
+//!         Some(6),
+//!         None,
+//!         SelectionMode::Multiple,
+//!         StyleSheet::default(),
+//!     );
+//!     match &user_input {
+//!         Some(it) => {
+//!             println!("User selected: {:?}", it);
+//!         }
+//!         None => println!("User did not select anything"),
+//!     }
+//!    Ok(())
+//! }
+//! ```
 //!
 //! ## How to use it as a binary?
 //! <a id="markdown-how-to-use-it-as-a-binary%3F" name="how-to-use-it-as-a-binary%3F"></a>
@@ -90,8 +289,7 @@
 //! </video>
 //!
 //! You can install the binary using `cargo install r3bl_tuify` (from crates.io). Or
-//! `cargo install --path .` from source. Once installed, you can `rt` is a command line
-//! tool that allows you to select one of the options from the list that is passed into it
+//! `cargo install --path .` from source. `rt` is a command line tool that allows you to select one of the options from the list that is passed into it
 //! via `stdin`. It supports both `stdin` and `stdout` piping.
 //!
 //! Here are the command line arguments that it accepts:
@@ -107,7 +305,7 @@
 //! <a id="markdown-interactive-user-experience" name="interactive-user-experience"></a>
 //!
 //! Typically a CLI app is not interactive. You can pass commands, subcommands, options, and
-//! arguments to it, but if you get something wrong, then you get an error, and have to start
+//! arguments to it, but if you get something wrong, then you get an error and have to start
 //! all over again. This "conversation" style interface might require a lot of trial and error
 //! to get the desired result.
 //!
@@ -143,12 +341,11 @@
 //!     item. So if the user selects `item 1`, then the command that will be run is `echo item
 //!     1`. The `echo` command simply prints the selected item to `stdout`.
 //!
-//! Now that is a lot to remember. It is helpful to use `clap` to provide nice command line help
-//! but that is still quite a few things that you have to get right in order for this command to
-//! work.
+//! Now that is a lot to remember. It is helpful to use `clap` to provide nice command line help but
+//! that are still quite a few things that you have to get right for this command to work.
 //!
-//! It doesn't have to be this way. It is entirely possible for the binary to be interactive
-//! along with the use of `clap` to specify some of the subcommands, and arguments. It doesn't
+//! It doesn't have to be this way. The binary can be interactive along with
+//! the use of `clap` to specify some of the subcommands, and arguments. It doesn't
 //! have to be an all or nothing approach. We can have the best of both worlds. The following
 //! videos illustrate what happens when:
 //!
@@ -162,9 +359,9 @@
 //!
 //!    - The user first chooses `single` selection mode (using a list selection component),
 //!      and then types in `echo %` in the terminal, as the command to run with each
-//!      selection. This is the really interactive scenario, since the user has to provide 2
-//!      pieces of information: the selection mode, and the command to run with each
-//!      selection. They didn't provide this up front when they ran the command.
+//!      selection. This is an
+//!      interactive scenario since the user has to provide 2 pieces of information:  the selection mode, and the command to run with each
+//!      selection. They didn't provide this upfront when they ran the command.
 //!      <!-- tuify-interactive-happy-path -->
 //!      <video width="100%" controls>
 //!        <source src="https://github.com/r3bl-org/r3bl-open-core/assets/2966499/51de8867-513b-429f-aff2-63dd25d71c82" type="video/mp4"/>
@@ -224,11 +421,11 @@
 //!   1. `ls -la | rt -s multiple | xargs -0` - does not expect `stdout` to be piped out,
 //!      and prints help.
 //!
-//! > Due to the way in which unix pipes are implemented, it is not possible to pipe the
-//! > `stdout` of this command to anything else. Unix pipes are non blocking. So there is no
-//! > way to stop the pipe "mid way". This is why `rt` displays an error when the `stdout` is
+//! > Due to how unix pipes are implemented, it is not possible to pipe the
+//! > `stdout` of this command to anything else. Unix pipes are nonblocking. So there is no
+//! > way to stop the pipe "midway". This is why `rt` displays an error when the `stdout` is
 //! > piped out. It is not possible to pipe the `stdout` of `rt` to another command. Instead,
-//! > the `rt` binary simply takes a command that it will run after the user has made their
+//! > the `rt` binary simply takes a command that will run after the user has made their
 //! > selection. Using the selected item(s) and applying them to this command.
 //!
 //! ## Style the components
@@ -353,7 +550,7 @@
 //!
 //! ### Prerequisites
 //!
-//! 🌠 In order for these to work you have to install the Rust toolchain, `nu`, `cargo-watch`,
+//! 🌠 For these to work you have to install the Rust toolchain, `nu`, `cargo-watch`,
 //! `bat`, and `flamegraph` on your system. Here are the instructions:
 //!
 //! 1. Install the Rust toolchain using `rustup` by following the instructions
@@ -364,13 +561,14 @@
 //! 1. Install [`nu`](https://crates.io/crates/nu) shell on your system using `cargo install
 //!    nu`. It is available for Linux, macOS, and Windows.
 //!
-//! ### Nu shell scripts to build, run, test etc.
-//! <a id="markdown-nu-shell-scripts-to-build%2C-run%2C-test-etc." name="nu-shell-scripts-to-build%2C-run%2C-test-etc."></a>
+//! ### Nu shell scripts to build, run, test, etc.
+//!
+//! Go to the `tuify` folder and run the commands below. These commands are defined in the `./run` folder.
 //!
 //! | Command                                | Description                                |
 //! | -------------------------------------- | ------------------------------------------ |
-//! | `nu run examples`                  | Run examples in the `./examples` folder    |
-//! | `nu run piped`                     | Run binary with piped input                |
+//! | `nu run examples`                      | Run examples in the `./examples` folder    |
+//! | `nu run piped`                         | Run binary with piped input                |
 //! | `nu run build`                         | Build                                      |
 //! | `nu run clean`                         | Clean                                      |
 //! | `nu run all`                           | All                                        |
@@ -386,7 +584,7 @@
 //!
 //! | Command                                             | Description                        |
 //! | --------------------------------------------------- | ---------------------------------- |
-//! | `nu run watch-examples`                         | Watch run examples                 |
+//! | `nu run watch-examples`                             | Watch run examples                 |
 //! | `nu run watch-all-tests`                            | Watch all test                     |
 //! | `nu run watch-one-test <test_name>`                 | Watch one test                     |
 //! | `nu run watch-clippy`                               | Watch clippy                       |
@@ -399,8 +597,8 @@
 //! | Command                       | Description                        |
 //! | ----------------------------- | ---------------------------------- |
 //! | `nu run all`                  | Run all the tests, linting, formatting, etc. in one go. Used in CI/CD |
-//! | `nu run build-full`           | This will build all the crates in the Rust workspace. And it will install all the required pre-requisite tools needed to work with this crate (what `install-cargo-tools` does) and clear the cargo cache, cleaning, and then do a really clean build. |
-//! | `nu run install-cargo-tools`  | This will install all the required pre-requisite tools needed to work with this crate (things like `cargo-deny`, `flamegraph` will all be installed in one go) |
+//! | `nu run build-full`           | This will build all the crates in the Rust workspace. It will install all the required pre-requisite tools needed to work with this crate (what `install-cargo-tools` does) and clear the cargo cache, cleaning, and then do a really clean build. |
+//! | `nu run install-cargo-tools`  | This will install all the required pre-requisite tools needed to work with this crate (things like `cargo-deny`,and `flamegraph` will all be installed in one go) |
 //! | `nu run check-licenses`       | Use `cargo-deny` to audit all licenses used in the Rust workspace |
 //!
 //!


### PR DESCRIPTION
Now `giti branch delete` uses `select_from_list_with_multi_line_header` function insead of a single line header `select_from_list`. 

## New multi line header 
![image](https://github.com/r3bl-org/r3bl-open-core/assets/22040032/717c0d83-baaa-47f1-9919-bfc5c35a8711)

![image](https://github.com/r3bl-org/r3bl-open-core/assets/22040032/438accfa-09db-4e5d-be1a-26dec34f7b41)
