### PR TITLE
[terminal_async, core] Clean up lifecycle

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -95,6 +95,7 @@
     "positionals",
     "powf",
     "PTAL",
+    "ptys",
     "punct",
     "qself",
     "Rearchitect",

--- a/core/src/utils/debug_file_logging.rs
+++ b/core/src/utils/debug_file_logging.rs
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) 2022 R3BL LLC
+ *   Copyright (c) 2024 R3BL LLC
  *   All rights reserved.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,12 +15,13 @@
  *   limitations under the License.
  */
 
-// Attach.
-pub mod file_logging;
-pub mod friendly_random_id;
-pub mod debug_file_logging;
+use std::{fs::OpenOptions, io::Write, path::Path};
 
-// Re-export.
-pub use file_logging::*;
-pub use friendly_random_id::*;
-pub use debug_file_logging::*;
+pub fn debug_file_log(file_path: &Path, message: &str) {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(file_path)
+        .unwrap();
+    file.write_all(message.as_bytes()).unwrap();
+}

--- a/simple_logger/src/lib.rs
+++ b/simple_logger/src/lib.rs
@@ -159,7 +159,7 @@ mod tests {
                 vec.push(WriteLogger::new(
                     LevelFilter::Error,
                     conf.clone(),
-                    File::create(&format!("error_{}.log", i)).unwrap(),
+                    File::create(format!("error_{}.log", i)).unwrap(),
                 ) as Box<dyn SharedLogger>);
                 vec.push(TestLogger::new(LevelFilter::Error, conf.clone()));
 
@@ -176,7 +176,7 @@ mod tests {
                 vec.push(WriteLogger::new(
                     LevelFilter::Warn,
                     conf.clone(),
-                    File::create(&format!("warn_{}.log", i)).unwrap(),
+                    File::create(format!("warn_{}.log", i)).unwrap(),
                 ) as Box<dyn SharedLogger>);
                 vec.push(TestLogger::new(LevelFilter::Warn, conf.clone()));
 
@@ -193,7 +193,7 @@ mod tests {
                 vec.push(WriteLogger::new(
                     LevelFilter::Info,
                     conf.clone(),
-                    File::create(&format!("info_{}.log", i)).unwrap(),
+                    File::create(format!("info_{}.log", i)).unwrap(),
                 ) as Box<dyn SharedLogger>);
                 vec.push(TestLogger::new(LevelFilter::Info, conf.clone()));
 
@@ -210,7 +210,7 @@ mod tests {
                 vec.push(WriteLogger::new(
                     LevelFilter::Debug,
                     conf.clone(),
-                    File::create(&format!("debug_{}.log", i)).unwrap(),
+                    File::create(format!("debug_{}.log", i)).unwrap(),
                 ) as Box<dyn SharedLogger>);
                 vec.push(TestLogger::new(LevelFilter::Debug, conf.clone()));
 
@@ -227,7 +227,7 @@ mod tests {
                 vec.push(WriteLogger::new(
                     LevelFilter::Trace,
                     conf.clone(),
-                    File::create(&format!("trace_{}.log", i)).unwrap(),
+                    File::create(format!("trace_{}.log", i)).unwrap(),
                 ) as Box<dyn SharedLogger>);
                 vec.push(TestLogger::new(LevelFilter::Trace, conf.clone()));
             }
@@ -254,27 +254,27 @@ mod tests {
 
         for j in 1..i {
             let mut error = String::new();
-            File::open(&format!("error_{}.log", j))
+            File::open(format!("error_{}.log", j))
                 .unwrap()
                 .read_to_string(&mut error)
                 .unwrap();
             let mut warn = String::new();
-            File::open(&format!("warn_{}.log", j))
+            File::open(format!("warn_{}.log", j))
                 .unwrap()
                 .read_to_string(&mut warn)
                 .unwrap();
             let mut info = String::new();
-            File::open(&format!("info_{}.log", j))
+            File::open(format!("info_{}.log", j))
                 .unwrap()
                 .read_to_string(&mut info)
                 .unwrap();
             let mut debug = String::new();
-            File::open(&format!("debug_{}.log", j))
+            File::open(format!("debug_{}.log", j))
                 .unwrap()
                 .read_to_string(&mut debug)
                 .unwrap();
             let mut trace = String::new();
-            File::open(&format!("trace_{}.log", j))
+            File::open(format!("trace_{}.log", j))
                 .unwrap()
                 .read_to_string(&mut trace)
                 .unwrap();

--- a/terminal_async/README.md
+++ b/terminal_async/README.md
@@ -10,17 +10,19 @@ beautiful, powerful, and interactive REPLs (read execute print loops) with ease.
 
 1. Because
    [`read_line()`](https://doc.rust-lang.org/std/io/struct.Stdin.html#method.read_line)
-   is blocking. And there is no way to terminate an OS thread that is blocking in Rust.
-   To do this you have to exit the process (who's thread is blocked in `read_line()`).
+   is blocking. And there is no way to terminate an OS thread that is blocking in
+   Rust. To do this you have to exit the process (who's thread is blocked in
+   `read_line()`).
 
     - There is no way to get `read_line()` unblocked once it is blocked.
-    - You can use [`process::exit()`](https://doc.rust-lang.org/std/process/fn.exit.html)
-      or [`panic!()`](https://doc.rust-lang.org/std/panic/index.html) to kill the entire
+    - You can use
+      [`process::exit()`](https://doc.rust-lang.org/std/process/fn.exit.html) or
+      [`panic!()`](https://doc.rust-lang.org/std/panic/index.html) to kill the entire
       process. This is not appealing.
     - Even if that task is wrapped in a [`thread::spawn()` or
       `thread::spawn_blocking()`](https://tokio.rs/tokio/tutorial/spawning), it isn't
-      possible to cancel or abort that thread, without cooperatively asking it to exit. To
-      see what this type of code looks like, take a look at
+      possible to cancel or abort that thread, without cooperatively asking it to
+      exit. To see what this type of code looks like, take a look at
       [this](https://github.com/nazmulidris/rust-scratch/blob/fcd730c4b17ed0b09ff2c1a7ac4dd5b4a0c66e49/tcp-api-server/src/client_task.rs#L275).
 
 2. Another annoyance is that when a thread is blocked in `read_line()`, and you have
@@ -88,8 +90,8 @@ channel](https://www.youtube.com/@developerlifecom):
 
 ### Input Editing Behavior
 
-While entering text, the user can edit and navigate through the current
-input line with the following key bindings:
+While entering text, the user can edit and navigate through the current input line
+with the following key bindings:
 
 - Works on all platforms supported by `crossterm`.
 - Full Unicode Support (Including Grapheme Clusters).
@@ -102,11 +104,9 @@ input line with the following key bindings:
 - Ctrl-L: Clear the screen.
 - Ctrl-Left / Ctrl-Right: Move to previous/next whitespace.
 - Home: Jump to the start of the line.
-    - When the "emacs" feature (on by default) is enabled, Ctrl-A has the
-      same effect.
+    - When the "emacs" feature (on by default) is enabled, Ctrl-A has the same effect.
 - End: Jump to the end of the line.
-    - When the "emacs" feature (on by default) is enabled, Ctrl-E has the
-      same effect.
+    - When the "emacs" feature (on by default) is enabled, Ctrl-E has the same effect.
 - Ctrl-C, Ctrl-D: Send an `Eof` event.
 - Ctrl-C: Send an `Interrupt` event.
 - Extensible design based on `crossterm`'s `event-stream` feature.
@@ -147,22 +147,23 @@ cargo run --example spinner
 - Terminal input is retrieved by calling [`Readline::readline()`], which returns each
   complete line of input once the user presses Enter.
 
-- Each [`Readline`] instance is associated with one or more [`SharedWriter`] instances.
-  Lines written to an associated [`SharedWriter`] are output to the raw terminal.
+- Each [`Readline`] instance is associated with one or more [`SharedWriter`]
+  instances. Lines written to an associated [`SharedWriter`] are output to the raw
+  terminal.
 
 - Call [`Readline::new()`] to create a [`Readline`] instance and associated
   [`SharedWriter`].
 
-- Call [`Readline::readline()`] (most likely in a loop) to receive a line
-  of input from the terminal.  The user entering the line can edit their
-  input using the key bindings listed under "Input Editing" below.
+- Call [`Readline::readline()`] (most likely in a loop) to receive a line of input
+  from the terminal.  The user entering the line can edit their input using the key
+  bindings listed under "Input Editing" below.
 
-- After receiving a line from the user, if you wish to add it to the
-  history (so that the user can retrieve it while editing a later line),
-  call [`Readline::add_history_entry()`].
+- After receiving a line from the user, if you wish to add it to the history (so that
+  the user can retrieve it while editing a later line), call
+  [`Readline::add_history_entry()`].
 
-- Lines written to the associated [`SharedWriter`] while `readline()` is in
-  progress will be output to the screen above the input line.
+- Lines written to the associated [`SharedWriter`] while `readline()` is in progress
+  will be output to the screen above the input line.
 
 - When done, call [`crate::pause_and_resume_support::flush_internal()`] to ensure that
   all lines written to the [`SharedWriter`] are output.
@@ -194,14 +195,18 @@ the log file.
 - [Part 2: What?](https://youtu.be/3vQJguti02I)
 - [Part 3: Do the refactor and rename the crate](https://youtu.be/uxgyZzOmVIw)
 - [Part 4: Build the spinner](https://www.youtube.com/watch?v=fcb6rstRniI)
-- [Part 5: Add color gradient animation to spinner](https://www.youtube.com/watch?v=_QjsGDds270)
+- [Part 5: Add color gradient animation to
+  spinner](https://www.youtube.com/watch?v=_QjsGDds270)
 - [Part 6: Publish the crate and overview](https://youtu.be/X5wDVaZENOo)
-- [Testing playlist](https://www.youtube.com/watch?v=Xt495QLrFFk&list=PLofhE49PEwmwLR_4Noa0dFOSPmSpIg_l8)
+- [Testing
+  playlist](https://www.youtube.com/watch?v=Xt495QLrFFk&list=PLofhE49PEwmwLR_4Noa0dFOSPmSpIg_l8)
   - [Part 1: Intro](https://www.youtube.com/watch?v=Xt495QLrFFk)
   - [Part 2: Deep dive](https://www.youtube.com/watch?v=4iM9t5dgvU4)
 - Playlists
-  - [Build with Naz, async readline and spinner for CLI in Rust](https://www.youtube.com/watch?v=3vQJguti02I&list=PLofhE49PEwmwelPkhfiqdFQ9IXnmGdnSE)
-  - [Build with Naz, testing in Rust](https://www.youtube.com/watch?v=Xt495QLrFFk&list=PLofhE49PEwmwLR_4Noa0dFOSPmSpIg_l8)
+  - [Build with Naz, async readline and spinner for CLI in
+    Rust](https://www.youtube.com/watch?v=3vQJguti02I&list=PLofhE49PEwmwelPkhfiqdFQ9IXnmGdnSE)
+  - [Build with Naz, testing in
+    Rust](https://www.youtube.com/watch?v=Xt495QLrFFk&list=PLofhE49PEwmwLR_4Noa0dFOSPmSpIg_l8)
 
 ## Why another async readline crate?
 
@@ -236,6 +241,7 @@ been rewritten and re-architected. Here are some changes made to the code:
 ## More info on Linux TTY
 
 - [TTY Demystified](https://www.linusakesson.net/programming/tty/)
-- [Deep dive into Unix shells, ptys, etc.](https://www.youtube.com/playlist?list=PLFAC320731F539902)
+- [Deep dive into Unix shells, ptys,
+  etc.](https://www.youtube.com/playlist?list=PLFAC320731F539902)
 
 License: Apache-2.0

--- a/terminal_async/src/lib.rs
+++ b/terminal_async/src/lib.rs
@@ -25,17 +25,19 @@
 //!
 //! 1. Because
 //!    [`read_line()`](https://doc.rust-lang.org/std/io/struct.Stdin.html#method.read_line)
-//!    is blocking. And there is no way to terminate an OS thread that is blocking in Rust.
-//!    To do this you have to exit the process (who's thread is blocked in `read_line()`).
+//!    is blocking. And there is no way to terminate an OS thread that is blocking in
+//!    Rust. To do this you have to exit the process (who's thread is blocked in
+//!    `read_line()`).
 //!
 //!     - There is no way to get `read_line()` unblocked once it is blocked.
-//!     - You can use [`process::exit()`](https://doc.rust-lang.org/std/process/fn.exit.html)
-//!       or [`panic!()`](https://doc.rust-lang.org/std/panic/index.html) to kill the entire
+//!     - You can use
+//!       [`process::exit()`](https://doc.rust-lang.org/std/process/fn.exit.html) or
+//!       [`panic!()`](https://doc.rust-lang.org/std/panic/index.html) to kill the entire
 //!       process. This is not appealing.
 //!     - Even if that task is wrapped in a [`thread::spawn()` or
 //!       `thread::spawn_blocking()`](https://tokio.rs/tokio/tutorial/spawning), it isn't
-//!       possible to cancel or abort that thread, without cooperatively asking it to exit. To
-//!       see what this type of code looks like, take a look at
+//!       possible to cancel or abort that thread, without cooperatively asking it to
+//!       exit. To see what this type of code looks like, take a look at
 //!       [this](https://github.com/nazmulidris/rust-scratch/blob/fcd730c4b17ed0b09ff2c1a7ac4dd5b4a0c66e49/tcp-api-server/src/client_task.rs#L275).
 //!
 //! 2. Another annoyance is that when a thread is blocked in `read_line()`, and you have
@@ -103,8 +105,8 @@
 //!
 //! ## Input Editing Behavior
 //!
-//! While entering text, the user can edit and navigate through the current
-//! input line with the following key bindings:
+//! While entering text, the user can edit and navigate through the current input line
+//! with the following key bindings:
 //!
 //! - Works on all platforms supported by `crossterm`.
 //! - Full Unicode Support (Including Grapheme Clusters).
@@ -117,11 +119,9 @@
 //! - Ctrl-L: Clear the screen.
 //! - Ctrl-Left / Ctrl-Right: Move to previous/next whitespace.
 //! - Home: Jump to the start of the line.
-//!     - When the "emacs" feature (on by default) is enabled, Ctrl-A has the
-//!       same effect.
+//!     - When the "emacs" feature (on by default) is enabled, Ctrl-A has the same effect.
 //! - End: Jump to the end of the line.
-//!     - When the "emacs" feature (on by default) is enabled, Ctrl-E has the
-//!       same effect.
+//!     - When the "emacs" feature (on by default) is enabled, Ctrl-E has the same effect.
 //! - Ctrl-C, Ctrl-D: Send an `Eof` event.
 //! - Ctrl-C: Send an `Interrupt` event.
 //! - Extensible design based on `crossterm`'s `event-stream` feature.
@@ -162,22 +162,23 @@
 //! - Terminal input is retrieved by calling [`Readline::readline()`], which returns each
 //!   complete line of input once the user presses Enter.
 //!
-//! - Each [`Readline`] instance is associated with one or more [`SharedWriter`] instances.
-//!   Lines written to an associated [`SharedWriter`] are output to the raw terminal.
+//! - Each [`Readline`] instance is associated with one or more [`SharedWriter`]
+//!   instances. Lines written to an associated [`SharedWriter`] are output to the raw
+//!   terminal.
 //!
 //! - Call [`Readline::new()`] to create a [`Readline`] instance and associated
 //!   [`SharedWriter`].
 //!
-//! - Call [`Readline::readline()`] (most likely in a loop) to receive a line
-//!   of input from the terminal.  The user entering the line can edit their
-//!   input using the key bindings listed under "Input Editing" below.
+//! - Call [`Readline::readline()`] (most likely in a loop) to receive a line of input
+//!   from the terminal.  The user entering the line can edit their input using the key
+//!   bindings listed under "Input Editing" below.
 //!
-//! - After receiving a line from the user, if you wish to add it to the
-//!   history (so that the user can retrieve it while editing a later line),
-//!   call [`Readline::add_history_entry()`].
+//! - After receiving a line from the user, if you wish to add it to the history (so that
+//!   the user can retrieve it while editing a later line), call
+//!   [`Readline::add_history_entry()`].
 //!
-//! - Lines written to the associated [`SharedWriter`] while `readline()` is in
-//!   progress will be output to the screen above the input line.
+//! - Lines written to the associated [`SharedWriter`] while `readline()` is in progress
+//!   will be output to the screen above the input line.
 //!
 //! - When done, call [`crate::pause_and_resume_support::flush_internal()`] to ensure that
 //!   all lines written to the [`SharedWriter`] are output.
@@ -209,14 +210,18 @@
 //! - [Part 2: What?](https://youtu.be/3vQJguti02I)
 //! - [Part 3: Do the refactor and rename the crate](https://youtu.be/uxgyZzOmVIw)
 //! - [Part 4: Build the spinner](https://www.youtube.com/watch?v=fcb6rstRniI)
-//! - [Part 5: Add color gradient animation to spinner](https://www.youtube.com/watch?v=_QjsGDds270)
+//! - [Part 5: Add color gradient animation to
+//!   spinner](https://www.youtube.com/watch?v=_QjsGDds270)
 //! - [Part 6: Publish the crate and overview](https://youtu.be/X5wDVaZENOo)
-//! - [Testing playlist](https://www.youtube.com/watch?v=Xt495QLrFFk&list=PLofhE49PEwmwLR_4Noa0dFOSPmSpIg_l8)
+//! - [Testing
+//!   playlist](https://www.youtube.com/watch?v=Xt495QLrFFk&list=PLofhE49PEwmwLR_4Noa0dFOSPmSpIg_l8)
 //!   - [Part 1: Intro](https://www.youtube.com/watch?v=Xt495QLrFFk)
 //!   - [Part 2: Deep dive](https://www.youtube.com/watch?v=4iM9t5dgvU4)
 //! - Playlists
-//!   - [Build with Naz, async readline and spinner for CLI in Rust](https://www.youtube.com/watch?v=3vQJguti02I&list=PLofhE49PEwmwelPkhfiqdFQ9IXnmGdnSE)
-//!   - [Build with Naz, testing in Rust](https://www.youtube.com/watch?v=Xt495QLrFFk&list=PLofhE49PEwmwLR_4Noa0dFOSPmSpIg_l8)
+//!   - [Build with Naz, async readline and spinner for CLI in
+//!     Rust](https://www.youtube.com/watch?v=3vQJguti02I&list=PLofhE49PEwmwelPkhfiqdFQ9IXnmGdnSE)
+//!   - [Build with Naz, testing in
+//!     Rust](https://www.youtube.com/watch?v=Xt495QLrFFk&list=PLofhE49PEwmwLR_4Noa0dFOSPmSpIg_l8)
 //!
 //! # Why another async readline crate?
 //!
@@ -251,7 +256,8 @@
 //! # More info on Linux TTY
 //!
 //! - [TTY Demystified](https://www.linusakesson.net/programming/tty/)
-//! - [Deep dive into Unix shells, ptys, etc.](https://www.youtube.com/playlist?list=PLFAC320731F539902)
+//! - [Deep dive into Unix shells, ptys,
+//!   etc.](https://www.youtube.com/playlist?list=PLFAC320731F539902)
 
 // Attach sources.
 pub mod public_api;

--- a/terminal_async/src/public_api/spinner.rs
+++ b/terminal_async/src/public_api/spinner.rs
@@ -84,7 +84,7 @@ impl Spinner {
         // Pause the terminal.
         let _ = self
             .shared_writer
-            .line_sender
+            .line_channel_sender
             .send(LineControlSignal::Pause)
             .await;
 
@@ -154,7 +154,7 @@ impl Spinner {
         // Resume the terminal.
         let _ = self
             .shared_writer
-            .line_sender
+            .line_channel_sender
             .send(LineControlSignal::Resume)
             .await;
         Ok(())

--- a/terminal_async/src/public_api/terminal_async.rs
+++ b/terminal_async/src/public_api/terminal_async.rs
@@ -128,7 +128,7 @@ impl TerminalAsync {
     pub async fn flush(&mut self) {
         let _ = self
             .shared_writer
-            .line_sender
+            .line_channel_sender
             .send(crate::LineControlSignal::Flush)
             .await;
     }
@@ -136,7 +136,7 @@ impl TerminalAsync {
     pub async fn pause(&mut self) {
         let _ = self
             .shared_writer
-            .line_sender
+            .line_channel_sender
             .send(crate::LineControlSignal::Pause)
             .await;
     }
@@ -144,16 +144,9 @@ impl TerminalAsync {
     pub async fn resume(&mut self) {
         let _ = self
             .shared_writer
-            .line_sender
+            .line_channel_sender
             .send(crate::LineControlSignal::Resume)
             .await;
-    }
-
-    /// Close the underlying [Readline] instance. This will terminate all the tasks that
-    /// are managing [SharedWriter] tasks. This is useful when you want to exit the CLI
-    /// event loop, typically when the user requests it.
-    pub fn close(&mut self) {
-        self.readline.close();
     }
 
     pub fn print_exit_message(message: &str) -> miette::Result<()> {


### PR DESCRIPTION
[core]
- Add new function in debug_file_log() for quick debugging

[terminal_async]
- Make it simple to use TerminalAsync and Readline, so that
  simply dropping Readline is sufficient to shut everything
  down.
- You can look at the examples/terminal_async.rs to see how
  this works.