### PR TITLE
Implement GCString iterator and fix AST cache regression in demos

### DIFF
--- a/core/src/tui_core/color_wheel/color_wheel_impl.rs
+++ b/core/src/tui_core/color_wheel/color_wheel_impl.rs
@@ -482,8 +482,7 @@ impl ColorWheel {
             };
 
             // Loop: Colorize each (next) character w/ (next) color.
-            for seg in us.iter() {
-                let next_character = seg.get_str(us);
+            for next_seg_str in us.iter() {
                 let maybe_next_bg_color = self.next_color();
 
                 if let Some(next_bg_color) = maybe_next_bg_color {
@@ -519,18 +518,18 @@ impl ColorWheel {
                                 Some(tui_color!(fg_red, fg_green, fg_blue)),
                                 Some(tui_color!(bg_red, bg_green, bg_blue)),
                             ),
-                            @text: next_character,
+                            @text: next_seg_str,
                         );
                     } else {
                         acc += tui_styled_text!(
                             @style: inner::gen_style_fg_bg_color_for(maybe_style, None, None,),
-                            @text: next_character,
+                            @text: next_seg_str,
                         );
                     }
                 } else {
                     acc += tui_styled_text!(
                         @style: inner::gen_style_fg_bg_color_for(maybe_style, None, None,),
-                        @text: next_character,
+                        @text: next_seg_str,
                     );
                 }
             }
