### PR TITLE
[giti] Handle `giti branch checkout` modified files use case

### DIFF
--- a/cmdr/src/bin/giti.rs
+++ b/cmdr/src/bin/giti.rs
@@ -119,11 +119,14 @@ pub fn try_run_command(giti_app_args: &CLIArg) -> CommonResult<TryRunCommandResu
     match &giti_app_args.command {
         CLICommand::Branch {
             command_to_run_with_each_selection,
+            maybe_branch_name,
             ..
         } => match command_to_run_with_each_selection {
             Some(subcommand) => match subcommand {
                 BranchSubcommand::Delete => return try_delete_branch(),
-                BranchSubcommand::Checkout => return try_checkout_branch(),
+                BranchSubcommand::Checkout => {
+                    return try_checkout_branch(maybe_branch_name.clone())
+                }
                 _ => unimplemented!(),
             },
             _ => {
@@ -138,6 +141,7 @@ pub fn try_run_command(giti_app_args: &CLIArg) -> CommonResult<TryRunCommandResu
 fn user_typed_giti_branch() -> CommonResult<TryRunCommandResult> {
     let branch_subcommands = get_giti_command_subcommand_names(CLICommand::Branch {
         command_to_run_with_each_selection: None,
+        maybe_branch_name: None,
     });
     let default_header_style = [
         Style::Foreground(FrozenBlue.as_ansi_color()),
@@ -165,7 +169,7 @@ fn user_typed_giti_branch() -> CommonResult<TryRunCommandResult> {
         let it = selected[0].as_str();
         match it {
             "delete" => return try_delete_branch(),
-            "checkout" => return try_checkout_branch(),
+            "checkout" => return try_checkout_branch(None),
             _ => unimplemented!(),
         };
     };

--- a/cmdr/src/color_constants.rs
+++ b/cmdr/src/color_constants.rs
@@ -3,9 +3,12 @@ use r3bl_ansi_color::Color as AnsiColor;
 pub enum DefaultColors {
     LizardGreen,
     SlateGray,
+    SilverMetallic,
     FrozenBlue,
     MoonlightBlue,
+    NightBlue,
     GuardsRed,
+    Orange,
 }
 
 impl DefaultColors {
@@ -13,9 +16,12 @@ impl DefaultColors {
         match self {
             DefaultColors::LizardGreen => AnsiColor::Rgb(20, 244, 0),
             DefaultColors::SlateGray => AnsiColor::Rgb(94, 103, 111),
+            DefaultColors::SilverMetallic => AnsiColor::Rgb(213, 217, 220),
             DefaultColors::FrozenBlue => AnsiColor::Rgb(171, 204, 242),
             DefaultColors::MoonlightBlue => AnsiColor::Rgb(31, 36, 46),
+            DefaultColors::NightBlue => AnsiColor::Rgb(14, 17, 23),
             DefaultColors::GuardsRed => AnsiColor::Rgb(200, 1, 1),
+            DefaultColors::Orange => AnsiColor::Rgb(255, 132, 18),
         }
     }
 }

--- a/cmdr/src/giti/branch/checkout.rs
+++ b/cmdr/src/giti/branch/checkout.rs
@@ -17,104 +17,357 @@
 
 use std::process::Command;
 
+use branch_checkout_formatting::{add_spaces_to_end_of_string,
+                                 display_correct_message_after_user_tried_to_checkout,
+                                 get_formatted_modified_files};
 use r3bl_ansi_color::{AnsiStyledText, Style};
-use r3bl_rs_utils_core::CommonResult;
-use r3bl_tuify::{select_from_list_with_multi_line_header, SelectionMode, StyleSheet};
+use r3bl_rs_utils_core::{ch, ChUnit, CommonResult, UnicodeString};
+use r3bl_tuify::{get_terminal_width,
+                 select_from_list_with_multi_line_header,
+                 SelectionMode,
+                 StyleSheet};
 
 use super::{get_branches, try_get_current_branch};
 use crate::{color_constants::DefaultColors::{FrozenBlue,
                                              GuardsRed,
                                              LizardGreen,
                                              MoonlightBlue,
+                                             NightBlue,
+                                             Orange,
                                              SlateGray},
-            giti::{report_unknown_error_and_propagate,
+            giti::{clap_config::clap_config::BranchSubcommand,
+                   report_unknown_error_and_propagate,
                    single_select_instruction_header,
                    ui_strings::UIStrings::*,
                    TryRunCommandResult}};
-
-pub fn try_checkout_branch() -> CommonResult<TryRunCommandResult> {
-    let try_run_command_result = TryRunCommandResult::default();
-
-    let default_header_style = [
-        Style::Foreground(FrozenBlue.as_ansi_color()),
-        Style::Background(MoonlightBlue.as_ansi_color()),
-    ];
-
-    let select_branch_to_switch_to = &SelectBranchToSwitchTo.to_string();
-
-    let instructions_and_branches = {
-        let mut instructions_and_branches = single_select_instruction_header();
-        let header = AnsiStyledText {
-            text: select_branch_to_switch_to,
-            style: &default_header_style,
-        };
-        instructions_and_branches.push(vec![header]);
-        instructions_and_branches
+pub fn try_checkout_branch(
+    maybe_branch_name: Option<String>,
+) -> CommonResult<TryRunCommandResult> {
+    let try_run_command_result = TryRunCommandResult {
+        maybe_deleted_branches: None,
+        branch_subcommand: Some(BranchSubcommand::Checkout),
     };
 
-    let current_branch = try_get_current_branch()?;
+    // If branch_name is passed as an argument, then check out to it and return early.
+    match maybe_branch_name {
+        Some(branch_name) => {
+            // Check does branch_name match any of the branches.
+            let branches = get_branches()?;
+            let branches_trimmed: Vec<String> = branches
+                .iter()
+                .map(|branch| branch.trim_start_matches("(current) ").to_string())
+                .collect();
 
-    if let Ok(branches) = get_branches() {
-        // Ask user to select a branch to check out to.
-        let maybe_selected_branch = select_from_list_with_multi_line_header(
-            instructions_and_branches,
-            branches,
-            Some(20),
-            None,
-            SelectionMode::Single,
-            StyleSheet::default(),
-        );
+            // If branch_name doesn't match any of the branches, then the branch doesn't exist,  return early.
+            if !branches_trimmed.contains(&branch_name) {
+                let ferrari_red = GuardsRed.as_ansi_color();
+                AnsiStyledText {
+                    text: &BranchDoesNotExist { branch_name }.to_string(),
+                    style: &[Style::Foreground(ferrari_red)],
+                }
+                .println();
+                return Ok(try_run_command_result);
+            };
 
-        // If user selected a branch, then check out to it.
-        if let Some(selected_branch) = maybe_selected_branch {
-            let selected_branch = &selected_branch[0];
-            let selected_branch = selected_branch.trim_start_matches("(current) ");
-            let command: &mut Command =
-                &mut create_git_command_to_checkout_branch(selected_branch);
-            let result_output = command.output();
+            let current_branch = try_get_current_branch()?;
 
-            match result_output {
-                Ok(output) => {
-                    if output.status.success() {
-                        let branch_name = AnsiStyledText {
-                            text: selected_branch,
+            // Check if branch_name is the same as current branch. Then early return.
+            if branch_name == current_branch {
+                let current_branch_name = AnsiStyledText {
+                    text: &current_branch,
+                    style: &[Style::Foreground(LizardGreen.as_ansi_color())],
+                };
+                let slate_gray = SlateGray.as_ansi_color();
+                let already_on_branch = AnsiStyledText {
+                    text: &AlreadyOnCurrentBranch.to_string(),
+                    style: &[Style::Foreground(slate_gray)],
+                };
+                println!("{already_on_branch}{current_branch_name}");
+                return Ok(try_run_command_result);
+            }
+
+            // Check for modified unstaged files.
+            let command_to_check_for_modified_files: &mut Command =
+                &mut create_git_command_to_check_for_modified_unstaged_files();
+            let result_output_for_modified_files =
+                command_to_check_for_modified_files.output();
+
+            if let Ok(output) = result_output_for_modified_files {
+                if output.status.success() {
+                    // Format each modified file in modified_files_vec.
+                    let modified_files: Vec<String> =
+                        get_formatted_modified_files(output);
+
+                    // If user has files that are modified (unstaged or staged), but not committed.
+                    if modified_files.len() > 0 {
+                        let terminal_width = get_terminal_width();
+
+                        let one_modified_file = &ModifiedFileOnCurrentBranch.to_string();
+                        let one_modified_file = add_spaces_to_end_of_string(
+                            one_modified_file,
+                            terminal_width,
+                        );
+
+                        let multiple_modified_files =
+                            &ModifiedFilesOnCurrentBranch.to_string();
+                        let multiple_modified_files = add_spaces_to_end_of_string(
+                            multiple_modified_files,
+                            terminal_width,
+                        );
+
+                        let modified_filed_text_style = &[
+                            Style::Foreground(Orange.as_ansi_color()),
+                            Style::Background(NightBlue.as_ansi_color()),
+                        ];
+
+                        if modified_files.len() == 1 {
+                            AnsiStyledText {
+                                text: &one_modified_file,
+                                style: modified_filed_text_style,
+                            }
+                            .println();
+                        } else {
+                            AnsiStyledText {
+                                text: &multiple_modified_files,
+                                style: modified_filed_text_style,
+                            }
+                            .println();
+                        }
+
+                        let gray_text_style = &[
+                            Style::Foreground(SlateGray.as_ansi_color()),
+                            Style::Background(NightBlue.as_ansi_color()),
+                        ];
+
+                        for file in &modified_files {
+                            let file = add_spaces_to_end_of_string(file, terminal_width);
+                            AnsiStyledText {
+                                text: &file,
+                                style: gray_text_style,
+                            }
+                            .println();
+                        }
+
+                        let please_commit_changes =
+                            PleaseCommitChangesBeforeSwitchingBranches.to_string();
+                        let please_commit_changes = add_spaces_to_end_of_string(
+                            &please_commit_changes,
+                            terminal_width,
+                        );
+                        AnsiStyledText {
+                            text: &please_commit_changes,
+                            style: &[
+                                Style::Foreground(Orange.as_ansi_color()),
+                                Style::Background(NightBlue.as_ansi_color()),
+                            ],
+                        }
+                        .println();
+                        return Ok(try_run_command_result);
+                    }
+                }
+            }
+
+            // Below code will execute if user doesn't have any modified uncommitted files.
+            let checkout_branch_command: &mut Command =
+                &mut create_git_command_to_checkout_branch(&branch_name);
+            let branch_checkout_result_output = checkout_branch_command.output();
+
+            match branch_checkout_result_output {
+                Ok(branch_checkout_output) => {
+                    if branch_checkout_output.status.success() {
+                        let branch_name_styled = AnsiStyledText {
+                            text: &branch_name,
                             style: &[Style::Foreground(LizardGreen.as_ansi_color())],
                         };
                         let slate_gray = SlateGray.as_ansi_color();
 
-                        if selected_branch == current_branch {
+                        if branch_name == current_branch {
                             let already_on_branch = AnsiStyledText {
                                 text: &AlreadyOnCurrentBranch.to_string(),
                                 style: &[Style::Foreground(slate_gray)],
                             };
-                            println!("{already_on_branch}{branch_name}");
+                            println!("{already_on_branch}{branch_name_styled}");
                         } else {
                             let switched_to = AnsiStyledText {
                                 text: &SwitchedToBranch.to_string(),
                                 style: &[Style::Foreground(slate_gray)],
                             };
-                            println!("{switched_to}{branch_name}");
+                            println!("{switched_to}{branch_name_styled}");
                         }
                     } else {
                         try_checkout_branch_error::display_error_message(
-                            selected_branch.to_string(),
-                            Some(output),
+                            branch_name,
+                            Some(branch_checkout_output),
                         );
                     }
                 }
                 Err(error) => {
                     // Can't even execute output(), something unknown has gone
                     // wrong. Propagate the error.
-                    try_checkout_branch_error::display_error_message(
-                        selected_branch.to_string(),
-                        None,
+                    try_checkout_branch_error::display_error_message(branch_name, None);
+                    return report_unknown_error_and_propagate(
+                        checkout_branch_command,
+                        error,
                     );
-                    return report_unknown_error_and_propagate(command, error);
+                }
+            }
+        }
+
+        // The code below will execute if branch_name is not passed as an argument. It displays user
+        // all the local branches and asks them to select a branch to check out to.
+        None => {
+            let default_header_style = [
+                Style::Foreground(FrozenBlue.as_ansi_color()),
+                Style::Background(MoonlightBlue.as_ansi_color()),
+            ];
+
+            let select_branch_to_switch_to = &SelectBranchToSwitchTo.to_string();
+
+            let instructions_and_branches = {
+                let mut instructions_and_branches = single_select_instruction_header();
+                let header = AnsiStyledText {
+                    text: select_branch_to_switch_to,
+                    style: &default_header_style,
+                };
+                instructions_and_branches.push(vec![header]);
+                instructions_and_branches
+            };
+
+            let current_branch = try_get_current_branch()?;
+
+            if let Ok(branches) = get_branches() {
+                // Ask user to select a branch to check out to.
+                let maybe_selected_branch = select_from_list_with_multi_line_header(
+                    instructions_and_branches,
+                    branches,
+                    Some(20),
+                    None,
+                    SelectionMode::Single,
+                    StyleSheet::default(),
+                );
+
+                // If user selected a branch, then check out to it.
+                if let Some(selected_branch) = maybe_selected_branch {
+                    let selected_branch = &selected_branch[0];
+                    let selected_branch =
+                        selected_branch.trim_start_matches("(current) ");
+                    let checkout_branch_command: &mut Command =
+                        &mut create_git_command_to_checkout_branch(selected_branch);
+                    let branch_checkout_result_output = checkout_branch_command.output();
+
+                    match branch_checkout_result_output {
+                        Ok(branch_checkout_output) => {
+                            if branch_checkout_output.status.success() {
+                                display_correct_message_after_user_tried_to_checkout(
+                                    selected_branch,
+                                    current_branch,
+                                );
+                            } else {
+                                try_checkout_branch_error::display_error_message(
+                                    selected_branch.to_string(),
+                                    Some(branch_checkout_output),
+                                );
+                            }
+                        }
+                        Err(error) => {
+                            // Can't even execute output(), something unknown has gone
+                            // wrong. Propagate the error.
+                            try_checkout_branch_error::display_error_message(
+                                selected_branch.to_string(),
+                                None,
+                            );
+                            return report_unknown_error_and_propagate(
+                                checkout_branch_command,
+                                error,
+                            );
+                        }
+                    }
                 }
             }
         }
     }
+
     return Ok(try_run_command_result);
+}
+
+mod branch_checkout_formatting {
+    use super::*;
+
+    pub fn add_spaces_to_end_of_string(string: &str, terminal_width: usize) -> String {
+        let string_length = UnicodeString::from(string).display_width;
+        let spaces_to_add = ch!(terminal_width) - string_length;
+        let spaces = " ".repeat(ch!(@to_usize spaces_to_add));
+        let string = format!("{}{}", string, spaces);
+        string
+    }
+
+    pub fn get_formatted_modified_files(output: std::process::Output) -> Vec<String> {
+        let mut modified_files_vec: Vec<String> = Vec::new();
+        let modified_files = String::from_utf8_lossy(&output.stdout).to_string();
+        // Early return if there are no modified files.
+        if modified_files.len() == 0 {
+            return modified_files_vec;
+        }
+        let modified_files = modified_files.trim();
+        let modified_files_vector: Vec<&str> = modified_files.split("\n").collect();
+        // Remove all the spaces from start and end of each modified file.
+        let modified_files_vector: Vec<String> = modified_files_vector
+            .iter()
+            .map(|output| output.trim().to_string())
+            .collect();
+
+        // Remove all the "MM" and " M" from modified files.
+        // "M" means unstaged files. "MM" means staged files.
+        for output in &modified_files_vector {
+            if output.starts_with("MM ") {
+                let modified_output = output.replace("MM", "");
+                let modified_output = modified_output.trim_start();
+                let modified_output = format!("    - {}", modified_output);
+                modified_files_vec.push(modified_output);
+            } else if output.starts_with("M ") {
+                let modified_output = output.replace("M ", "");
+                let modified_output = modified_output.trim_start();
+                let modified_output = format!("    - {}", modified_output);
+                modified_files_vec.push(modified_output);
+            } else {
+                let modified_output = output.trim_start();
+                let modified_output = format!("    - {}", modified_output);
+                modified_files_vec.push(modified_output);
+            }
+        }
+        modified_files_vec
+    }
+
+    pub fn display_correct_message_after_user_tried_to_checkout(
+        selected_branch: &str,
+        current_branch: String,
+    ) {
+        let branch_name = AnsiStyledText {
+            text: selected_branch,
+            style: &[Style::Foreground(LizardGreen.as_ansi_color())],
+        };
+        let slate_gray = SlateGray.as_ansi_color();
+
+        if selected_branch == current_branch {
+            let already_on_branch = AnsiStyledText {
+                text: &AlreadyOnCurrentBranch.to_string(),
+                style: &[Style::Foreground(slate_gray)],
+            };
+            println!("{already_on_branch}{branch_name}");
+        } else {
+            let switched_to = AnsiStyledText {
+                text: &SwitchedToBranch.to_string(),
+                style: &[Style::Foreground(slate_gray)],
+            };
+            println!("{switched_to}{branch_name}");
+        }
+    }
+}
+
+fn create_git_command_to_check_for_modified_unstaged_files() -> Command {
+    let mut command = Command::new("git");
+    command.args(["status", "--porcelain"]);
+    command
 }
 
 fn create_git_command_to_checkout_branch(branch_name: &str) -> Command {

--- a/cmdr/src/giti/branch/delete.rs
+++ b/cmdr/src/giti/branch/delete.rs
@@ -321,33 +321,37 @@ pub fn get_branches() -> CommonResult<Vec<String>> {
     // If branch name is current_branch, then append `(current)` in front of it.
     // Create command.
     let mut command = Command::new("git");
-    let command: &mut Command = command.args(["branch", "--show-current"]);
+    let show_current_branch_command: &mut Command =
+        command.args(["branch", "--show-current"]);
 
-    let result_output = command.output();
+    let current_branch_result_output = show_current_branch_command.output();
 
     let current_branch;
-    match result_output {
-        // Can't even execute output(), something unknown has gone wrong. Propagate the
-        // error.
-        Err(error) => {
-            return report_unknown_error_and_propagate(command, error);
-        }
+    match current_branch_result_output {
         Ok(output) => {
             let output_string = String::from_utf8_lossy(&output.stdout);
             current_branch = output_string.to_string().trim_end_matches('\n').to_string();
         }
+        // Can't even execute output(), something unknown has gone wrong. Propagate the
+        // error.
+        Err(error) => {
+            return report_unknown_error_and_propagate(
+                show_current_branch_command,
+                error,
+            );
+        }
     };
 
-    let mut return_vec = vec![];
+    let mut branches_vec = vec![];
     for branch in branches {
         if branch == current_branch {
-            return_vec.push(CurrentBranch { branch }.to_string());
+            branches_vec.push(CurrentBranch { branch }.to_string());
         } else {
-            return_vec.push(branch.to_string());
+            branches_vec.push(branch.to_string());
         }
     }
 
-    Ok(return_vec)
+    Ok(branches_vec)
 }
 
 pub fn try_get_current_branch() -> CommonResult<String> {

--- a/cmdr/src/giti/clap_config.rs
+++ b/cmdr/src/giti/clap_config.rs
@@ -95,6 +95,7 @@ pub mod clap_config {
                 help = "In your shell, this command will execute, taking each selected item as an argument."
             )]
             command_to_run_with_each_selection: Option<BranchSubcommand>,
+            maybe_branch_name: Option<String>,
         },
 
         #[clap(about = "TODO Commit help")]

--- a/cmdr/src/giti/ui_strings.rs
+++ b/cmdr/src/giti/ui_strings.rs
@@ -60,6 +60,18 @@ pub enum UIStrings {
         command_args_to_string: String,
         command_output_error: std::io::Error,
     },
+    BranchDoesNotExist {
+        branch_name: String,
+    },
+    ModifiedFileOnCurrentBranch,
+    ModifiedFilesOnCurrentBranch,
+    WouldYouLikeToSwitchToBranch {
+        branch_name: String,
+    },
+    SwitchToBranchAndApplyChanges,
+    StayOnCurrentBranch,
+    StayingOnCurrentBranch,
+    PleaseCommitChangesBeforeSwitchingBranches,
 }
 
 impl UIStrings {
@@ -120,7 +132,7 @@ impl UIStrings {
                 error_message,
             } => {
                 format!(
-                    "Failed to switch to branch:\n ╴{branch}!\n\n{}",
+                    "Failed to switch to branch '{branch}'!\n\n{}",
                     error_message
                 )
             }
@@ -151,6 +163,28 @@ impl UIStrings {
                     "Error executing command: '{program_name_to_string} {command_args_to_string}'. Error: {command_output_error}"
                 )
             }
+            UIStrings::BranchDoesNotExist { branch_name } => {
+                format!("Branch `{}` does not exist.", branch_name)
+            }
+            UIStrings::ModifiedFileOnCurrentBranch => {
+                format!(" You have a 📝 modified file on the current branch: ")
+            }
+            UIStrings::ModifiedFilesOnCurrentBranch => {
+                format!(" You have 📝 modified files on the current branch: ")
+            }
+            UIStrings::WouldYouLikeToSwitchToBranch { branch_name } => {
+                format!(" Would you like to switch to branch '{branch_name}?'")
+            }
+            UIStrings::SwitchToBranchAndApplyChanges => {
+                String::from("Switch to branch and apply changes")
+            }
+            UIStrings::StayOnCurrentBranch => String::from("Stay on current branch"),
+            UIStrings::StayingOnCurrentBranch => {
+                String::from(" Staying on current branch ")
+            }
+            UIStrings::PleaseCommitChangesBeforeSwitchingBranches => String::from(
+                " Please commit your changes or stash them before you switch branches.",
+            ),
         }
     }
 }


### PR DESCRIPTION
Closes #303

User can type in a branch name as 4th command line argument and if the branch name is valid, then user switched to the branch. 

![image](https://github.com/r3bl-org/r3bl-open-core/assets/22040032/35f03bfc-6c39-490a-8d9e-08c550f57d3c)


In case branch name is invalid, user will see an error message.

![image](https://github.com/r3bl-org/r3bl-open-core/assets/22040032/ca3ea305-364c-4160-8e6b-dfb4967d035e)


In case user has modified files on branch and they try to checkout another branch, user will see a message saying to stash or commit the current changes before changing branches. 

![image](https://github.com/r3bl-org/r3bl-open-core/assets/22040032/4754e964-647b-4b11-af1c-40e765dab379)

If user has more than one modified files that need to be committed or stashed.
![image](https://github.com/r3bl-org/r3bl-open-core/assets/22040032/eebb9df1-af41-4a08-96f5-3b2ba53e3c02)

