### PR TITLE
v0.4.0-terminal_async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -624,6 +624,19 @@
 ## `r3bl_terminal_async`
 <a id="markdown-r3bl_terminal_async" name="r3bl_terminal_async"></a>
 
+### v0.4.0 (2024-04-21)
+
+- Changed:
+  - Remove use of `TokioMutex`. There are some dangers to being "cancel safe" when using
+    async Rust. This is outlined in the following:
+    [docs](https://docs.rs/tokio/latest/tokio/sync/struct.Mutex.html), and
+    [video](https://www.youtube.com/watch?v=1zOd52_tUWg&t=2088s). It is better to avoid
+    using a `TokioMutex` to check for cancellation and instead to use broadcast channel
+    for shutdown signals, just like the code already does. The changes made in this
+    release are related to removing the use of `TokioMutex` all together in favor of the
+    `StdMutex` since there is really no need to use it at all. And thus avoid any
+    potential of "cancel safe" errors cropping up!
+
 ### v0.3.1 (2024-04-17)
 
 - Updated:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "r3bl_terminal_async"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "async-stream",
  "crossterm",

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -93,8 +93,8 @@ cd terminal_async
 # Update CHANGELOG.md
 cargo build; cargo test; cargo doc
 git add -A
-git commit -m "v0.3.1-terminal_async"
-git tag -a v0.3.1-terminal_async -m "v0.3.1-terminal_async"
+git commit -m "v0.4.0-terminal_async"
+git tag -a v0.4.0-terminal_async -m "v0.4.0-terminal_async"
 cargo publish
 cd ..
 

--- a/terminal_async/Cargo.toml
+++ b/terminal_async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r3bl_terminal_async"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 resolver = "2"
 description = "Async non-blocking read_line implemenation with multiline editor, with concurrent display output from tasks, and colorful animated spinners"

--- a/terminal_async/examples/spinner.rs
+++ b/terminal_async/examples/spinner.rs
@@ -16,7 +16,7 @@
  */
 
 use r3bl_terminal_async::{
-    Spinner, SpinnerColor, SpinnerStyle, SpinnerTemplate, TerminalAsync, TokioMutex,
+    Spinner, SpinnerColor, SpinnerStyle, SpinnerTemplate, StdMutex, TerminalAsync,
     ARTIFICIAL_UI_DELAY, DELAY_MS, DELAY_UNIT,
 };
 use std::{io::stderr, time::Duration};
@@ -66,7 +66,7 @@ async fn example_with_concurrent_output(style: SpinnerStyle) -> miette::Result<(
         message_trying_to_connect.clone(),
         DELAY_UNIT,
         style,
-        Arc::new(TokioMutex::new(stderr())),
+        Arc::new(StdMutex::new(stderr())),
         shared_writer.clone(),
     )
     .await?;

--- a/terminal_async/src/lib.rs
+++ b/terminal_async/src/lib.rs
@@ -252,19 +252,18 @@ use futures_core::Stream;
 use std::{collections::VecDeque, io::Error, pin::Pin, sync::Arc};
 
 pub type StdMutex<T> = std::sync::Mutex<T>;
-pub type TokioMutex<T> = tokio::sync::Mutex<T>;
 
 pub type SendRawTerminal = dyn std::io::Write + Send;
-pub type SafeRawTerminal = Arc<TokioMutex<SendRawTerminal>>;
+pub type SafeRawTerminal = Arc<StdMutex<SendRawTerminal>>;
 
-pub type SafeLineState = Arc<TokioMutex<LineState>>;
-pub type SafeHistory = Arc<TokioMutex<History>>;
+pub type SafeLineState = Arc<StdMutex<LineState>>;
+pub type SafeHistory = Arc<StdMutex<History>>;
 
-pub type SafeBool = Arc<TokioMutex<bool>>;
+pub type SafeBool = Arc<StdMutex<bool>>;
 pub type Text = Vec<u8>;
 
 pub type PauseBuffer = VecDeque<Text>;
-pub type SafePauseBuffer = Arc<TokioMutex<PauseBuffer>>;
+pub type SafePauseBuffer = Arc<StdMutex<PauseBuffer>>;
 
 pub type PinnedInputStream = Pin<Box<dyn Stream<Item = Result<Event, Error>>>>;
 

--- a/terminal_async/src/public_api/spinner.rs
+++ b/terminal_async/src/public_api/spinner.rs
@@ -114,8 +114,7 @@ impl Spinner {
                         // Render and paint the output, based on style.
                         let output = style.render_tick(&message_clone, count, get_terminal_display_width());
                         let _ = style
-                            .print_tick(&output, &mut *safe_output_terminal.lock().await)
-                            .await;
+                            .print_tick(&output, &mut (*safe_output_terminal.lock().unwrap()));
                         // Increment count to affect the output in the next iteration of this loop.
                         count += 1;
                     },
@@ -139,12 +138,10 @@ impl Spinner {
         let final_output = self
             .style
             .render_final_tick(final_message, get_terminal_display_width());
-        self.style
-            .print_final_tick(
-                &final_output,
-                &mut *self.safe_output_terminal.clone().lock().await,
-            )
-            .await?;
+        self.style.print_final_tick(
+            &final_output,
+            &mut *self.safe_output_terminal.clone().lock().unwrap(),
+        )?;
 
         // Resume the terminal.
         let _ = self
@@ -166,7 +163,7 @@ fn get_terminal_display_width() -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_fixtures::StdoutMock, SpinnerColor, StdMutex, TokioMutex};
+    use crate::{test_fixtures::StdoutMock, SpinnerColor, StdMutex};
     use std::sync::Arc;
     use strip_ansi_escapes::strip;
 
@@ -175,7 +172,7 @@ mod tests {
         let stdout_mock = StdoutMock {
             buffer: Arc::new(StdMutex::new(Vec::new())),
         };
-        let safe_output_terminal = Arc::new(TokioMutex::new(stdout_mock.clone()));
+        let safe_output_terminal = Arc::new(StdMutex::new(stdout_mock.clone()));
 
         let (line_sender, mut line_receiver) = tokio::sync::mpsc::channel(1_000);
         let shared_writer = SharedWriter {
@@ -252,7 +249,7 @@ mod tests {
         let stdout_mock = StdoutMock {
             buffer: Arc::new(StdMutex::new(Vec::new())),
         };
-        let safe_output_terminal = Arc::new(TokioMutex::new(stdout_mock.clone()));
+        let safe_output_terminal = Arc::new(StdMutex::new(stdout_mock.clone()));
 
         let (line_sender, mut line_receiver) = tokio::sync::mpsc::channel(1_000);
         let shared_writer = SharedWriter {

--- a/terminal_async/src/public_api/terminal_async.rs
+++ b/terminal_async/src/public_api/terminal_async.rs
@@ -15,7 +15,7 @@
  *   limitations under the License.
  */
 
-use crate::{PinnedInputStream, Readline, ReadlineEvent, SharedWriter, TokioMutex};
+use crate::{PinnedInputStream, Readline, ReadlineEvent, SharedWriter, StdMutex};
 use crossterm::{event::EventStream, style::Stylize};
 use futures_util::FutureExt;
 use miette::IntoDiagnostic;
@@ -60,11 +60,10 @@ impl TerminalAsync {
             return Ok(None);
         }
 
-        let safe_raw_terminal = Arc::new(TokioMutex::new(stdout()));
+        let safe_raw_terminal = Arc::new(StdMutex::new(stdout()));
         let pinned_input_stream: PinnedInputStream = Box::pin(EventStream::new());
         let (readline, stdout) =
             Readline::new(prompt.to_owned(), safe_raw_terminal, pinned_input_stream)
-                .await
                 .into_diagnostic()?;
         Ok(Some(TerminalAsync {
             readline,
@@ -133,7 +132,7 @@ impl TerminalAsync {
     /// Close the underlying [Readline] instance. This will terminate all the tasks that
     /// are managing [SharedWriter] tasks. This is useful when you want to exit the CLI
     /// event loop, typically when the user requests it.
-    pub async fn close(&mut self) {
-        self.readline.close().await;
+    pub fn close(&mut self) {
+        self.readline.close();
     }
 }

--- a/terminal_async/src/readline_impl/history.rs
+++ b/terminal_async/src/readline_impl/history.rs
@@ -43,7 +43,7 @@ impl History {
 
 impl History {
     // Update history entries
-    pub async fn update(&mut self, maybe_line: Option<String>) {
+    pub fn update(&mut self, maybe_line: Option<String>) {
         // Receive a new line.
         if let Some(line) = maybe_line {
             // Don't add entry if last entry was same, or line was empty.
@@ -102,21 +102,21 @@ mod tests {
     async fn test_update() {
         let (mut history, _) = History::new();
         history.max_size = 2;
-        history.update(Some("test1".into())).await;
+        history.update(Some("test1".into()));
         assert_eq!(history.entries.front(), Some(&"test1".to_string()));
 
-        history.update(None).await;
+        history.update(None);
         assert_eq!(history.entries.front(), Some(&"test1".to_string()));
 
-        history.update(Some("test1".into())).await;
+        history.update(Some("test1".into()));
         assert_eq!(history.entries.front(), Some(&"test1".to_string()));
 
-        history.update(Some("test2".into())).await;
+        history.update(Some("test2".into()));
         assert_eq!(history.entries.front(), Some(&"test2".to_string()));
 
         assert_eq!(history.entries.len(), 2);
 
-        history.update(Some("test3".into())).await;
+        history.update(Some("test3".into()));
         assert_eq!(history.entries.len(), 2);
         assert!(history.entries.contains(&"test2".to_string()));
         assert!(history.entries.contains(&"test3".to_string()));
@@ -127,9 +127,9 @@ mod tests {
     async fn test_search_next() {
         let (mut history, _) = History::new();
         history.max_size = 2;
-        history.update(Some("test1".into())).await;
-        history.update(Some("test2".into())).await;
-        history.update(Some("test3".into())).await;
+        history.update(Some("test1".into()));
+        history.update(Some("test2".into()));
+        history.update(Some("test3".into()));
 
         assert_eq!(history.search_next(), Some("test3"));
         assert_eq!(history.search_next(), Some("test2"));
@@ -141,9 +141,9 @@ mod tests {
     async fn test_search_previous() {
         let (mut history, _) = History::new();
         history.max_size = 2;
-        history.update(Some("test1".into())).await;
-        history.update(Some("test2".into())).await;
-        history.update(Some("test3".into())).await;
+        history.update(Some("test1".into()));
+        history.update(Some("test2".into()));
+        history.update(Some("test3".into()));
 
         assert_eq!(history.search_previous(), None);
         assert_eq!(history.search_next(), Some("test3"));

--- a/terminal_async/src/readline_impl/line.rs
+++ b/terminal_async/src/readline_impl/line.rs
@@ -225,7 +225,7 @@ impl LineState {
         Ok(())
     }
 
-    pub async fn handle_event(
+    pub fn handle_event(
         &mut self,
         event: Event,
         term: &mut dyn Write,
@@ -419,7 +419,7 @@ impl LineState {
                 }
                 KeyCode::Up => {
                     // search for next history item, replace line if found.
-                    if let Some(line) = safe_history.lock().await.search_next() {
+                    if let Some(line) = safe_history.lock().unwrap().search_next() {
                         self.line.clear();
                         self.line += line;
                         self.clear(term)?;
@@ -429,7 +429,7 @@ impl LineState {
                 }
                 KeyCode::Down => {
                     // search for next history item, replace line if found.
-                    if let Some(line) = safe_history.lock().await.search_previous() {
+                    if let Some(line) = safe_history.lock().unwrap().search_previous() {
                         self.line.clear();
                         self.line += line;
                         self.clear(term)?;
@@ -477,7 +477,7 @@ impl LineState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test_fixtures::StdoutMock, History, StdMutex, TokioMutex};
+    use crate::{test_fixtures::StdoutMock, History, StdMutex};
     use std::sync::Arc;
 
     #[tokio::test]
@@ -487,16 +487,18 @@ mod tests {
         let stdout_mock = StdoutMock {
             buffer: Arc::new(StdMutex::new(Vec::new())),
         };
-        let safe_output_terminal = Arc::new(TokioMutex::new(stdout_mock.clone()));
+        let safe_output_terminal = Arc::new(StdMutex::new(stdout_mock.clone()));
 
         let (history, _) = History::new();
-        let safe_history = Arc::new(TokioMutex::new(history));
+        let safe_history = Arc::new(StdMutex::new(history));
 
         let event = Event::Key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE));
 
-        let it = line
-            .handle_event(event, &mut *safe_output_terminal.lock().await, safe_history)
-            .await;
+        let it = line.handle_event(
+            event,
+            &mut *safe_output_terminal.lock().unwrap(),
+            safe_history,
+        );
 
         assert!(matches!(it, Ok(None)));
 
@@ -510,16 +512,18 @@ mod tests {
         let stdout_mock = StdoutMock {
             buffer: Arc::new(StdMutex::new(Vec::new())),
         };
-        let safe_output_terminal = Arc::new(TokioMutex::new(stdout_mock.clone()));
+        let safe_output_terminal = Arc::new(StdMutex::new(stdout_mock.clone()));
 
         let (history, _) = History::new();
-        let safe_history = Arc::new(TokioMutex::new(history));
+        let safe_history = Arc::new(StdMutex::new(history));
 
         let event = Event::Key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
 
-        let it = line
-            .handle_event(event, &mut *safe_output_terminal.lock().await, safe_history)
-            .await;
+        let it = line.handle_event(
+            event,
+            &mut *safe_output_terminal.lock().unwrap(),
+            safe_history,
+        );
 
         assert!(matches!(it, Ok(None)));
 
@@ -533,16 +537,18 @@ mod tests {
         let stdout_mock = StdoutMock {
             buffer: Arc::new(StdMutex::new(Vec::new())),
         };
-        let safe_output_terminal = Arc::new(TokioMutex::new(stdout_mock.clone()));
+        let safe_output_terminal = Arc::new(StdMutex::new(stdout_mock.clone()));
 
         let (history, _) = History::new();
-        let safe_history = Arc::new(TokioMutex::new(history));
+        let safe_history = Arc::new(StdMutex::new(history));
 
         let event = Event::Key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
 
-        let it = line
-            .handle_event(event, &mut *safe_output_terminal.lock().await, safe_history)
-            .await;
+        let it = line.handle_event(
+            event,
+            &mut *safe_output_terminal.lock().unwrap(),
+            safe_history,
+        );
 
         assert!(matches!(it, Ok(None)));
 

--- a/terminal_async/src/spinner_impl/spinner_render.rs
+++ b/terminal_async/src/spinner_impl/spinner_render.rs
@@ -31,18 +31,10 @@ use r3bl_tuify::clip_string_to_width_with_ellipsis;
 
 pub trait SpinnerRender {
     fn render_tick(&mut self, message: &str, count: usize, display_width: usize) -> String;
-    fn print_tick(
-        &self,
-        output: &str,
-        writer: &mut SendRawTerminal,
-    ) -> impl std::future::Future<Output = miette::Result<()>> + Send; /* this is in lieu of async marker on the fn */
+    fn print_tick(&self, output: &str, writer: &mut SendRawTerminal) -> miette::Result<()>;
 
     fn render_final_tick(&self, message: &str, display_width: usize) -> String;
-    fn print_final_tick(
-        &self,
-        output: &str,
-        writer: &mut SendRawTerminal,
-    ) -> impl std::future::Future<Output = miette::Result<()>> + Send; /* this is in lieu of async marker on the fn */
+    fn print_final_tick(&self, output: &str, writer: &mut SendRawTerminal) -> miette::Result<()>;
 }
 
 fn apply_color(output: &str, color: &mut SpinnerColor) -> String {
@@ -99,7 +91,7 @@ impl SpinnerRender for SpinnerStyle {
         }
     }
 
-    async fn print_tick(&self, output: &str, writer: &mut SendRawTerminal) -> miette::Result<()> {
+    fn print_tick(&self, output: &str, writer: &mut SendRawTerminal) -> miette::Result<()> {
         match self.template {
             SpinnerTemplate::Dots => {
                 // Print the output. And make sure to terminate w/ a newline, so that the
@@ -157,11 +149,7 @@ impl SpinnerRender for SpinnerStyle {
         }
     }
 
-    async fn print_final_tick(
-        &self,
-        output: &str,
-        writer: &mut SendRawTerminal,
-    ) -> miette::Result<()> {
+    fn print_final_tick(&self, output: &str, writer: &mut SendRawTerminal) -> miette::Result<()> {
         match self.template {
             SpinnerTemplate::Dots | SpinnerTemplate::Braille | SpinnerTemplate::Block => writer
                 .queue(MoveToColumn(0))


### PR DESCRIPTION
[terminal_async] Remove use of TokioMutex

There are some dangers to being "cancel safe" when using async Rust.
This can be seen in the links below (to docs, and video) which outline
what the problem is.

https://docs.rs/tokio/latest/tokio/sync/struct.Mutex.html
https://www.youtube.com/watch?v=1zOd52_tUWg&t=2088s

It is better to avoid using a TokioMutex to check for cancellation
and instead to use broadcast channel for shutdown signals, just like
the code already does. The changes made in this commit are related
to removing the use of TokioMutex all together in favor of the StdMutex
since there is really no need to use it at all. And thus avoid any
potential of "cancel safe" errors cropping up!