@@ -541,12 +540,11 @@ impl ColorWheel {
         // Handle regular case.
         match text_colorization_policy {
             TextColorizationPolicy::ColorEachCharacter(maybe_style) => {
-                for seg in us.iter() {
-                    let next_character = seg.get_str(us);
+                for next_seg_str in us.iter() {
                     // Loop: Colorize each (next) character w/ (next) color.
                     acc += tui_styled_text!(
                         @style: inner::gen_style_fg_color_for(maybe_style, self.next_color()),
-                        @text: next_character,
+                        @text: next_seg_str,
                     );
                 }
             }

--- a/core/src/tui_core/color_wheel/lolcat_impl.rs
+++ b/core/src/tui_core/color_wheel/lolcat_impl.rs
@@ -61,7 +61,7 @@ impl Lolcat {
     pub fn colorize_to_styled_texts(&mut self, us: &GCString) -> TuiStyledTexts {
         let mut acc = TuiStyledTexts::default();
 
-        for seg in us.iter() {
+        for seg_str in us.iter() {
             let new_color = ColorUtils::get_color_tuple(&self.color_wheel_control);
             let derived_from_new_color = ColorUtils::calc_fg_color(new_color);
 
@@ -86,7 +86,7 @@ impl Lolcat {
 
             acc += tui_styled_text!(
                 @style: style,
-                @text: seg.get_str(us),
+                @text: seg_str,
             );
 
             self.color_wheel_control.seed +=

--- a/tui/examples/demo/ex_pitch/app_main.rs
+++ b/tui/examples/demo/ex_pitch/app_main.rs
@@ -144,16 +144,16 @@ mod app_main_impl_app_trait {
             component_registry_map: &mut ComponentRegistryMap<State, AppSignal>,
             has_focus: &mut HasFocus,
         ) -> CommonResult<EventPropagation> {
-            // Things from global scope.
-            let GlobalData { state, .. } = global_data;
-
             // Ctrl + n => next slide.
             if input_event.matches_keypress(KeyPress::WithModifiers {
                 key: Key::Character('n'),
                 mask: ModifierKeysMask::new().with_ctrl(),
             }) {
-                // Update state and re-render.
-                state_mutator::next_slide(state);
+                // Spawn next slide action.
+                send_signal!(
+                    global_data.main_thread_channel_sender,
+                    TerminalWindowMainThreadSignal::ApplyAppSignal(AppSignal::NextSlide)
+                );
                 return Ok(EventPropagation::ConsumedRender);
             };
 
@@ -165,9 +165,7 @@ mod app_main_impl_app_trait {
                 // Spawn previous slide action.
                 send_signal!(
                     global_data.main_thread_channel_sender,
-                    TerminalWindowMainThreadSignal::ApplyAppSignal(
-                        AppSignal::PreviousSlide
-                    )
+                    TerminalWindowMainThreadSignal::ApplyAppSignal(AppSignal::PrevSlide)
                 );
                 return Ok(EventPropagation::ConsumedRender);
             };
@@ -187,15 +185,19 @@ mod app_main_impl_app_trait {
             &mut self,
             action: &AppSignal,
             global_data: &mut GlobalData<State, AppSignal>,
-            _component_registry_map: &mut ComponentRegistryMap<State, AppSignal>,
+            component_registry_map: &mut ComponentRegistryMap<State, AppSignal>,
             _has_focus: &mut HasFocus,
         ) -> CommonResult<EventPropagation> {
             throws_with_return!({
                 let state = &mut global_data.state;
                 match action {
                     AppSignal::Noop => {}
-                    AppSignal::NextSlide => state_mutator::next_slide(state),
-                    AppSignal::PreviousSlide => state_mutator::prev_slide(state),
+                    AppSignal::NextSlide => {
+                        state_mutator::next_slide(state, component_registry_map)
+                    }
+                    AppSignal::PrevSlide => {
+                        state_mutator::prev_slide(state, component_registry_map)
+                    }
                 };
                 EventPropagation::ConsumedRender
             });

--- a/tui/examples/demo/ex_pitch/state.rs
+++ b/tui/examples/demo/ex_pitch/state.rs
@@ -18,6 +18,7 @@ use std::{collections::HashMap,
           fmt::{Debug, Formatter, Result}};
 
 use r3bl_tui::{editor_buffer::EditorBuffer,
+               ComponentRegistryMap,
                FlexBoxId,
                HasEditorBuffers,
                DEFAULT_SYN_HI_FILE_EXT};
@@ -49,7 +50,20 @@ pub struct State {
 pub mod state_mutator {
     use super::*;
 
-    pub fn next_slide(state: &mut State) {
+    pub fn reset_editor_engine_ast_cache(
+        component_registry_map: &mut ComponentRegistryMap<State, AppSignal>,
+    ) {
+        // Reset the editor component to the current state.
+        let id = FlexBoxId::from(Id::Editor);
+        if let Some(editor_component) = component_registry_map.get_mut(&id) {
+            editor_component.reset();
+        }
+    }
+
+    pub fn next_slide(
+        state: &mut State,
+        component_registry_map: &mut ComponentRegistryMap<State, AppSignal>,
+    ) {
         if state.current_slide_index < FILE_CONTENT_ARRAY.len() - 1 {
             state.current_slide_index += 1;
             state
@@ -57,11 +71,15 @@ pub mod state_mutator {
                 .entry(FlexBoxId::from(Id::Editor as u8))
                 .and_modify(|it| {
                     it.set_lines(get_slide_content(state.current_slide_index));
+                    reset_editor_engine_ast_cache(component_registry_map);
                 });
         }
     }
 
-    pub fn prev_slide(state: &mut State) {
+    pub fn prev_slide(
+        state: &mut State,
+        component_registry_map: &mut ComponentRegistryMap<State, AppSignal>,
+    ) {
         if state.current_slide_index > 0 {
             state.current_slide_index -= 1;
             state
@@ -69,6 +87,7 @@ pub mod state_mutator {
                 .entry(FlexBoxId::from(Id::Editor as u8))
                 .and_modify(|it| {
                     it.set_lines(get_slide_content(state.current_slide_index));
+                    reset_editor_engine_ast_cache(component_registry_map);
                 });
         }
     }
@@ -136,7 +155,7 @@ pub enum AppSignal {
     #[default]
     Noop,
     NextSlide,
-    PreviousSlide,
+    PrevSlide,
 }
 
 mod debug_format_helpers {

--- a/tui/examples/demo/ex_rc/app_main.rs
+++ b/tui/examples/demo/ex_rc/app_main.rs
@@ -246,14 +246,14 @@ mod app_main_impl_app_trait {
             let AppData { animator, .. } = &mut self.data;
 
             // Things from global scope.
-            let GlobalData { state, .. } = global_data;
+            let GlobalData { .. } = global_data;
 
             // Ctrl + n => next slide.
             if input_event.matches_keypress(KeyPress::WithModifiers {
                 key: Key::Character('n'),
                 mask: ModifierKeysMask::new().with_ctrl(),
             }) {
-                // Spawn previous slide action.
+                // Spawn next slide action.
                 send_signal!(
                     global_data.main_thread_channel_sender,
                     TerminalWindowMainThreadSignal::ApplyAppSignal(AppSignal::NextSlide)
@@ -269,9 +269,7 @@ mod app_main_impl_app_trait {
                 // Spawn previous slide action.
                 send_signal!(
                     global_data.main_thread_channel_sender,
-                    TerminalWindowMainThreadSignal::ApplyAppSignal(
-                        AppSignal::PreviousSlide
-                    )
+                    TerminalWindowMainThreadSignal::ApplyAppSignal(AppSignal::PrevSlide)
                 );
                 return Ok(EventPropagation::Consumed);
             };
@@ -309,7 +307,7 @@ mod app_main_impl_app_trait {
                     AppSignal::NextSlide => {
                         state_mutator::next_slide(state, component_registry_map);
                     }
-                    AppSignal::PreviousSlide => {
+                    AppSignal::PrevSlide => {
                         state_mutator::prev_slide(state, component_registry_map);
                     }
                 };

--- a/tui/examples/demo/ex_rc/state.rs
+++ b/tui/examples/demo/ex_rc/state.rs
@@ -38,7 +38,7 @@ pub enum AppSignal {
     #[default]
     Noop,
     NextSlide,
-    PreviousSlide,
+    PrevSlide,
 }
 
 #[derive(Clone, PartialEq)]

--- a/tui/examples/demo/ex_rc/state.rs
+++ b/tui/examples/demo/ex_rc/state.rs
@@ -14,11 +14,14 @@
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-
 use std::{collections::HashMap,
           fmt::{Debug, Formatter, Result}};
 
-use r3bl_tui::{EditorBuffer, FlexBoxId, HasEditorBuffers, DEFAULT_SYN_HI_FILE_EXT};
+use r3bl_tui::{ComponentRegistryMap,
+               EditorBuffer,
+               FlexBoxId,
+               HasEditorBuffers,
+               DEFAULT_SYN_HI_FILE_EXT};
 
 use crate::ex_rc::Id;
 
@@ -47,7 +50,20 @@ pub struct State {
 pub mod state_mutator {
     use super::*;
 
-    pub fn next_slide(state: &mut State) {
+    pub fn reset_editor_engine_ast_cache(
+        component_registry_map: &mut ComponentRegistryMap<State, AppSignal>,
+    ) {
+        // Reset the editor component to the current state.
+        let id = FlexBoxId::from(Id::Editor);
+        if let Some(editor_component) = component_registry_map.get_mut(&id) {
+            editor_component.reset();
+        }
+    }
+
+    pub fn next_slide(
+        state: &mut State,
+        component_registry_map: &mut ComponentRegistryMap<State, AppSignal>,
+    ) {
         if state.current_slide_index < FILE_CONTENT_ARRAY.len() - 1 {
             state.current_slide_index += 1;
             state
@@ -55,11 +71,15 @@ pub mod state_mutator {
                 .entry(FlexBoxId::from(Id::Editor as u8))
                 .and_modify(|it| {
                     it.set_lines(get_slide_content(state.current_slide_index));
+                    reset_editor_engine_ast_cache(component_registry_map);
                 });
         }
     }
 
-    pub fn prev_slide(state: &mut State) {
+    pub fn prev_slide(
+        state: &mut State,
+        component_registry_map: &mut ComponentRegistryMap<State, AppSignal>,
+    ) {
         if state.current_slide_index > 0 {
             state.current_slide_index -= 1;
             state
@@ -67,6 +87,7 @@ pub mod state_mutator {
                 .entry(FlexBoxId::from(Id::Editor as u8))
                 .and_modify(|it| {
                     it.set_lines(get_slide_content(state.current_slide_index));
+                    reset_editor_engine_ast_cache(component_registry_map);
                 });
         }
     }

--- a/tui/src/tui/editor/editor_component/editor_component_struct.rs
+++ b/tui/src/tui/editor/editor_component/editor_component_struct.rs
@@ -93,7 +93,7 @@ pub mod editor_component_impl_component_trait {
         S: HasEditorBuffers + Default + Clone + Debug + Sync + Send,
         AS: Debug + Default + Clone + Sync + Send,
     {
-        fn reset(&mut self) {}
+        fn reset(&mut self) { self.data.editor_engine.clear_ast_cache(); }
 
         fn get_id(&self) -> FlexBoxId { self.data.id }
 

--- a/tui/src/tui/syntax_highlighting/intermediate_types.rs
+++ b/tui/src/tui/syntax_highlighting/intermediate_types.rs
@@ -182,8 +182,8 @@ impl StyleUSSpanLine {
 
             let mut clipped_text_fragment = InlineString::new();
 
-            for seg in text_gcs.iter() {
-                for character in seg.get_str(text_gcs).chars() {
+            for seg_str in text_gcs.iter() {
+                for character in seg_str.chars() {
                     match matcher.match_next(character) {
                         CharacterMatchResult::Keep => {
                             clipped_text_fragment.push(character);

--- a/tui/src/tui/terminal_lib_backends/render_pipeline_to_offscreen_buffer.rs
+++ b/tui/src/tui/terminal_lib_backends/render_pipeline_to_offscreen_buffer.rs
@@ -268,7 +268,7 @@ pub fn print_plain_text(
 
     // Loop over each grapheme cluster segment (the character) in `text_ref_gcs` (text in
     // a line). For each GraphemeClusterSegment, create a PixelChar.
-    for seg in text_gcs.iter() {
+    for seg in text_gcs.seg_iter() {
         let segment_display_width = usize(*seg.display_width);
         if segment_display_width == 0 {
             continue;


### PR DESCRIPTION
Introduce a simple iterator for GCString that yields logical string segments, simplifying indexing operations. Fix the AST cache regression affecting the demo examples, ensuring that Ctrl+P and Ctrl+N function correctly to render new data.

Fixes #392, #394