### PR TITLE
[tui] Add clip() and convert() to ASText and clean up naming

### DIFF
--- a/cmdr/src/analytics_client/ui_str.rs
+++ b/cmdr/src/analytics_client/ui_str.rs
@@ -117,7 +117,7 @@ pub mod upgrade_check {
         let plain_text_exit_msg = inline_string!(
             "\n{a}\n{b}\n",
             a = inline_string!(
-                "🎁 A new version of {} is available.",
+                "A new version of {} is available. 🎁",
                 get_self_bin_name()
             ),
             b = inline_string!(

--- a/cmdr/src/common/ui_templates.rs
+++ b/cmdr/src/common/ui_templates.rs
@@ -15,7 +15,7 @@
  *   limitations under the License.
  */
 
-use r3bl_tui::{AST,
+use r3bl_tui::{ASText,
                AnsiStyledText,
                InlineVec,
                TuiStyle,
@@ -48,7 +48,7 @@ fn fmt_two_col(col_1: &str, col_2: &str) -> String {
 /// The last line is passed in as a parameter to allow for customization. This is useful
 /// when the list is long and the instructions are at the top.
 pub fn prefix_multi_select_instruction_header(
-    last_lines: InlineVec<InlineVec<AST>>,
+    last_lines: InlineVec<InlineVec<ASText>>,
 ) -> InlineVec<InlineVec<AnsiStyledText>> {
     let text_up_and_down = fmt_two_col("Up or down:", "navigate");
     let text_space = fmt_two_col("Space:", "select or deselect item");
@@ -76,8 +76,8 @@ pub fn prefix_multi_select_instruction_header(
 /// can only select one item from the list. The instructions are displayed at the top of
 /// the list. This is easily converted into a [r3bl_tui::choose_impl::Header::MultiLine].
 pub fn prefix_single_select_instruction_header(
-    last_lines: InlineVec<InlineVec<AST>>,
-) -> InlineVec<InlineVec<AST>> {
+    last_lines: InlineVec<InlineVec<ASText>>,
+) -> InlineVec<InlineVec<ASText>> {
     let text_up_or_down = fmt_two_col("Up or down:", "navigate");
     let text_esc = fmt_two_col("Esc or Ctrl+C:", "exit program");
     let text_return_key = fmt_two_col("Return:", "confirm selection");

--- a/cmdr/src/giti/branch/branch_delete_command.rs
+++ b/cmdr/src/giti/branch/branch_delete_command.rs
@@ -14,7 +14,7 @@
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-use r3bl_tui::{AST,
+use r3bl_tui::{ASText,
                CommandRunResult,
                CommonResult,
                DefaultIoDevices,
@@ -222,7 +222,7 @@ mod user_interaction {
         // the lines. Then prefix with the instruction header.
         let header_with_instructions = {
             let mut header_last_lines = header_text.lines();
-            let mut header_last_lines_fmt: InlineVec<InlineVec<AST>> = smallvec![];
+            let mut header_last_lines_fmt: InlineVec<InlineVec<ASText>> = smallvec![];
 
             if let Some(first_line) = header_last_lines.next() {
                 let first_line = ast_line![ast(

--- a/done.md
+++ b/done.md
@@ -205,3 +205,13 @@
   - [x] `giti/ui_str.rs`
 - [x] introduce consistent imperative formatting for `giti` and `edi`
 - [x] fix `giti branch checkout`
+
+# clean up giti phase 11
+
+- [x] rename `AST` -> `ASText`, etc.
+- [x] evaluate the use of `AST[]` -> `PixelChar[]` which can then be clipped for `readline_async`
+      prompt, `spinner`, and `choose` display. not all `ui_str::*` functions have to be changed,
+      just the ones that are related to the prompt and spinner displays
+  - `tui/src/core/tui_core/spinner_impl/spinner_render.rs:58`
+  - `tui/src/readline_async/readline_async_api.rs:121`
+  - [issue](https://github.com/r3bl-org/r3bl-open-core/issues/420)

--- a/todo.md
+++ b/todo.md
@@ -41,6 +41,7 @@
 
 # create sub-issues for giti https://github.com/r3bl-org/r3bl-open-core/issues/391
 
+- [ ] `giti branch rename` -> rename an existing branch to other
 - [ ] `giti show <name>` -> choose an older version of a file to checkout to `Downloads` and
       optionally view in the `editor_component` itself in a TUI applet
 - [ ] `giti develop *` -> choose issues using TUI app as part of the flow

--- a/tui/src/core/ansi/ansi_styled_text.rs
+++ b/tui/src/core/ansi/ansi_styled_text.rs
@@ -22,9 +22,14 @@ use strum_macros::EnumCount;
 
 use crate::{inline_string,
             tui_color,
+            tui_style::tui_style_attrib::*,
             ASTColor,
+            ColIndex,
+            ColWidth,
+            GCString,
             InlineString,
             InlineVec,
+            PixelChar,
             SgrCode,
             TuiStyle};
 
@@ -48,7 +53,7 @@ use crate::{inline_string,
 /// ```rust
 /// # use r3bl_tui::{
 /// #     TuiStyle, tui_color, new_style,
-/// #     ast, fg_red, dim, AST, fg_color,
+/// #     ast, fg_red, dim, ASText, fg_color,
 /// #     ASTStyle, ASTColor,
 /// # };
 ///
@@ -75,7 +80,7 @@ use crate::{inline_string,
 /// blue_text_on_white.println();
 ///
 /// // Verbose struct construction (don't use this).
-/// AST {
+/// ASText {
 ///     text: "Print a formatted (bold, italic, underline) string w/ ANSI color codes.".into(),
 ///     styles: smallvec::smallvec![
 ///         ASTStyle::Bold,
@@ -92,15 +97,15 @@ pub struct AnsiStyledText {
     pub text: InlineString,
     /// You can supply this directly, or use [crate::new_style!] to create a
     /// [crate::TuiStyle] and convert it to this type using `.into()`.
-    pub styles: ASTStyles,
+    pub styles: ASTextStyles,
 }
 
 // Type aliases for better readability.
 
-pub type AST = AnsiStyledText;
-pub type ASTLine = InlineVec<AnsiStyledText>;
-pub type ASTLines = InlineVec<ASTLine>;
-pub type ASTStyles = sizing::InlineVecASTStyles;
+pub type ASText = AnsiStyledText;
+pub type ASTextLine = InlineVec<AnsiStyledText>;
+pub type ASTextLines = InlineVec<ASTextLine>;
+pub type ASTextStyles = sizing::InlineVecASTextStyles;
 
 pub(in crate::core::ansi) mod sizing {
     use super::*;
@@ -108,15 +113,15 @@ pub(in crate::core::ansi) mod sizing {
     /// Attributes are: color_fg, color_bg, bold, dim, italic, underline, reverse, hidden,
     /// etc. which are in [crate::ASTStyle].
     pub const MAX_ANSI_STYLED_TEXT_STYLE_ATTRIB_SIZE: usize = 12;
-    pub type InlineVecASTStyles =
+    pub type InlineVecASTextStyles =
         SmallVec<[ASTStyle; MAX_ANSI_STYLED_TEXT_STYLE_ATTRIB_SIZE]>;
 }
 
 /// Easy to use constructor function, instead of creating a new [AnsiStyledText] struct
 /// directly. If you need to assemble a bunch of these together, you can use
 /// [crate::ast_line!] to create a list of them.
-pub fn ast(arg_text: impl AsRef<str>, arg_styles: impl Into<ASTStyles>) -> AST {
-    AST {
+pub fn ast(arg_text: impl AsRef<str>, arg_styles: impl Into<ASTextStyles>) -> ASText {
+    ASText {
         text: arg_text.as_ref().into(),
         styles: arg_styles.into(),
     }
@@ -130,8 +135,8 @@ macro_rules! ast_line {
     (
         $( $ast_chunk:expr ),* $(,)?
     ) => {{
-        use $crate::{InlineVec, ASTLine};
-        let mut acc: ASTLine = InlineVec::new();
+        use $crate::{InlineVec, ASTextLine};
+        let mut acc: ASTextLine = InlineVec::new();
         $(
             acc.push($ast_chunk);
         )*
@@ -147,8 +152,8 @@ macro_rules! ast_lines {
     (
         $( $ast_line:expr ),* $(,)?
     ) => {{
-        use $crate::{InlineVec, ASTLines};
-        let mut acc: ASTLines = InlineVec::new();
+        use $crate::{InlineVec, ASTextLines};
+        let mut acc: ASTextLines = InlineVec::new();
         $(
             acc.push($ast_line);
         )*
@@ -156,8 +161,23 @@ macro_rules! ast_lines {
     }};
 }
 
-mod ansi_styled_text_impl {
+pub mod ansi_styled_text_impl {
     use super::*;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+    pub struct ASTextConvertOptions {
+        pub start: Option<ColIndex>,
+        pub end: Option<ColIndex>,
+    }
+
+    impl From<ColWidth> for ASTextConvertOptions {
+        fn from(col_width: ColWidth) -> Self {
+            Self {
+                start: Some(0.into()),
+                end: Some(col_width.convert_to_col_index()),
+            }
+        }
+    }
 
     impl AnsiStyledText {
         pub fn println(&self) {
@@ -168,51 +188,140 @@ mod ansi_styled_text_impl {
 
         /// This is different from the [Display] trait implementation, because it doesn't
         /// allocate a new [String], but instead allocates an inline buffer on the stack.
-        /// If this buffer gets larger than [DEFAULT_STRING_STORAGE_SIZE], it will
-        /// spill to the heap.
         pub fn to_small_str(&self) -> InlineString { inline_string!("{self}") }
+
+        /// This is a convenience function to clip the text to a certain display width.
+        /// You can also clip it to any given start and end index (inclusive).
+        pub fn clip(&self, arg_options: impl Into<ASTextConvertOptions>) -> ASText {
+            let ir_text = self.convert(arg_options);
+
+            let mut acc = InlineString::with_capacity(self.text.len());
+            for pixel_char in ir_text.iter() {
+                if let PixelChar::PlainText {
+                    text,
+                    maybe_style: _,
+                } = pixel_char
+                {
+                    use std::fmt::Write as _;
+                    _ = write!(acc, "{text}");
+                }
+            }
+
+            ASText {
+                text: acc,
+                styles: self.styles.clone(),
+            }
+        }
+
+        /// Converts the text to a vector of [PixelChar]s. This is used for rendering the
+        /// text on the screen.
+        /// - To clip the text to a certain display width you can pass in the [ColWidth]
+        ///   to this function.
+        /// - To convert the entire text, just pass in [ASTextConvertOptions::default()]
+        ///   function.
+        /// - To convert a range of text, pass in the start and end indices. Note that it
+        ///   will be inclusive (not the default Rust behavior), so the end index will be
+        ///   included in the result.
+        pub fn convert(
+            &self,
+            arg_options: impl Into<ASTextConvertOptions>,
+        ) -> InlineVec<PixelChar> {
+            let ASTextConvertOptions { start, end } = arg_options.into();
+
+            // 1. Early return if the text is empty.
+            if self.text.is_empty() {
+                return InlineVec::new();
+            }
+
+            // 2. Convert self.styles to Option<TuiStyle>.
+            let maybe_tui_style: Option<TuiStyle> = if self.styles.is_empty() {
+                None
+            } else {
+                Some(self.styles.clone().into())
+            };
+
+            // 3. Iterate through characters and create PixelChar with maybe_tui_style.
+            let pixel_chars = {
+                let mut acc: InlineVec<PixelChar> =
+                    InlineVec::with_capacity(self.text.len());
+                let gc_string = GCString::from(&self.text);
+                for item in gc_string.iter() {
+                    let pixel_char = PixelChar::PlainText {
+                        text: item.into(),
+                        maybe_style: maybe_tui_style,
+                    };
+                    acc.push(pixel_char);
+                }
+                acc
+            };
+
+            // 4. Handle start and end inclusive indices, and slice the result.
+            let end_index = match end {
+                None => pixel_chars.len().saturating_sub(1),
+                Some(it) => it.as_usize(),
+            };
+            let start_index = match start {
+                None => 0,
+                Some(it) => it.as_usize(),
+            };
+
+            // 4.1. Validate indices, and return empty InlineVec if invalid.
+            if pixel_chars.is_empty()
+                || start_index > end_index
+                || start_index >= pixel_chars.len()
+                || end_index >= pixel_chars.len()
+            {
+                return InlineVec::new();
+            }
+
+            // Slice and collect into a new InlineVec
+            pixel_chars[start_index..=end_index]
+                .iter()
+                .cloned()
+                .collect()
+        }
     }
 }
 
 // The following functions are convenience functions for providing ANSI attributes.
 
-pub fn bold(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn bold(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Bold),
     }
 }
 
-pub fn italic(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn italic(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Italic),
     }
 }
 
-pub fn underline(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn underline(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Underline),
     }
 }
 
-pub fn strikethrough(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn strikethrough(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Strikethrough),
     }
 }
 
-pub fn dim(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn dim(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Dim),
     }
 }
 
-pub fn dim_underline(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn dim_underline(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Dim, ASTStyle::Underline),
     }
@@ -220,8 +329,8 @@ pub fn dim_underline(text: impl AsRef<str>) -> AST {
 
 // The following function is a convenience function for providing any color.
 
-pub fn fg_color(arg_color: impl Into<ASTColor>, text: &str) -> AST {
-    AST {
+pub fn fg_color(arg_color: impl Into<ASTColor>, text: &str) -> ASText {
+    ASText {
         text: text.into(),
         styles: smallvec!(ASTStyle::Foreground(arg_color.into())),
     }
@@ -230,72 +339,72 @@ pub fn fg_color(arg_color: impl Into<ASTColor>, text: &str) -> AST {
 // The following functions are convenience functions for providing ANSI colors.
 
 /// More info: <https://www.ditig.com/256-colors-cheat-sheet>
-pub fn fg_dark_gray(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_dark_gray(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(ASTColor::Ansi(236.into()))),
     }
 }
 
 /// More info: <https://www.ditig.com/256-colors-cheat-sheet>
-pub fn fg_black(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_black(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(ASTColor::Ansi(0.into()))),
     }
 }
 
 /// More info: <https://www.ditig.com/256-colors-cheat-sheet>
-pub fn fg_yellow(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_yellow(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(ASTColor::Ansi(226.into()))),
     }
 }
 
 /// More info: <https://www.ditig.com/256-colors-cheat-sheet>
-pub fn fg_green(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_green(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(ASTColor::Ansi(34.into()))),
     }
 }
 
 /// More info: <https://www.ditig.com/256-colors-cheat-sheet>
-pub fn fg_blue(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_blue(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(ASTColor::Ansi(27.into()))),
     }
 }
 
 /// More info: <https://www.ditig.com/256-colors-cheat-sheet>
-pub fn fg_red(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_red(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(ASTColor::Ansi(196.into()))),
     }
 }
 
 /// More info: <https://www.ditig.com/256-colors-cheat-sheet>
-pub fn fg_white(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_white(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(ASTColor::Ansi(231.into()))),
     }
 }
 
 /// More info: <https://www.ditig.com/256-colors-cheat-sheet>
-pub fn fg_cyan(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_cyan(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(ASTColor::Ansi(51.into()))),
     }
 }
 
 /// More info: <https://www.ditig.com/256-colors-cheat-sheet>
-pub fn fg_magenta(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_magenta(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(ASTColor::Ansi(201.into()))),
     }
@@ -303,50 +412,50 @@ pub fn fg_magenta(text: impl AsRef<str>) -> AST {
 
 // The following colors are a convenience for using the [crate::tui_color!] macro.
 
-pub fn fg_medium_gray(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_medium_gray(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(crate::tui_color!(medium_gray).into())),
     }
 }
 
-pub fn fg_light_cyan(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_light_cyan(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(crate::tui_color!(light_cyan).into())),
     }
 }
 
-pub fn fg_light_purple(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_light_purple(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(crate::tui_color!(light_purple).into())),
     }
 }
 
-pub fn fg_deep_purple(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_deep_purple(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(crate::tui_color!(deep_purple).into())),
     }
 }
 
-pub fn fg_soft_pink(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_soft_pink(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(crate::tui_color!(soft_pink).into())),
     }
 }
 
-pub fn fg_hot_pink(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_hot_pink(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(crate::tui_color!(hot_pink).into())),
     }
 }
 
-pub fn fg_light_yellow_green(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_light_yellow_green(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(
             crate::tui_color!(light_yellow_green).into()
@@ -354,43 +463,43 @@ pub fn fg_light_yellow_green(text: impl AsRef<str>) -> AST {
     }
 }
 
-pub fn fg_dark_teal(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_dark_teal(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(crate::tui_color!(dark_teal).into())),
     }
 }
 
-pub fn fg_bright_cyan(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_bright_cyan(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(crate::tui_color!(bright_cyan).into())),
     }
 }
 
-pub fn fg_dark_purple(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_dark_purple(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(crate::tui_color!(dark_purple).into())),
     }
 }
 
-pub fn fg_sky_blue(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_sky_blue(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(crate::tui_color!(sky_blue).into())),
     }
 }
 
-pub fn fg_lavender(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_lavender(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(crate::tui_color!(lavender).into())),
     }
 }
 
-pub fn fg_dark_lizard_green(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_dark_lizard_green(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(
             crate::tui_color!(dark_lizard_green).into()
@@ -398,15 +507,15 @@ pub fn fg_dark_lizard_green(text: impl AsRef<str>) -> AST {
     }
 }
 
-pub fn fg_orange(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_orange(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(crate::tui_color!(orange).into())),
     }
 }
 
-pub fn fg_silver_metallic(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_silver_metallic(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(
             crate::tui_color!(silver_metallic).into()
@@ -414,49 +523,49 @@ pub fn fg_silver_metallic(text: impl AsRef<str>) -> AST {
     }
 }
 
-pub fn fg_lizard_green(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_lizard_green(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(crate::tui_color!(lizard_green).into())),
     }
 }
 
-pub fn fg_pink(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_pink(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(crate::tui_color!(pink).into())),
     }
 }
 
-pub fn fg_dark_pink(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_dark_pink(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(crate::tui_color!(dark_pink).into())),
     }
 }
 
-pub fn fg_frozen_blue(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_frozen_blue(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(crate::tui_color!(frozen_blue).into())),
     }
 }
 
-pub fn fg_guards_red(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_guards_red(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(crate::tui_color!(guards_red).into())),
     }
 }
 
-pub fn fg_slate_gray(text: impl AsRef<str>) -> AST {
-    AST {
+pub fn fg_slate_gray(text: impl AsRef<str>) -> ASText {
+    ASText {
         text: text.as_ref().into(),
         styles: smallvec!(ASTStyle::Foreground(crate::tui_color!(slate_gray).into())),
     }
 }
 
-impl AST {
+impl ASText {
     pub fn dim(mut self) -> Self {
         self.styles.push(ASTStyle::Dim);
         self
@@ -552,12 +661,44 @@ pub enum ASTStyle {
     Strikethrough,
 }
 
-mod convert_tui_style_to_vec_ast_style {
-    use super::{sizing::InlineVecASTStyles, *};
+mod convert_vec_ast_style_to_tui_style {
+    use super::*;
 
-    impl From<TuiStyle> for sizing::InlineVecASTStyles {
+    impl From<ASTextStyles> for TuiStyle {
+        fn from(styles: ASTextStyles) -> Self {
+            let mut tui_style = TuiStyle::default();
+            for style in styles {
+                match style {
+                    ASTStyle::Foreground(color) => {
+                        tui_style.color_fg = Some(color.into())
+                    }
+                    ASTStyle::Background(color) => {
+                        tui_style.color_bg = Some(color.into())
+                    }
+                    ASTStyle::Bold => tui_style.bold = Some(Bold),
+                    ASTStyle::Dim => tui_style.dim = Some(Dim),
+                    ASTStyle::Italic => tui_style.italic = Some(Italic),
+                    ASTStyle::Underline => tui_style.underline = Some(Underline),
+                    ASTStyle::Invert => tui_style.reverse = Some(Reverse),
+                    ASTStyle::Hidden => tui_style.hidden = Some(Hidden),
+                    ASTStyle::Strikethrough => {
+                        tui_style.strikethrough = Some(Strikethrough)
+                    }
+                    // TuiStyle doesn't have direct equivalents for these:
+                    ASTStyle::Overline | ASTStyle::RapidBlink | ASTStyle::SlowBlink => {}
+                }
+            }
+            tui_style
+        }
+    }
+}
+
+mod convert_tui_style_to_vec_ast_style {
+    use super::{sizing::InlineVecASTextStyles, *};
+
+    impl From<TuiStyle> for sizing::InlineVecASTextStyles {
         fn from(tui_style: TuiStyle) -> Self {
-            let mut styles = InlineVecASTStyles::new();
+            let mut styles = InlineVecASTextStyles::new();
             if tui_style.bold.is_some() {
                 styles.push(ASTStyle::Bold);
             }
@@ -685,7 +826,7 @@ mod style_impl {
 mod display_trait_impl {
     use super::*;
 
-    impl Display for AST {
+    impl Display for ASText {
         fn fmt(&self, f: &mut Formatter<'_>) -> Result {
             for style_item in &self.styles {
                 write!(f, "{style_item}")?;
@@ -704,7 +845,8 @@ mod tests {
     use smallvec::smallvec;
 
     use super::dim;
-    use crate::{ansi::sizing::InlineVecASTStyles,
+    use crate::{ansi::sizing::InlineVecASTextStyles,
+                ansi_styled_text::ansi_styled_text_impl::ASTextConvertOptions,
                 global_color_support,
                 tui_color,
                 tui_style::tui_style_attrib::{Bold,
@@ -714,11 +856,17 @@ mod tests {
                                               Reverse,
                                               Strikethrough,
                                               Underline},
+                width,
                 ASTColor,
                 ASTStyle,
+                ASText,
+                ASTextStyles,
+                ColIndex,
                 ColorSupport,
-                TuiStyle,
-                AST};
+                InlineVec,
+                PixelChar,
+                TuiColor,
+                TuiStyle};
 
     #[serial]
     #[test]
@@ -734,7 +882,7 @@ mod tests {
                 strikethrough: Some(Strikethrough),
                 ..Default::default()
             };
-            let ast_styles: InlineVecASTStyles = tui_style.into();
+            let ast_styles: InlineVecASTextStyles = tui_style.into();
             assert_eq!(
                 ast_styles.as_ref(),
                 &[ASTStyle::Bold, ASTStyle::Italic, ASTStyle::Strikethrough]
@@ -752,7 +900,7 @@ mod tests {
                 strikethrough: None,
                 ..Default::default()
             };
-            let ast_styles: InlineVecASTStyles = tui_style.into();
+            let ast_styles: InlineVecASTextStyles = tui_style.into();
             assert_eq!(
                 ast_styles.as_ref(),
                 &[
@@ -775,7 +923,7 @@ mod tests {
                 strikethrough: Some(Strikethrough),
                 ..Default::default()
             };
-            let ast_styles: InlineVecASTStyles = tui_style.into();
+            let ast_styles: InlineVecASTextStyles = tui_style.into();
             assert_eq!(
                 ast_styles.as_ref(),
                 &[
@@ -794,7 +942,7 @@ mod tests {
             let tui_style = TuiStyle {
                 ..Default::default()
             };
-            let ast_styles: InlineVecASTStyles = tui_style.into();
+            let ast_styles: InlineVecASTextStyles = tui_style.into();
             assert!(ast_styles.is_empty());
         }
     }
@@ -802,7 +950,7 @@ mod tests {
     #[serial]
     #[test]
     fn test_fg_color_on_bg_color() {
-        let eg_1 = AST {
+        let eg_1 = ASText {
             text: "Hello".into(),
             styles: smallvec!(
                 ASTStyle::Bold,
@@ -843,7 +991,7 @@ mod tests {
     #[test]
     fn test_formatted_string_creation_ansi256() -> Result<(), String> {
         global_color_support::set_override(ColorSupport::Ansi256);
-        let eg_1 = AST {
+        let eg_1 = ASText {
             text: "Hello".into(),
             styles: smallvec!(
                 ASTStyle::Bold,
@@ -857,7 +1005,7 @@ mod tests {
             "\x1b[1m\x1b[38;5;16m\x1b[48;5;16mHello\x1b[0m".to_string()
         );
 
-        let eg_2 = AST {
+        let eg_2 = ASText {
             text: "World".into(),
             styles: smallvec!(
                 ASTStyle::Bold,
@@ -878,7 +1026,7 @@ mod tests {
     #[test]
     fn test_formatted_string_creation_truecolor() -> Result<(), String> {
         global_color_support::set_override(ColorSupport::Truecolor);
-        let eg_1 = AST {
+        let eg_1 = ASText {
             text: "Hello".into(),
             styles: smallvec!(
                 ASTStyle::Bold,
@@ -892,7 +1040,7 @@ mod tests {
             "\x1b[1m\x1b[38;2;0;0;0m\x1b[48;2;1;1;1mHello\x1b[0m".to_string()
         );
 
-        let eg_2 = AST {
+        let eg_2 = ASText {
             text: "World".into(),
             styles: smallvec!(
                 ASTStyle::Bold,
@@ -913,7 +1061,7 @@ mod tests {
     #[test]
     fn test_formatted_string_creation_grayscale() -> Result<(), String> {
         global_color_support::set_override(ColorSupport::Grayscale);
-        let eg_1 = AST {
+        let eg_1 = ASText {
             text: "Hello".into(),
             styles: smallvec!(
                 ASTStyle::Bold,
@@ -929,7 +1077,7 @@ mod tests {
             "\u{1b}[1m\u{1b}[38;5;16m\u{1b}[48;5;16mHello\u{1b}[0m".to_string()
         );
 
-        let eg_2 = AST {
+        let eg_2 = ASText {
             text: "World".into(),
             styles: smallvec!(
                 ASTStyle::Bold,
@@ -946,5 +1094,596 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[serial]
+    #[test]
+    fn test_convert_vec_ast_style_to_tui_style() {
+        // Test case 1: Mix of styles
+        let ast_styles_1: ASTextStyles = smallvec![
+            ASTStyle::Bold,
+            ASTStyle::Foreground(ASTColor::Ansi(196.into())), // Red
+            ASTStyle::Italic,
+            ASTStyle::Background(ASTColor::Rgb((50, 50, 50).into())), // Dark Gray RGB
+            ASTStyle::Underline,
+            ASTStyle::Overline, // This should be ignored
+        ];
+        let expected_tui_style_1 = TuiStyle {
+            bold: Some(Bold),
+            italic: Some(Italic),
+            underline: Some(Underline),
+            color_fg: Some(TuiColor::Ansi(196.into())),
+            color_bg: Some(TuiColor::Rgb((50, 50, 50).into())),
+            ..Default::default()
+        };
+        let converted_tui_style_1: TuiStyle = ast_styles_1.into();
+        assert_eq!(converted_tui_style_1, expected_tui_style_1);
+
+        // Test case 2: Only attributes
+        let ast_styles_2: ASTextStyles = smallvec![
+            ASTStyle::Dim,
+            ASTStyle::Strikethrough,
+            ASTStyle::Hidden,
+            ASTStyle::RapidBlink, // This should be ignored
+        ];
+        let expected_tui_style_2 = TuiStyle {
+            dim: Some(Dim),
+            strikethrough: Some(Strikethrough),
+            hidden: Some(Hidden),
+            ..Default::default()
+        };
+        let converted_tui_style_2: TuiStyle = ast_styles_2.into();
+        assert_eq!(converted_tui_style_2, expected_tui_style_2);
+
+        // Test case 3: Only colors
+        let ast_styles_3: ASTextStyles = smallvec![
+            ASTStyle::Foreground(ASTColor::Ansi(34.into())), // Green
+            ASTStyle::Background(ASTColor::Ansi(226.into())), // Yellow
+        ];
+        let expected_tui_style_3 = TuiStyle {
+            color_fg: Some(TuiColor::Ansi(34.into())),
+            color_bg: Some(TuiColor::Ansi(226.into())),
+            ..Default::default()
+        };
+        let converted_tui_style_3: TuiStyle = ast_styles_3.into();
+        assert_eq!(converted_tui_style_3, expected_tui_style_3);
+
+        // Test case 4: Empty styles
+        let ast_styles_4: ASTextStyles = smallvec![];
+        let expected_tui_style_4 = TuiStyle::default();
+        let converted_tui_style_4: TuiStyle = ast_styles_4.into();
+        assert_eq!(converted_tui_style_4, expected_tui_style_4);
+
+        // Test case 5: Invert style
+        let ast_styles_5: ASTextStyles = smallvec![ASTStyle::Invert];
+        let expected_tui_style_5 = TuiStyle {
+            reverse: Some(Reverse),
+            ..Default::default()
+        };
+        let converted_tui_style_5: TuiStyle = ast_styles_5.into();
+        assert_eq!(converted_tui_style_5, expected_tui_style_5);
+    }
+
+    #[serial]
+    #[test]
+    fn test_ast_convert_options_struct() {
+        let options1 = ASTextConvertOptions {
+            start: Some(ColIndex::new(5)),
+            end: Some(ColIndex::new(10)),
+        };
+        assert_eq!(options1.start, Some(ColIndex::new(5)));
+        assert_eq!(options1.end, Some(ColIndex::new(10)));
+
+        let options2 = ASTextConvertOptions {
+            start: None,
+            end: None,
+        };
+        assert_eq!(options2.start, None);
+        assert_eq!(options2.end, None);
+    }
+
+    #[serial]
+    #[test]
+    fn test_from_col_width_for_ast_convert_options() {
+        let col_width = width(20);
+        let options: ASTextConvertOptions = col_width.into();
+        assert_eq!(options.start, Some(ColIndex::new(0)));
+        // ColWidth 20 means indices 0-19.
+        assert_eq!(options.end, Some(ColIndex::new(19)));
+
+        let col_width_zero = width(0);
+        let options_zero: ASTextConvertOptions = col_width_zero.into();
+        assert_eq!(options_zero.start, Some(ColIndex::new(0)));
+        // ColWidth(0) converts to ColIndex(0), which is technically index 0.
+        assert_eq!(options_zero.end, Some(ColIndex::new(0)));
+    }
+
+    #[serial]
+    #[test]
+    fn test_ast_convert_method() {
+        let tui_style = TuiStyle {
+            bold: Some(Bold),
+            color_fg: Some(TuiColor::Ansi(196.into())), // Red.
+            ..Default::default()
+        };
+        let ast_style_vec: ASTextStyles = tui_style.into();
+
+        let styled_text = ASText {
+            text: "Hello World".into(),
+            styles: ast_style_vec.clone(),
+        };
+
+        // Test case 1: Using From<ColWidth>
+        {
+            let col_width = width(5);
+            let res: InlineVec<PixelChar> = styled_text.convert(col_width);
+            assert_eq!(res.len(), 5); // "Hello"
+            assert_eq!(
+                res[0],
+                PixelChar::PlainText {
+                    text: 'H'.into(),
+                    maybe_style: Some(tui_style)
+                }
+            );
+            assert_eq!(
+                res[1],
+                PixelChar::PlainText {
+                    text: 'e'.into(),
+                    maybe_style: Some(tui_style)
+                }
+            );
+            assert_eq!(
+                res[2],
+                PixelChar::PlainText {
+                    text: 'l'.into(),
+                    maybe_style: Some(tui_style)
+                }
+            );
+            assert_eq!(
+                res[3],
+                PixelChar::PlainText {
+                    text: 'l'.into(),
+                    maybe_style: Some(tui_style)
+                }
+            );
+            assert_eq!(
+                res[4],
+                PixelChar::PlainText {
+                    text: 'o'.into(),
+                    maybe_style: Some(tui_style)
+                }
+            );
+        }
+
+        // Test case 2: Convert full text (None, None)
+        {
+            let res: InlineVec<PixelChar> =
+                styled_text.convert(ASTextConvertOptions::default());
+            assert_eq!(res.len(), 11);
+            assert_eq!(
+                res[0],
+                PixelChar::PlainText {
+                    text: 'H'.into(),
+                    maybe_style: Some(tui_style)
+                }
+            );
+            assert_eq!(
+                res[10],
+                PixelChar::PlainText {
+                    text: 'd'.into(),
+                    maybe_style: Some(tui_style)
+                }
+            );
+        }
+
+        // Test case 3: Convert partial text (start specified)
+        {
+            let opt = ASTextConvertOptions {
+                start: Some(ColIndex::new(6)),
+                end: None,
+            };
+            let res: InlineVec<PixelChar> = styled_text.convert(opt);
+            assert_eq!(res.len(), 5); // "World"
+            assert_eq!(
+                res[0],
+                PixelChar::PlainText {
+                    text: 'W'.into(),
+                    maybe_style: Some(tui_style)
+                }
+            );
+            assert_eq!(
+                res[4],
+                PixelChar::PlainText {
+                    text: 'd'.into(),
+                    maybe_style: Some(tui_style)
+                }
+            );
+        }
+
+        // Test case 4: Convert partial text (end specified)
+        {
+            let opt = ASTextConvertOptions {
+                start: None,
+                end: Some(ColIndex::new(4)),
+            };
+            let res: InlineVec<PixelChar> = styled_text.convert(opt);
+            assert_eq!(res.len(), 5); // "Hello"
+            assert_eq!(
+                res[0],
+                PixelChar::PlainText {
+                    text: 'H'.into(),
+                    maybe_style: Some(tui_style)
+                }
+            );
+            assert_eq!(
+                res[4],
+                PixelChar::PlainText {
+                    text: 'o'.into(),
+                    maybe_style: Some(tui_style)
+                }
+            );
+        }
+
+        // Test case 5: Convert partial text (start and end specified)
+        {
+            let opt = ASTextConvertOptions {
+                start: Some(ColIndex::new(2)),
+                end: Some(ColIndex::new(8)),
+            };
+            let res: InlineVec<PixelChar> = styled_text.convert(opt);
+            assert_eq!(res.len(), 7); // "llo Wor"
+            assert_eq!(
+                res[0],
+                PixelChar::PlainText {
+                    text: 'l'.into(),
+                    maybe_style: Some(tui_style)
+                }
+            );
+            assert_eq!(
+                res[6],
+                PixelChar::PlainText {
+                    text: 'r'.into(),
+                    maybe_style: Some(tui_style)
+                }
+            );
+        }
+
+        // Test case 6: Empty text
+        {
+            let empty_text = ASText {
+                text: "".into(),
+                styles: ast_style_vec.clone(),
+            };
+            let res: InlineVec<PixelChar> =
+                empty_text.convert(ASTextConvertOptions::default());
+            assert!(res.is_empty());
+        }
+
+        // Test case 7: No styles
+        {
+            let no_style_text = ASText {
+                text: "Test".into(),
+                styles: smallvec![],
+            };
+            let res: InlineVec<PixelChar> =
+                no_style_text.convert(ASTextConvertOptions::default());
+            assert_eq!(res.len(), 4);
+            assert_eq!(
+                res[0],
+                PixelChar::PlainText {
+                    text: 'T'.into(),
+                    maybe_style: None
+                }
+            );
+            assert_eq!(
+                res[3],
+                PixelChar::PlainText {
+                    text: 't'.into(),
+                    maybe_style: None
+                }
+            );
+        }
+
+        // Test case 8: Invalid range (start > end)
+        {
+            let opt = ASTextConvertOptions {
+                start: Some(ColIndex::new(5)),
+                end: Some(ColIndex::new(3)),
+            };
+            let res: InlineVec<PixelChar> = styled_text.convert(opt);
+            assert!(res.is_empty());
+        }
+
+        // Test case 9: Invalid range (start out of bounds)
+        {
+            let opt = ASTextConvertOptions {
+                start: Some(ColIndex::new(11)),
+                end: Some(ColIndex::new(12)),
+            };
+            let res: InlineVec<PixelChar> = styled_text.convert(opt);
+            assert!(res.is_empty());
+        }
+
+        // Test case 10: Invalid range (end out of bounds, but start is valid)
+        // The current implementation returns empty if end >= len()
+        {
+            let opt = ASTextConvertOptions {
+                start: Some(ColIndex::new(8)),
+                end: Some(ColIndex::new(11)), // index 11 is out of bounds for "Hello World" (len 11)
+            };
+            let res: InlineVec<PixelChar> = styled_text.convert(opt);
+            assert!(res.is_empty());
+        }
+
+        // Test case 10.1: Valid range, end is last index
+        {
+            let opt = ASTextConvertOptions {
+                start: Some(ColIndex::new(8)),
+                end: Some(ColIndex::new(10)), // index 10 is the last valid index
+            };
+            let res: InlineVec<PixelChar> = styled_text.convert(opt);
+            assert_eq!(res.len(), 3); // "rld"
+            assert_eq!(
+                res[0],
+                PixelChar::PlainText {
+                    text: 'r'.into(),
+                    maybe_style: Some(tui_style)
+                }
+            );
+            assert_eq!(
+                res[2],
+                PixelChar::PlainText {
+                    text: 'd'.into(),
+                    maybe_style: Some(tui_style)
+                }
+            );
+        }
+
+        // Test case 11: Single character range
+        {
+            let opt = ASTextConvertOptions {
+                start: Some(ColIndex::new(6)),
+                end: Some(ColIndex::new(6)),
+            };
+            let res: InlineVec<PixelChar> = styled_text.convert(opt);
+            assert_eq!(res.len(), 1); // "W"
+            assert_eq!(
+                res[0],
+                PixelChar::PlainText {
+                    text: 'W'.into(),
+                    maybe_style: Some(tui_style)
+                }
+            );
+        }
+
+        // Test case 12: Unicode characters
+        {
+            let unicode_text = ASText {
+                text: "你好世界".into(), // "Hello World" in Chinese
+                styles: ast_style_vec.clone(),
+            };
+            let opt = ASTextConvertOptions {
+                start: Some(ColIndex::new(1)),
+                end: Some(ColIndex::new(2)),
+            };
+            let res: InlineVec<PixelChar> = unicode_text.convert(opt);
+            assert_eq!(res.len(), 2); // "好世"
+            assert_eq!(
+                res[0],
+                PixelChar::PlainText {
+                    text: '好'.into(),
+                    maybe_style: Some(tui_style)
+                }
+            );
+            assert_eq!(
+                res[1],
+                PixelChar::PlainText {
+                    text: '世'.into(),
+                    maybe_style: Some(tui_style)
+                }
+            );
+        }
+
+        // Test case 13: ColWidth(0)
+        {
+            let col_width_zero = width(0);
+            let res: InlineVec<PixelChar> = styled_text.convert(col_width_zero);
+            // start=0, end=0 -> should return the first char
+            assert_eq!(res.len(), 1);
+            assert_eq!(
+                res[0],
+                PixelChar::PlainText {
+                    text: 'H'.into(),
+                    maybe_style: Some(tui_style)
+                }
+            );
+        }
+
+        // Test case 14: ColWidth(1)
+        {
+            let col_width_one = width(1);
+            let res: InlineVec<PixelChar> = styled_text.convert(col_width_one);
+            // start=0, end=0 -> should return the first char
+            assert_eq!(res.len(), 1);
+            assert_eq!(
+                res[0],
+                PixelChar::PlainText {
+                    text: 'H'.into(),
+                    maybe_style: Some(tui_style)
+                }
+            );
+        }
+    }
+
+    #[serial]
+    #[test]
+    fn test_ast_clip() {
+        let tui_style = TuiStyle {
+            bold: Some(Bold),
+            color_fg: Some(TuiColor::Ansi(196.into())), // Red.
+            ..Default::default()
+        };
+        let ast_style_vec: ASTextStyles = tui_style.into();
+
+        let styled_text = ASText {
+            text: "Hello World".into(),
+            styles: ast_style_vec.clone(),
+        };
+
+        // Test case 1: Using From<ColWidth>
+        {
+            let col_width = width(4);
+            let clipped_text = styled_text.clip(col_width);
+            assert_eq!(clipped_text.text, "Hell");
+            assert_eq!(clipped_text.styles, styled_text.styles);
+        }
+
+        // Test case 2: Clip full text (None, None)
+        {
+            let clipped_text = styled_text.clip(ASTextConvertOptions::default());
+            assert_eq!(clipped_text.text, "Hello World");
+            assert_eq!(clipped_text.styles, styled_text.styles);
+        }
+
+        // Test case 3: Clip partial text (start specified)
+        {
+            let opt = ASTextConvertOptions {
+                start: Some(ColIndex::new(6)),
+                end: None,
+            };
+            let clipped_text = styled_text.clip(opt);
+            assert_eq!(clipped_text.text, "World");
+            assert_eq!(clipped_text.styles, styled_text.styles);
+        }
+
+        // Test case 4: Clip partial text (end specified)
+        {
+            let opt = ASTextConvertOptions {
+                start: None,
+                end: Some(ColIndex::new(4)),
+            };
+            let clipped_text = styled_text.clip(opt);
+            assert_eq!(clipped_text.text, "Hello");
+            assert_eq!(clipped_text.styles, styled_text.styles);
+        }
+
+        // Test case 5: Clip partial text (start and end specified)
+        {
+            let opt = ASTextConvertOptions {
+                start: Some(ColIndex::new(2)),
+                end: Some(ColIndex::new(8)),
+            };
+            let clipped_text = styled_text.clip(opt);
+            assert_eq!(clipped_text.text, "llo Wor");
+            assert_eq!(clipped_text.styles, styled_text.styles);
+        }
+
+        // Test case 6: Empty text
+        {
+            let empty_text = ASText {
+                text: "".into(),
+                styles: ast_style_vec.clone(),
+            };
+            let clipped_text = empty_text.clip(ASTextConvertOptions::default());
+            assert!(clipped_text.text.is_empty());
+            assert_eq!(clipped_text.styles, empty_text.styles);
+        }
+
+        // Test case 7: No styles
+        {
+            let no_style_text = ASText {
+                text: "Test".into(),
+                styles: smallvec![],
+            };
+            let clipped_text = no_style_text.clip(ASTextConvertOptions::default());
+            assert_eq!(clipped_text.text, "Test");
+            assert_eq!(clipped_text.styles, no_style_text.styles);
+        }
+
+        // Test case 8: Invalid range (start > end)
+        {
+            let opt = ASTextConvertOptions {
+                start: Some(ColIndex::new(5)),
+                end: Some(ColIndex::new(3)),
+            };
+            let clipped_text = styled_text.clip(opt);
+            assert!(clipped_text.text.is_empty());
+            assert_eq!(clipped_text.styles, styled_text.styles);
+        }
+
+        // Test case 9: Invalid range (start out of bounds)
+        {
+            let opt = ASTextConvertOptions {
+                start: Some(ColIndex::new(11)),
+                end: Some(ColIndex::new(12)),
+            };
+            let clipped_text = styled_text.clip(opt);
+            assert!(clipped_text.text.is_empty());
+            assert_eq!(clipped_text.styles, styled_text.styles);
+        }
+
+        // Test case 10: Invalid range (end out of bounds, but start is valid)
+        {
+            let opt = ASTextConvertOptions {
+                start: Some(ColIndex::new(8)),
+                end: Some(ColIndex::new(11)), // index 11 is out of bounds
+            };
+            let clipped_text = styled_text.clip(opt);
+            assert!(clipped_text.text.is_empty()); // convert returns empty for invalid end
+            assert_eq!(clipped_text.styles, styled_text.styles);
+        }
+
+        // Test case 10.1: Valid range, end is last index
+        {
+            let opt = ASTextConvertOptions {
+                start: Some(ColIndex::new(8)),
+                end: Some(ColIndex::new(10)), // index 10 is the last valid index
+            };
+            let clipped_text = styled_text.clip(opt);
+            assert_eq!(clipped_text.text, "rld");
+            assert_eq!(clipped_text.styles, styled_text.styles);
+        }
+
+        // Test case 11: Single character range
+        {
+            let opt = ASTextConvertOptions {
+                start: Some(ColIndex::new(6)),
+                end: Some(ColIndex::new(6)),
+            };
+            let clipped_text = styled_text.clip(opt);
+            assert_eq!(clipped_text.text, "W");
+            assert_eq!(clipped_text.styles, styled_text.styles);
+        }
+
+        // Test case 12: Unicode characters
+        {
+            let unicode_text = ASText {
+                text: "你好世界".into(), // "Hello World" in Chinese
+                styles: ast_style_vec.clone(),
+            };
+            let opt = ASTextConvertOptions {
+                start: Some(ColIndex::new(1)),
+                end: Some(ColIndex::new(2)),
+            };
+            let clipped_text = unicode_text.clip(opt);
+            assert_eq!(clipped_text.text, "好世");
+            assert_eq!(clipped_text.styles, unicode_text.styles);
+        }
+
+        // Test case 13: ColWidth(0)
+        {
+            let col_width_zero = width(0);
+            let clipped_text = styled_text.clip(col_width_zero);
+            assert_eq!(clipped_text.text, "H"); // start=0, end=0 -> first char
+            assert_eq!(clipped_text.styles, styled_text.styles);
+        }
+
+        // Test case 14: ColWidth(1)
+        {
+            let col_width_one = width(1);
+            let clipped_text = styled_text.clip(col_width_one);
+            assert_eq!(clipped_text.text, "H"); // start=0, end=0 -> first char
+            assert_eq!(clipped_text.styles, styled_text.styles);
+        }
     }
 }

--- a/tui/src/core/tui_core/spinner_impl/spinner_render.rs
+++ b/tui/src/core/tui_core/spinner_impl/spinner_render.rs
@@ -61,6 +61,9 @@ pub fn render_tick(
     count: usize,
     display_width: ColWidth,
 ) -> InlineString {
+    // Make sure to remove all ANSI escape sequences if they exist in the `message`.
+    let message = strip_ansi_escapes::strip_str(message);
+
     match style.template {
         SpinnerTemplate::Braille => {
             // Translate count into the index of the BRAILLE_DOTS array.

--- a/tui/src/readline_async/mod.rs
+++ b/tui/src/readline_async/mod.rs
@@ -482,9 +482,9 @@ pub type SafeHistory = Arc<StdMutex<History>>;
 
 pub type SafeBool = Arc<StdMutex<bool>>;
 
-/// This is a buffer of [DEFAULT_PAUSE_BUFFER_SIZE] 80 rows x
-/// [crate::DEFAULT_TEXT_SIZE] 128 columns (chars). This buffer collects output while
-/// the async terminal is paused.
+/// This is a buffer of [crate::DEFAULT_STRING_STORAGE_SIZE] 80 rows x
+/// [crate::DEFAULT_PAUSE_BUFFER_SIZE] 128 columns (chars). This buffer collects output
+/// while the async terminal is paused.
 pub type PauseBuffer = SmallVec<[InlineString; DEFAULT_PAUSE_BUFFER_SIZE]>;
 pub const DEFAULT_PAUSE_BUFFER_SIZE: usize = 128;
 pub type SafePauseBuffer = Arc<StdMutex<PauseBuffer>>;

--- a/tui/src/readline_async/readline_async_api.rs
+++ b/tui/src/readline_async/readline_async_api.rs
@@ -77,7 +77,10 @@ macro_rules! rla_println_prefixed {
 }
 
 impl ReadlineAsync {
-    /// Create a new instance of [ReadlineAsync]. Example of `prompt` is `"> "`.
+    /// Create a new instance of [ReadlineAsync]. Example of `prompt` is `"> "`. It is
+    /// safe to have ANSI escape sequences inside the `prompt` as this is taken into
+    /// account when calculating the width of the terminal when displaying it in the "line
+    /// editor".
     ///
     /// # Example
     ///


### PR DESCRIPTION
Also audit the following:
- tui/src/core/tui_core/spinner_impl/spinner_render.rs, render_tick(),
- tui/src/readline_async/readline_async_api.rs, try_new(),
to ensure that they can handle spinner message and readline_async prompt
that can contain ANSI escape sequence text.

These can both handle ANSI escape sequences in the spinner message and
prompt.

Fixes: #420