### PR TITLE
feat(tui): add App::app_start lifecycle hook for pre-render background task startup

### DIFF
--- a/cmdr/src/edi/app_main.rs
+++ b/cmdr/src/edi/app_main.rs
@@ -94,7 +94,7 @@ mod app_main_impl_app_trait {
         type S = State;
         type AS = AppSignal;
 
-        fn app_init(
+        fn app_init_components(
             &mut self,
             component_registry_map: &mut ComponentRegistryMap<State, AppSignal>,
             has_focus: &mut HasFocus,

--- a/task/prepare-v0.8.0-meta-task.md
+++ b/task/prepare-v0.8.0-meta-task.md
@@ -3,7 +3,7 @@
 - [x] PTY MUX UI Freeze
   - [x] [fix-pty-mux-debug-session.md](file:///home/nazmul/github/roc/task/fix-pty-mux-debug-session.md)
 - [ ] Polling and Event Loop Fixes
-  - [ ] https://github.com/r3bl-org/r3bl-open-core/pull/450
+  - [x] https://github.com/r3bl-org/r3bl-open-core/pull/450
   - [ ] [fix-mio-poller-edge-triggered-polling.md](file:///home/nazmul/github/roc/task/fix-mio-poller-edge-triggered-polling.md)
 - [ ] Terminal Parsing (Pending PRs)
   - [ ] https://github.com/r3bl-org/r3bl-open-core/pull/448

--- a/tui/README.md
+++ b/tui/README.md
@@ -1188,9 +1188,9 @@ The current render pipeline flow is:
       processed the entire [App] gets re-rendered. This is the unidirectional data
       flow architecture inspired by React and Elm.
 - Your [App] trait impl is the main entry point for laying out the entire application.
-  Before the first render, the [App] is initialized (via a call to [`App::app_init`]),
-  and is responsible for creating all the [Component]s that it uses, and saving them
-  to the [`ComponentRegistryMap`].
+  Before the first render, the [App] is initialized (via a call to [`App::app_init_components`]
+  and [`App::app_start_background_services`]). The `app_init_components` method is responsible
+  for creating all the [Component]s that it uses, and saving them to the [`ComponentRegistryMap`].
   - State is stored in many places. Globally at the [`GlobalData`] level, and also in
     [App], and also in [Component].
 - This sets everything up so that [`App::app_render`],

--- a/tui/examples/tui_apps/ex_app_no_layout/app_main.rs
+++ b/tui/examples/tui_apps/ex_app_no_layout/app_main.rs
@@ -100,7 +100,7 @@ mod app_main_impl_trait_app {
         type S = State;
         type AS = AppSignal;
 
-        fn app_init(
+        fn app_init_components(
             &mut self,
             _component_registry_map: &mut ComponentRegistryMap<State, AppSignal>,
             _has_focus: &mut HasFocus,

--- a/tui/examples/tui_apps/ex_app_with_1col_layout/app_main.rs
+++ b/tui/examples/tui_apps/ex_app_with_1col_layout/app_main.rs
@@ -55,7 +55,7 @@ mod app_main_impl_app_trait {
         type S = State;
         type AS = AppSignal;
 
-        fn app_init(
+        fn app_init_components(
             &mut self,
             component_registry_map: &mut ComponentRegistryMap<Self::S, Self::AS>,
             has_focus: &mut HasFocus,

--- a/tui/examples/tui_apps/ex_app_with_2col_layout/app_main.rs
+++ b/tui/examples/tui_apps/ex_app_with_2col_layout/app_main.rs
@@ -58,7 +58,7 @@ mod app_main_impl_app_trait {
         type S = State;
         type AS = AppSignal;
 
-        fn app_init(
+        fn app_init_components(
             &mut self,
             component_registry_map: &mut ComponentRegistryMap<Self::S, Self::AS>,
             has_focus: &mut HasFocus,

--- a/tui/examples/tui_apps/ex_editor/app_main.rs
+++ b/tui/examples/tui_apps/ex_editor/app_main.rs
@@ -76,7 +76,7 @@ mod app_main_impl_app_trait {
         type S = State;
         type AS = AppSignal;
 
-        fn app_init(
+        fn app_init_components(
             &mut self,
             component_registry_map: &mut ComponentRegistryMap<State, AppSignal>,
             has_focus: &mut HasFocus,

--- a/tui/examples/tui_apps/ex_pitch/app_main.rs
+++ b/tui/examples/tui_apps/ex_pitch/app_main.rs
@@ -69,7 +69,7 @@ mod app_main_impl_app_trait {
         type S = State;
         type AS = AppSignal;
 
-        fn app_init(
+        fn app_init_components(
             &mut self,
             component_registry_map: &mut ComponentRegistryMap<State, AppSignal>,
             has_focus: &mut HasFocus,

--- a/tui/examples/tui_apps/ex_rc/app_main.rs
+++ b/tui/examples/tui_apps/ex_rc/app_main.rs
@@ -148,7 +148,7 @@ mod app_main_impl_app_trait {
         type S = State;
         type AS = AppSignal;
 
-        fn app_init(
+        fn app_init_components(
             &mut self,
             component_registry_map: &mut ComponentRegistryMap<State, AppSignal>,
             has_focus: &mut HasFocus,

--- a/tui/src/core/pty/pty_mux/mux.rs
+++ b/tui/src/core/pty/pty_mux/mux.rs
@@ -20,6 +20,7 @@ use crate::{AnsiSequenceGenerator, Continuation, DEBUG_TUI_PTY_MUX, InputEvent, 
             ok, row};
 use std::{fmt::Debug,
           time::{Duration, Instant}};
+use tokio::time::interval;
 
 /// Builder for configuring and creating a [`PTYMux`] instance.
 #[derive(Default, Debug)]
@@ -267,7 +268,6 @@ impl PTYMux {
     async fn run_event_loop(&mut self) -> miette::Result<()> {
         use adaptive_render_budget::{AdaptiveRenderResult::{Render, Skip},
                                      Budget};
-        use tokio::time::interval;
 
         // Create a periodic timer for status bar updates.
         let mut status_bar_interval = interval(Duration::from_millis(500));
@@ -275,7 +275,7 @@ impl PTYMux {
         // Create a fast timer for polling PTY output.
         let mut output_poll_interval = interval(Duration::from_millis(10));
 
-        let mut render_budget = Budget::new();
+        let mut render_budget = Budget::default();
 
         loop {
             tokio::select! {
@@ -394,6 +394,7 @@ impl PTYMux {
     }
 
     /// Cleanup terminal state - always called on exit.
+    #[allow(clippy::too_many_lines)]
     fn cleanup_terminal(&mut self) {
         let start_time = std::time::Instant::now();
         DEBUG_TUI_PTY_MUX.then(|| {
@@ -628,15 +629,17 @@ pub mod adaptive_render_budget {
         pub maybe_render_start: Option<Instant>,
     }
 
-    impl Budget {
-        pub fn new() -> Self {
+    impl Default for Budget {
+        fn default() -> Self {
             Self {
                 last_render_time: Instant::now(),
                 render_cooldown_delay: DEFAULT_FRAME_DELAY_MS,
                 maybe_render_start: None,
             }
         }
+    }
 
+    impl Budget {
         /// Decides if we should render this frame based on output and budget.
         pub fn should_render(
             &self,
@@ -666,9 +669,10 @@ pub mod adaptive_render_budget {
         /// [`mark_end()`]: Self::mark_end
         /// [`mark_start()`]: Self::mark_start
         pub fn mark_start(&mut self) {
-            if self.maybe_render_start.is_some() {
-                panic!("Can't call mark_start() more than once");
-            }
+            assert!(
+                self.maybe_render_start.is_none(),
+                "Can't call mark_start() more than once"
+            );
             self.maybe_render_start = Some(Instant::now());
         }
 
@@ -697,52 +701,49 @@ pub mod adaptive_render_budget {
             // implementing asymmetric backoff.
             let backpressure_detected =
                 render_duration > RENDER_TIME_BACKPRESSURE_THRESHOLD_MS;
-            match backpressure_detected {
-                true => {
-                    // Penalize render budget for backpressure.
-                    self.render_cooldown_delay = self
-                        .render_cooldown_delay
-                        .saturating_add(THROTTLE_PENALTY_MS)
-                        .min(MAX_FRAME_DELAY_MS);
+            if backpressure_detected {
+                // Penalize render budget for backpressure.
+                self.render_cooldown_delay = self
+                    .render_cooldown_delay
+                    .saturating_add(THROTTLE_PENALTY_MS)
+                    .min(MAX_FRAME_DELAY_MS);
 
+                DEBUG_TUI_PTY_MUX.then(|| {
+                    // % is Display, ? is Debug.
+                    tracing::info! {
+                        message = "Budget::mark_end",
+                        info = %crate::inline_string!(
+                            "Render took {:?} (> {:?}). Throttling frame delay to {:?}",
+                            render_duration,
+                            RENDER_TIME_BACKPRESSURE_THRESHOLD_MS,
+                            self.render_cooldown_delay
+                        )
+                    };
+                });
+            } else {
+                // Used for logging.
+                let old_delay = self.render_cooldown_delay;
+
+                // Reward render budget for smooth rendering.
+                self.render_cooldown_delay = self
+                    .render_cooldown_delay
+                    .saturating_sub(RECOVERY_REWARD_MS)
+                    .max(MIN_FRAME_DELAY_MS);
+
+                // Only log recovery if the delay actually changed to avoid spamming
+                // the logs
+                if old_delay != self.render_cooldown_delay {
                     DEBUG_TUI_PTY_MUX.then(|| {
                         // % is Display, ? is Debug.
                         tracing::info! {
                             message = "Budget::mark_end",
                             info = %crate::inline_string!(
-                                "Render took {:?} (> {:?}). Throttling frame delay to {:?}",
+                                "Render took {:?}. Recovering frame delay to {:?}",
                                 render_duration,
-                                RENDER_TIME_BACKPRESSURE_THRESHOLD_MS,
                                 self.render_cooldown_delay
                             )
                         };
                     });
-                }
-                false => {
-                    // Used for logging.
-                    let old_delay = self.render_cooldown_delay;
-
-                    // Reward render budget for smooth rendering.
-                    self.render_cooldown_delay = self
-                        .render_cooldown_delay
-                        .saturating_sub(RECOVERY_REWARD_MS)
-                        .max(MIN_FRAME_DELAY_MS);
-
-                    // Only log recovery if the delay actually changed to avoid spamming
-                    // the logs
-                    if old_delay != self.render_cooldown_delay {
-                        DEBUG_TUI_PTY_MUX.then(|| {
-                            // % is Display, ? is Debug.
-                            tracing::info! {
-                                message = "Budget::mark_end",
-                                info = %crate::inline_string!(
-                                    "Render took {:?}. Recovering frame delay to {:?}",
-                                    render_duration,
-                                    self.render_cooldown_delay
-                                )
-                            };
-                        });
-                    }
                 }
             }
         }

--- a/tui/src/lib.rs
+++ b/tui/src/lib.rs
@@ -1215,9 +1215,9 @@
 //!       processed the entire [App] gets re-rendered. This is the unidirectional data
 //!       flow architecture inspired by React and Elm.
 //! - Your [App] trait impl is the main entry point for laying out the entire application.
-//!   Before the first render, the [App] is initialized (via a call to [`App::app_init`]),
-//!   and is responsible for creating all the [Component]s that it uses, and saving them
-//!   to the [`ComponentRegistryMap`].
+//!   Before the first render, the [App] is initialized (via a call to [`App::app_init_components`]
+//!   and [`App::app_start_background_services`]). The `app_init_components` method is responsible
+//!   for creating all the [Component]s that it uses, and saving them to the [`ComponentRegistryMap`].
 //!   - State is stored in many places. Globally at the [`GlobalData`] level, and also in
 //!     [App], and also in [Component].
 //! - This sets everything up so that [`App::app_render`],

--- a/tui/src/tui/terminal_window/app.rs
+++ b/tui/src/tui/terminal_window/app.rs
@@ -29,11 +29,21 @@ pub trait App {
     /// This is called once at the beginning of the app's lifecycle. It is used to
     /// initialize the [`ComponentRegistryMap`] and [`HasFocus`] structs. It is called
     /// before the first render by the [`crate::TerminalWindow::main_event_loop`].
-    fn app_init(
+    fn app_init_components(
         &mut self,
         component_registry_map: &mut ComponentRegistryMap<Self::S, Self::AS>,
         has_focus: &mut HasFocus,
     );
+
+    /// Called once immediately after [`App::app_init_components`], before the first
+    /// render.
+    ///
+    /// Use this to start background tasks that need
+    /// [`global_data.main_thread_channel_sender`] to communicate back to the main thread.
+    ///
+    /// [`global_data.main_thread_channel_sender`]:
+    ///     crate::GlobalData::main_thread_channel_sender
+    fn app_start_background_services(&mut self, _global_data: &mut GlobalData<Self::S, Self::AS>) {}
 
     /// At a high level:
     /// - Use the `input_event` to dispatch an action to the store if needed.

--- a/tui/src/tui/terminal_window/main_event_loop.rs
+++ b/tui/src/tui/terminal_window/main_event_loop.rs
@@ -260,13 +260,17 @@ where
             );
         });
 
-        // Initialize app and render.
+        // Initialize app and start background tasks before the first render. Both these
+        // operations are not recorded in telemetry.
+        app.app_init_components(&mut self.component_registry_map, &mut self.has_focus);
+        app.app_start_background_services(&mut self.global_data);
+
+        // Render the first frame.
         let telemetry = &mut self.telemetry;
         telemetry_record!(
             @telemetry: telemetry,
             @hint: TelemetryAtomHint::Render,
             @block: {
-                app.app_init(&mut self.component_registry_map, &mut self.has_focus);
                 output_device.write(|writer| {
                     AppManager::render_app(
                         app,

--- a/tui/src/tui/terminal_window/terminal_window_integration_tests/pty_main_event_loop_test.rs
+++ b/tui/src/tui/terminal_window/terminal_window_integration_tests/pty_main_event_loop_test.rs
@@ -144,8 +144,16 @@ impl Debug for State {
     }
 }
 
+#[derive(Debug, Default)]
+pub struct TestData {
+    pub init_called: bool,
+    pub start_called: bool,
+}
+
 #[derive(Default)]
-struct AppMainTest;
+struct AppMainTest {
+    pub data: TestData,
+}
 
 impl App for AppMainTest {
     type S = State;
@@ -157,6 +165,10 @@ impl App for AppMainTest {
         _component_registry_map: &mut ComponentRegistryMap<State, AppSignal>,
         _has_focus: &mut HasFocus,
     ) -> CommonResult<RenderPipeline> {
+        assert!(
+            self.data.start_called,
+            "app_start must be called before app_render"
+        );
         throws_with_return!({ RenderPipeline::default() });
     }
 
@@ -209,10 +221,19 @@ impl App for AppMainTest {
         });
     }
 
-    fn app_init(
+    fn app_init_components(
         &mut self,
         _component_registry_map: &mut ComponentRegistryMap<State, AppSignal>,
         _has_focus: &mut HasFocus,
     ) {
+        self.data.init_called = true;
+    }
+
+    fn app_start_background_services(&mut self, _global_data: &mut GlobalData<State, AppSignal>) {
+        assert!(
+            self.data.init_called,
+            "app_init_components must be called before app_start_background_services"
+        );
+        self.data.start_called = true;
     }
 }


### PR DESCRIPTION
## Motivation

The `App` trait had no lifecycle hook for starting background tasks at app startup. The only hook with access to `GlobalData` (and therefore `main_thread_channel_sender`) was `app_render` and `app_handle_input_event` — both wrong in responsibility and too late in the lifecycle.

The concrete use case driving this is in [`explorer`](https://github.com/cecton/explorer), where the app needs to:

- Spawn an LSP supervisor (a `tokio::spawn` loop that monitors and restarts the LSP task, sending `AppSignal::TaskRestarting`/`TaskRunning` back via `main_thread_channel_sender`)
- Spawn a file-watcher relay task (relays `RRTEvent::Worker` signals back to the main thread)
- Publish the `main_thread_channel_sender` into a `OnceLock` so SIGTERM/SIGINT handlers registered before the TUI starts can request a clean exit

None of this was possible before `app_start` because `app_init` — the only other startup hook — does not receive `GlobalData`.

## What this PR does

- Adds `App::app_start(&mut self, global_data: &mut GlobalData<S, AS>)` with a default no-op implementation (non-breaking — all 8 existing `App` implementations continue to compile unchanged)
- Moves `app_init` and `app_start` calls outside the `telemetry_record!(Render)` block so startup time is not incorrectly attributed to render telemetry
- Adds ordering assertions in the test fixture to lock in the contract: `app_init` → `app_start` → first `app_render`

## Design decisions considered and rejected

**Including `component_registry_map` and `has_focus` in `app_start`**

An earlier version passed all three resources for completeness. Removed because no concrete use case requires them here — by the time `app_start` is called, `app_init` has already fully populated both. Speculative parameters widen the API surface and obscure the hook's purpose. If an implementor needs component or focus data when starting background tasks, it can be captured on `self` during `app_init`.

**Folding `global_data` into `app_init` instead of adding a second hook**

`app_init` has a single, clear responsibility: populate the `ComponentRegistryMap` and set initial `HasFocus` state. Adding `global_data` to it would conflate component setup with background task startup and obscure the ordering guarantee (components must be fully registered before tasks try to interact with them). It would also be a breaking change requiring updates to all 8 existing `app_init` implementations.

**Exposing `GlobalData` via a getter method on `App`**

A `fn app_global_data(&mut self) -> &mut GlobalData<S, AS>` getter was considered so implementors could access `GlobalData` on demand without it being passed as a parameter. Rejected because `GlobalData` is owned by the framework (`AppManager`), not the `App` implementor. Moving that ownership would require `Arc<Mutex<...>>`, and a getter method would break the consistent pattern where the framework passes all resources as parameters to every `App` method.