### PR TITLE
Add tests for existing ansi_color

### DIFF
--- a/ansi_color/Cargo.toml
+++ b/ansi_color/Cargo.toml
@@ -25,3 +25,4 @@ is_ci = "1.1.1"
 [dev-dependencies]
 pretty_assertions = "1.4.0"
 serial_test = "2.0.0"
+test-case = "3.3.1"

--- a/ansi_color/src/color.rs
+++ b/ansi_color/src/color.rs
@@ -136,3 +136,72 @@ mod ansi_color_impl {
         fn as_ansi256(&self) -> Ansi256Color { *self }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use test_case::test_case;
+
+    use super::*;
+
+    #[test_case(0, 0, 0)]
+    #[test_case(255, 125, 0)]
+    #[test_case(255, 255, 255)]
+    fn test_color_as_rgb(red: u8, green: u8, blue: u8) {
+        let rgb_color = Color::Rgb(red, green, blue);
+        assert_eq!(rgb_color.as_rgb(), RgbColor { red, green, blue });
+    }
+
+    #[test_case(Color::Rgb(255, 255, 255), 231)]
+    #[test_case(Color::Rgb(255, 128, 0), 208)]
+    fn test_color_as_ansi256(rgb_color: crate::Color, index: u8) {
+        let expected_ansi = Ansi256Color { index };
+        assert_eq!(rgb_color.as_ansi256(), expected_ansi);
+    }
+
+    #[test_case(RgbColor{red: 0, green: 0, blue: 0})]
+    #[test_case(RgbColor{red: 0, green: 128, blue: 255})]
+    #[test_case(RgbColor{red: 255, green: 255, blue: 255})]
+    fn test_rgb_color_as_rgb(rgb_color: RgbColor) {
+        assert_eq!(rgb_color.as_rgb(), rgb_color);
+    }
+
+    #[test_case(Ansi256Color{index: 42}, RgbColor{red: 0, green: 215, blue: 135})]
+    fn test_ansi256_color_as_rgb(ansi_color: Ansi256Color, rgb_color: RgbColor) {
+        assert_eq!(ansi_color.as_rgb(), rgb_color);
+    }
+
+    #[test_case(RgbColor{red: 0, green: 0, blue: 0}, 16)]
+    #[test_case(RgbColor{red: 0, green: 128, blue: 255}, 33)]
+    fn test_rgb_color_as_ansi256(rgb_color: RgbColor, index: u8) {
+        let expected_ansi = Ansi256Color { index };
+        assert_eq!(rgb_color.as_ansi256(), expected_ansi);
+    }
+
+    #[test_case(Color::Rgb(0, 0, 0), 16)]
+    #[test_case(Color::Rgb(255, 128, 0), 249)]
+    fn test_color_as_grayscale(rgb_color: crate::Color, index: u8) {
+        let expected_gray = Ansi256Color { index };
+        assert_eq!(rgb_color.as_grayscale(), expected_gray);
+    }
+
+    #[test_case(RgbColor{red: 0, green: 128, blue: 255}, 245)]
+    #[test_case(RgbColor{red: 128, green: 128, blue: 128}, 244)]
+    fn test_rgb_color_as_grayscale(rgb_color: RgbColor, index: u8) {
+        let expected_gray = Ansi256Color { index };
+        assert_eq!(rgb_color.as_grayscale(), expected_gray);
+    }
+
+    #[test_case(RgbColor{red: 0, green: 0, blue: 0}, 16)]
+    #[test_case(RgbColor{red: 0, green: 128, blue: 255}, 33)]
+    fn test_ansi256_color_as_ansi256(rgb_color: RgbColor, index: u8) {
+        let expected_ansi = Ansi256Color { index };
+        assert_eq!(rgb_color.as_ansi256(), expected_ansi);
+    }
+
+    #[test_case(RgbColor{red: 0, green: 128, blue: 255}, 245)]
+    #[test_case(RgbColor{red: 255, green: 255, blue: 255}, 231)]
+    fn test_ansi256_color_as_grayscale(rgb_color: RgbColor, index: u8) {
+        let expected_gray = Ansi256Color { index };
+        assert_eq!(rgb_color.as_grayscale(), expected_gray);
+    }
+}


### PR DESCRIPTION
For issue #135
The tests added use test_case macro to easily generate many test for various colors.  What the test lack is edge cases or negative tests.  These can be easily added using the test_case format.  I could use some feedback and suggestions on the tests.