### PR TITLE
feat: implement EL (Erase Line) and ED (Erase Display) for PTY mux

### DIFF
--- a/tui/src/core/ansi/vt_100_pty_output_parser/operations/vt_100_shim_line_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/operations/vt_100_shim_line_ops.rs
@@ -59,9 +59,9 @@
 //!     Route to operations module:
 //!       - cursor_ops:: for movement (A,B,C,D,H)
 //!       - scroll_ops:: for scrolling (S,T)
-//!       - sgr_ops:: for styling (m)     ╭───────────╮
-//!       - line_ops:: for lines (L,M) <- │THIS MODULE│
-//!       - char_ops:: for chars (@,P,X)  ╰───────────╯
+//!       - sgr_ops:: for styling (m)         ╭───────────╮
+//!       - line_ops:: for lines (J,K,L,M) <- │THIS MODULE│
+//!       - char_ops:: for chars (@,P,X)      ╰───────────╯
 //!         ↓
 //!     Update OffscreenBuffer state
 //! ```
@@ -96,7 +96,7 @@
 //! [module-level documentation]: self
 
 use super::super::ansi_parser_public_api::AnsiToOfsBufPerformer;
-use crate::ParamsExt;
+use crate::{EraseDisplayMode, EraseLineMode, ParamsExt};
 
 /// Handle IL (Insert Line) - insert n blank lines at cursor position.
 /// Lines below cursor and within scroll region shift down.
@@ -143,4 +143,46 @@ pub fn delete_lines(performer: &mut AnsiToOfsBufPerformer, params: &vte::Params)
         result.is_ok(),
         "Failed to delete {how_many:?} lines at row {at:?}",
     );
+}
+
+/// Handle EL (Erase Line) - erase part or all of current line.
+///
+/// Fills affected cells with spaces using the current SGR style (preserving active
+/// background color). This differs from [`clear_line`] which fills with unstyled
+/// [`PixelChar::Spacer`].
+///
+/// **[`VT-100`] Protocol**: The mode parameter selects the erase region:
+/// - `0` (default, missing) - From cursor to end of line
+/// - `1` - From start of line to cursor
+/// - `2` - Entire line
+///
+/// [`PixelChar::Spacer`]: crate::PixelChar::Spacer
+/// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
+/// [`clear_line`]: crate::OffscreenBuffer::clear_line
+pub fn erase_line(performer: &mut AnsiToOfsBufPerformer, params: &vte::Params) {
+    let mode: EraseLineMode = params
+        .extract_nth_single_opt_raw(0)
+        .unwrap_or(0)
+        .into();
+    performer.ofs_buf.erase_line(mode);
+}
+
+/// Handle ED (Erase Display) - erase part or all of the display.
+///
+/// Fills affected cells with spaces using the current SGR style (preserving active
+/// background color).
+///
+/// **[`VT-100`] Protocol**: The mode parameter selects the erase region:
+/// - `0` (default, missing) - From cursor to end of display
+/// - `1` - From start of display to cursor
+/// - `2` - Entire display
+/// - `3` - Entire display and scrollback buffer (treated same as `2`)
+///
+/// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
+pub fn erase_display(performer: &mut AnsiToOfsBufPerformer, params: &vte::Params) {
+    let mode: EraseDisplayMode = params
+        .extract_nth_single_opt_raw(0)
+        .unwrap_or(0)
+        .into();
+    performer.ofs_buf.erase_display(mode);
 }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/performer.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/performer.rs
@@ -367,7 +367,7 @@ impl Perform for AnsiToOfsBufPerformer<'_> {
     ///       - cursor_ops:: for movement (A,B,C,D,H)
     ///       - scroll_ops:: for scrolling (S,T)
     ///       - sgr_ops:: for styling (m)
-    ///       - line_ops:: for lines (L,M)
+    ///       - line_ops:: for lines (J,K,L,M)
     ///       - char_ops:: for chars (@,P,X)
     ///         ↓
     ///     Update OffscreenBuffer state
@@ -400,7 +400,7 @@ impl Perform for AnsiToOfsBufPerformer<'_> {
     /// - Scrolling: SU (Scroll Up), SD (Scroll Down)
     /// - Line operations: IL (Insert Line), DL (Delete Line)
     /// - Character operations: ICH (Insert Char), DCH (Delete Char), ECH (Erase Char)
-    /// - Display control: ED, EL (explicitly ignored - see comments)
+    /// - Display control: ED (Erase Display), EL (Erase Line)
     /// - Cursor save/restore: SCP, RCP
     /// - Margins: [`DECSTBM`] (Set Top and Bottom Margins)
     /// - Modes: SM, RM (including private modes with ? prefix)
@@ -526,13 +526,12 @@ impl Perform for AnsiToOfsBufPerformer<'_> {
                 vt_100_shim_cursor_ops::vertical_position_absolute(self, params);
             }
 
-            // Display control operations (explicitly ignored).
-            ED_ERASE_DISPLAY | EL_ERASE_LINE => {
-                // Clear screen/line - ignore, TUI apps will repaint themselves
-                tracing::warn!(
-                    "CSI {}: Clear display/line operation ignored",
-                    dispatch_char
-                );
+            // Display control operations.
+            ED_ERASE_DISPLAY => {
+                vt_100_shim_line_ops::erase_display(self, params);
+            }
+            EL_ERASE_LINE => {
+                vt_100_shim_line_ops::erase_line(self, params);
             }
 
             // Other unimplemented CSI sequences.

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_line_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_line_ops.rs
@@ -18,7 +18,7 @@
 //! [parser module docs]: super::super
 
 use super::super::test_fixtures_vt_100_ansi_conformance::*;
-use crate::{CsiCount, col,
+use crate::{ANSIBasicColor, CsiCount, EraseDisplayMode, EraseLineMode, SgrCode, col,
             core::ansi::vt_100_pty_output_parser::{CsiSequence,
                                                    ansi_parser_public_api::AnsiToOfsBufPerformer},
             row, term_col, term_row};
@@ -226,5 +226,212 @@ pub mod delete_line {
         for r in 0..5 {
             assert_line_content(&ofs_buf, r, &format!("Line{r:02}"));
         }
+    }
+}
+
+/// Tests for Erase Line (EL) operations.
+pub mod erase_line {
+    use super::*;
+
+    #[test]
+    fn test_erase_from_cursor_to_end() {
+        let mut ofs_buf = create_numbered_buffer(3, 10);
+
+        // Move cursor to row 1 (0-based), col 3 (0-based) and erase to end.
+        let move_cursor = term_row(nz(2)) + term_col(nz(4));
+        let erase = CsiSequence::EraseLine(EraseLineMode::FromCursorToEnd);
+        let sequence = format!("{move_cursor}{erase}");
+        let _result = ofs_buf.apply_ansi_bytes(sequence);
+
+        // Line 0 unchanged.
+        assert_line_content(&ofs_buf, 0, "Line00");
+        // Line 1: "Lin" preserved, rest erased to spaces.
+        assert_line_content(&ofs_buf, 1, "Lin       ");
+        // Line 2 unchanged.
+        assert_line_content(&ofs_buf, 2, "Line02");
+    }
+
+    #[test]
+    fn test_erase_from_start_to_cursor() {
+        let mut ofs_buf = create_numbered_buffer(3, 10);
+
+        // Move cursor to row 1 (0-based), col 3 (0-based) and erase from start.
+        let move_cursor = term_row(nz(2)) + term_col(nz(4));
+        let erase = CsiSequence::EraseLine(EraseLineMode::FromStartToCursor);
+        let sequence = format!("{move_cursor}{erase}");
+        let _result = ofs_buf.apply_ansi_bytes(sequence);
+
+        // Line 0 unchanged.
+        assert_line_content(&ofs_buf, 0, "Line00");
+        // Line 1: cols 0-3 erased, "01" preserved, trailing columns are spaces.
+        assert_line_content(&ofs_buf, 1, "    01    ");
+        // Line 2 unchanged.
+        assert_line_content(&ofs_buf, 2, "Line02");
+    }
+
+    #[test]
+    fn test_erase_entire_line() {
+        let mut ofs_buf = create_numbered_buffer(3, 10);
+
+        // Move cursor to row 1 (0-based) and erase entire line.
+        let move_cursor = term_row(nz(2)) + term_col(nz(1));
+        let erase = CsiSequence::EraseLine(EraseLineMode::EntireLine);
+        let sequence = format!("{move_cursor}{erase}");
+        let _result = ofs_buf.apply_ansi_bytes(sequence);
+
+        // Line 0 unchanged.
+        assert_line_content(&ofs_buf, 0, "Line00");
+        // Line 1 entirely erased.
+        assert_line_content(&ofs_buf, 1, "          ");
+        // Line 2 unchanged.
+        assert_line_content(&ofs_buf, 2, "Line02");
+    }
+
+    #[test]
+    fn test_erase_line_preserves_sgr_style() {
+        let mut ofs_buf = create_numbered_buffer(3, 10);
+
+        // Set a background color via SGR
+        let sgr = format!("{}", SgrCode::BackgroundBasic(ANSIBasicColor::Blue));
+        let _result = ofs_buf.apply_ansi_bytes(sgr);
+
+        // Move cursor to row 1 (0-based) and erase entire line
+        let move_cursor = CsiSequence::CursorPosition {
+            row: term_row(nz(2)),
+            col: term_col(nz(1)),
+        };
+        let erase = CsiSequence::EraseLine(EraseLineMode::EntireLine);
+        let sequence = format!("{move_cursor}{erase}");
+        let _result = ofs_buf.apply_ansi_bytes(sequence);
+
+        // Verify erased cells are PixelChar::PlainText with the active style
+        for c in 0..10 {
+            match &ofs_buf.buffer[1][c] {
+                crate::PixelChar::PlainText { display_char, style } => {
+                    assert_eq!(*display_char, ' ');
+                    assert_eq!(
+                        style.color_bg,
+                        Some(ANSIBasicColor::Blue.into()),
+                        "SGR background style not preserved in erased cell at col {c}"
+                    );
+                }
+                _ => panic!(
+                    "Expected styled PlainText at row 1 col {c}, got {:?}",
+                    ofs_buf.buffer[1][c]
+                ),
+            }
+        }
+
+        // Line 0 and 2 unchanged
+        assert_line_content(&ofs_buf, 0, "Line00");
+        assert_line_content(&ofs_buf, 2, "Line02");
+    }
+}
+
+/// Tests for Erase Display (ED) operations.
+pub mod erase_display {
+    use super::*;
+
+    #[test]
+    fn test_erase_display_from_cursor_to_end() {
+        let mut ofs_buf = create_numbered_buffer(3, 10);
+
+        // Move cursor to row 1 (0-based), col 3 (0-based) and erase to end.
+        let move_cursor = term_row(nz(2)) + term_col(nz(4));
+        let erase = CsiSequence::EraseDisplay(EraseDisplayMode::FromCursorToEnd);
+        let sequence = format!("{move_cursor}{erase}");
+        let _result = ofs_buf.apply_ansi_bytes(sequence);
+
+        // Line 0 unchanged.
+        assert_line_content(&ofs_buf, 0, "Line00");
+        // Line 1: "Lin" preserved, rest erased to spaces.
+        assert_line_content(&ofs_buf, 1, "Lin       ");
+        // Line 2 entirely erased.
+        assert_line_content(&ofs_buf, 2, "          ");
+    }
+
+    #[test]
+    fn test_erase_display_from_start_to_cursor() {
+        let mut ofs_buf = create_numbered_buffer(3, 10);
+
+        // Move cursor to row 1 (0-based), col 3 (0-based) and erase from start.
+        let move_cursor = term_row(nz(2)) + term_col(nz(4));
+        let erase = CsiSequence::EraseDisplay(EraseDisplayMode::FromStartToCursor);
+        let sequence = format!("{move_cursor}{erase}");
+        let _result = ofs_buf.apply_ansi_bytes(sequence);
+
+        // Line 0 entirely erased.
+        assert_line_content(&ofs_buf, 0, "          ");
+        // Line 1: cols 0-3 erased, "01" preserved, trailing columns are spaces.
+        assert_line_content(&ofs_buf, 1, "    01    ");
+        // Line 2 unchanged.
+        assert_line_content(&ofs_buf, 2, "Line02");
+    }
+
+    #[test]
+    fn test_erase_display_entire_screen() {
+        let mut ofs_buf = create_numbered_buffer(3, 10);
+
+        // Erase entire screen.
+        let erase = CsiSequence::EraseDisplay(EraseDisplayMode::EntireScreen);
+        let sequence = format!("{erase}");
+        let _result = ofs_buf.apply_ansi_bytes(sequence);
+
+        // All lines entirely erased.
+        assert_line_content(&ofs_buf, 0, "          ");
+        assert_line_content(&ofs_buf, 1, "          ");
+        assert_line_content(&ofs_buf, 2, "          ");
+    }
+
+    #[test]
+    fn test_erase_display_preserves_sgr_style() {
+        let mut ofs_buf = create_numbered_buffer(3, 10);
+
+        // Set a background color via SGR
+        let sgr = format!("{}", SgrCode::BackgroundBasic(ANSIBasicColor::Blue));
+        let _result = ofs_buf.apply_ansi_bytes(sgr);
+
+        // Erase entire display
+        let erase = CsiSequence::EraseDisplay(EraseDisplayMode::EntireScreen);
+        let sequence = format!("{erase}");
+        let _result = ofs_buf.apply_ansi_bytes(sequence);
+
+        // Verify all erased cells are PixelChar::PlainText with the active style
+        for r in 0..3 {
+            for c in 0..10 {
+                match &ofs_buf.buffer[r][c] {
+                    crate::PixelChar::PlainText { display_char, style } => {
+                        assert_eq!(*display_char, ' ');
+                        assert_eq!(
+                            style.color_bg,
+                            Some(ANSIBasicColor::Blue.into()),
+                            "SGR background style not preserved in erased cell at row {r} col {c}"
+                        );
+                    }
+                    _ => panic!(
+                        "Expected styled PlainText at row {r} col {c}, got {:?}",
+                        ofs_buf.buffer[r][c]
+                    ),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_erase_display_entire_screen_and_scrollback() {
+        let mut ofs_buf = create_numbered_buffer(3, 10);
+
+        // Erase entire display and scrollback buffer.
+        // VT-100 specifies mode 3 for this, which in this implementation
+        // is treated identically to mode 2 (EntireScreen).
+        let erase =
+            CsiSequence::EraseDisplay(EraseDisplayMode::EntireScreenAndScrollback);
+        let sequence = format!("{erase}");
+        let _result = ofs_buf.apply_ansi_bytes(sequence);
+
+        // All lines entirely erased.
+        assert_line_content(&ofs_buf, 0, "          ");
+        assert_line_content(&ofs_buf, 1, "          ");
+        assert_line_content(&ofs_buf, 2, "          ");
     }
 }

--- a/tui/src/tui/terminal_lib_backends/direct_to_ansi/output/direct_to_ansi_output_integration_tests/screen_operations_rendered.rs
+++ b/tui/src/tui/terminal_lib_backends/direct_to_ansi/output/direct_to_ansi_output_integration_tests/screen_operations_rendered.rs
@@ -6,21 +6,8 @@
 //! that clear operations produce the correct **visual result** when [`ANSI`] sequences
 //! are rendered to a buffer.
 //!
-//! # Important Design Note
-//!
-//! The [`OffscreenBuffer`] [`ANSI`] parser **intentionally ignores** clear operations
-//! (ED/EL sequences). This is by design because TUI applications repaint themselves
-//! after clear operations. See [`performer.rs`] where `ED_ERASE_DISPLAY` and
-//! `EL_ERASE_LINE` are explicitly ignored.
-//!
-//! As a result, these tests verify:
-//! - Clear [`ANSI`] sequences are **generated correctly** (verified by byte-level tests)
-//! - Text painting **after** clear operations works correctly (cursor positioning)
-//! - Buffer state is correct for content that **isn't** cleared
-//!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 //! [`OffscreenBuffer`]: crate::OffscreenBuffer
-//! [`performer.rs`]: crate::vt_100_pty_output_parser::performer
 //! [`screen_operations`]: super::screen_operations
 
 use super::test_helpers_rendered::*;
@@ -28,28 +15,21 @@ use crate::{offscreen_buffer::test_fixtures_ofs_buf::*, render_op::RenderOpCommo
 
 /// Verify text can be painted at various positions.
 ///
-/// NOTE: Clear operations (`ClearScreen`, `ClearLine`, etc.) are intentionally ignored
-/// by [`OffscreenBuffer`]'s [`ANSI`] parser - TUI apps repaint themselves. This test
-/// verifies the cursor positioning and text painting still work correctly.
-///
-/// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
+/// Verify that text painted before a ClearScreen is erased and text painted after
+/// it appears correctly.
 #[test]
 fn test_paint_after_clear_sequence_rendered() {
-    // Even though ClearScreen is ignored by the parser, the cursor positioning
-    // and subsequent text painting should work correctly.
     let ops = vec![
         move_cursor_abs(5, 5),
         paint_text("X", None),
         crate::RenderOpOutput::Common(RenderOpCommon::ClearScreen),
-        // Move explicitly and paint new content.
         move_cursor_abs(3, 3),
         paint_text("Y", None),
     ];
 
     let buffer = execute_ops_and_render(ops);
 
-    // Both 'X' and 'Y' should be present (clear is ignored).
-    assert_plain_char_at(&buffer, 5, 5, 'X');
+    assert_empty_at(&buffer, 5, 5);
     assert_plain_char_at(&buffer, 3, 3, 'Y');
 }
 

--- a/tui/src/tui/terminal_lib_backends/offscreen_buffer/vt_100_ansi_impl/vt_100_impl_line_ops.rs
+++ b/tui/src/tui/terminal_lib_backends/offscreen_buffer/vt_100_ansi_impl/vt_100_impl_line_ops.rs
@@ -7,7 +7,8 @@
 //!
 //! - **IL** (Insert Lines) - [`shift_lines_down()`]
 //! - **DL** (Delete Lines) - [`shift_lines_up()`]
-//! - **EL** (Erase Line) - [`clear_line()`]
+//! - **EL** (Erase Line) - [`erase_line()`]
+//! - **ED** (Erase Display) - [`erase_display()`]
 //!
 //! All operations maintain VT100 compliance and handle proper line manipulation
 //! within scroll regions as specified in VT100 documentation.
@@ -54,12 +55,15 @@
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 //! [`clear_line()`]: crate::OffscreenBuffer::clear_line
+//! [`erase_line()`]: crate::OffscreenBuffer::erase_line
+//! [`erase_display()`]: crate::OffscreenBuffer::erase_display
 //! [`shift_lines_down()`]: crate::OffscreenBuffer::shift_lines_down
 //! [`shift_lines_up()`]: crate::OffscreenBuffer::shift_lines_up
 //! [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
 //! [Interval Notation]: crate::bounds_check#interval-notation
 
-use crate::{Length, OffscreenBuffer, PixelChar, RowHeight, RowIndex,
+use crate::{EraseDisplayMode, EraseLineMode, Length, OffscreenBuffer, PixelChar,
+            RowHeight, RowIndex,
             core::coordinates::bounds_check::{RangeBoundsExt, RangeBoundsResult,
                                               RangeConvertExt}, ok};
 use std::ops::Range;
@@ -89,6 +93,105 @@ impl OffscreenBuffer {
         );
 
         ok!()
+    }
+
+    /// Erase part or all of the current line, filling with spaces that use the active
+    /// SGR style (including background color).
+    ///
+    /// This implements [`VT-100`] EL (Erase Line) behavior for the ANSI parser. Unlike
+    /// [`clear_line`], the erased cells preserve the current SGR state so background
+    /// colors extend to the end of the line.
+    ///
+    /// Per [`VT-100`] spec, EL silently no-ops for out-of-bounds cursor positions — there
+    /// is no error path.
+    ///
+    /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
+    /// [`clear_line`]: crate::OffscreenBuffer::clear_line
+    pub fn erase_line(&mut self, mode: EraseLineMode) {
+        let row = self.cursor_pos.row_index.as_usize();
+        let col = self.cursor_pos.col_index.as_usize();
+        let current_style = self.ansi_parser_support.current_style;
+
+        let Some(line) = self.buffer.get_mut(row) else {
+            return;
+        };
+
+        let fill = PixelChar::PlainText {
+            display_char: ' ',
+            style: current_style,
+        };
+
+        match mode {
+            EraseLineMode::FromCursorToEnd => {
+                let start = col.min(line.len());
+                for c in start..line.len() {
+                    line[c] = fill;
+                }
+            }
+            EraseLineMode::FromStartToCursor => {
+                debug_assert!(!line.is_empty(), "VT-100 lines have positive width; inclusive range 0..=end would panic on empty line");
+                let end = col.min(line.len().saturating_sub(1));
+                for c in 0..=end {
+                    line[c] = fill;
+                }
+            }
+            EraseLineMode::EntireLine => {
+                line.fill(fill);
+            }
+        }
+    }
+
+    /// Erase part or all of the display, filling with spaces that use the active SGR
+    /// style.
+    ///
+    /// This implements [`VT-100`] ED (Erase Display) behavior for the ANSI parser.
+    ///
+    /// Like [`erase_line`](Self::erase_line), this operation uses [`Vec::get_mut`] on
+    /// each row it touches. Per [`VT-100`] spec, ED silently no-ops for out-of-bounds
+    /// cursor positions — there is no error path.
+    ///
+    /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
+    pub fn erase_display(&mut self, mode: EraseDisplayMode) {
+        let fill = PixelChar::PlainText {
+            display_char: ' ',
+            style: self.ansi_parser_support.current_style,
+        };
+
+        let cursor_row = self.cursor_pos.row_index.as_usize();
+        let cursor_col = self.cursor_pos.col_index.as_usize();
+
+        match mode {
+            EraseDisplayMode::FromCursorToEnd => {
+                if let Some(line) = self.buffer.get_mut(cursor_row) {
+                    let col = cursor_col.min(line.len());
+                    for c in col..line.len() {
+                        line[c] = fill;
+                    }
+                }
+                for r in (cursor_row + 1)..self.buffer.len() {
+                    self.buffer[r].fill(fill);
+                }
+            }
+            EraseDisplayMode::FromStartToCursor => {
+                let end = cursor_row.min(self.buffer.len());
+                for r in 0..end {
+                    self.buffer[r].fill(fill);
+                }
+                if let Some(line) = self.buffer.get_mut(cursor_row) {
+                    debug_assert!(!line.is_empty(), "VT-100 lines have positive width; inclusive range 0..=col would panic on empty line");
+                    let col = cursor_col.min(line.len().saturating_sub(1));
+                    for c in 0..=col {
+                        line[c] = fill;
+                    }
+                }
+            }
+            EraseDisplayMode::EntireScreen
+            | EraseDisplayMode::EntireScreenAndScrollback => {
+                for line in self.buffer.iter_mut() {
+                    line.fill(fill);
+                }
+            }
+        }
     }
 
     /// Shift lines up within a range by the specified amount.
@@ -538,6 +641,246 @@ mod tests_line_ops {
         let line4 = buffer.get_line(row(4)).unwrap();
         for col_idx in 0..4 {
             assert_eq!(line4[col_idx], create_test_char('Y'));
+        }
+    }
+
+    #[test]
+    fn test_erase_line_from_cursor_to_end() {
+        let mut buffer = create_test_buffer();
+        buffer.cursor_pos = row(1) + col(2);
+
+        // Fill the line with test characters.
+        for col_idx in 0..4 {
+            let _unused = buffer.set_char(row(1) + col(col_idx), create_test_char('X'));
+        }
+
+        // Erase from cursor to end of line.
+        buffer.erase_line(EraseLineMode::FromCursorToEnd);
+
+        // Columns 0-1 should still be 'X', columns 2-3 should be erased (styled space).
+        for col_idx in 0..2 {
+            assert_eq!(
+                buffer.get_char(row(1) + col(col_idx)).unwrap(),
+                create_test_char('X')
+            );
+        }
+        for col_idx in 2..4 {
+            assert_eq!(
+                buffer.get_char(row(1) + col(col_idx)).unwrap(),
+                create_plain_test_char(' ')
+            );
+        }
+    }
+
+    #[test]
+    fn test_erase_line_from_start_to_cursor() {
+        let mut buffer = create_test_buffer();
+        buffer.cursor_pos = row(1) + col(2);
+
+        // Fill the line with test characters.
+        for col_idx in 0..4 {
+            let _unused = buffer.set_char(row(1) + col(col_idx), create_test_char('X'));
+        }
+
+        // Erase from start of line to cursor.
+        buffer.erase_line(EraseLineMode::FromStartToCursor);
+
+        // Columns 0-2 should be erased (styled space), column 3 should still be 'X'.
+        for col_idx in 0..=2 {
+            assert_eq!(
+                buffer.get_char(row(1) + col(col_idx)).unwrap(),
+                create_plain_test_char(' ')
+            );
+        }
+        assert_eq!(
+            buffer.get_char(row(1) + col(3)).unwrap(),
+            create_test_char('X')
+        );
+    }
+
+    #[test]
+    fn test_erase_line_entire_line() {
+        let mut buffer = create_test_buffer();
+        buffer.cursor_pos = row(1) + col(2);
+
+        // Fill the line with test characters.
+        for col_idx in 0..4 {
+            let _unused = buffer.set_char(row(1) + col(col_idx), create_test_char('X'));
+        }
+
+        // Erase entire line.
+        buffer.erase_line(EraseLineMode::EntireLine);
+
+        // All columns should be erased.
+        for col_idx in 0..4 {
+            assert_eq!(
+                buffer.get_char(row(1) + col(col_idx)).unwrap(),
+                create_plain_test_char(' ')
+            );
+        }
+    }
+
+    #[test]
+    fn test_erase_line_out_of_bounds() {
+        let mut buffer = create_test_buffer();
+
+        // Position cursor outside the buffer.
+        buffer.cursor_pos = row(10) + col(0);
+        buffer.erase_line(EraseLineMode::EntireLine);
+        // Must silently no-op, not panic — per VT-100 spec.
+    }
+
+    #[test]
+    fn test_erase_display_from_cursor_to_end() {
+        let mut buffer = create_test_buffer();
+        buffer.cursor_pos = row(2) + col(2);
+
+        // Fill the entire buffer with test characters.
+        for row_idx in 0..5 {
+            for col_idx in 0..4 {
+                let _unused =
+                    buffer.set_char(row(row_idx) + col(col_idx), create_test_char('X'));
+            }
+        }
+
+        // Erase from cursor to end of display.
+        buffer.erase_display(EraseDisplayMode::FromCursorToEnd);
+
+        // Rows 0-1 should still be 'X' (unchanged).
+        for row_idx in 0..2 {
+            for col_idx in 0..4 {
+                assert_eq!(
+                    buffer.get_char(row(row_idx) + col(col_idx)).unwrap(),
+                    create_test_char('X')
+                );
+            }
+        }
+
+        // Row 2: col 0-1 unchanged, col 2-3 erased.
+        for col_idx in 0..2 {
+            assert_eq!(
+                buffer.get_char(row(2) + col(col_idx)).unwrap(),
+                create_test_char('X')
+            );
+        }
+        for col_idx in 2..4 {
+            assert_eq!(
+                buffer.get_char(row(2) + col(col_idx)).unwrap(),
+                create_plain_test_char(' ')
+            );
+        }
+
+        // Rows 3-4 should be entirely erased.
+        for row_idx in 3..5 {
+            for col_idx in 0..4 {
+                assert_eq!(
+                    buffer.get_char(row(row_idx) + col(col_idx)).unwrap(),
+                    create_plain_test_char(' ')
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_erase_display_from_start_to_cursor() {
+        let mut buffer = create_test_buffer();
+        buffer.cursor_pos = row(2) + col(2);
+
+        // Fill the entire buffer with test characters.
+        for row_idx in 0..5 {
+            for col_idx in 0..4 {
+                let _unused =
+                    buffer.set_char(row(row_idx) + col(col_idx), create_test_char('X'));
+            }
+        }
+
+        // Erase from start of display to cursor.
+        buffer.erase_display(EraseDisplayMode::FromStartToCursor);
+
+        // Rows 0-1 should be entirely erased.
+        for row_idx in 0..2 {
+            for col_idx in 0..4 {
+                assert_eq!(
+                    buffer.get_char(row(row_idx) + col(col_idx)).unwrap(),
+                    create_plain_test_char(' ')
+                );
+            }
+        }
+
+        // Row 2: col 0-2 erased, col 3 unchanged.
+        for col_idx in 0..=2 {
+            assert_eq!(
+                buffer.get_char(row(2) + col(col_idx)).unwrap(),
+                create_plain_test_char(' ')
+            );
+        }
+        assert_eq!(
+            buffer.get_char(row(2) + col(3)).unwrap(),
+            create_test_char('X')
+        );
+
+        // Rows 3-4 should still be 'X' (unchanged).
+        for row_idx in 3..5 {
+            for col_idx in 0..4 {
+                assert_eq!(
+                    buffer.get_char(row(row_idx) + col(col_idx)).unwrap(),
+                    create_test_char('X')
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_erase_display_entire_screen() {
+        let mut buffer = create_test_buffer();
+        buffer.cursor_pos = row(2) + col(2);
+
+        // Fill the entire buffer with test characters.
+        for row_idx in 0..5 {
+            for col_idx in 0..4 {
+                let _unused =
+                    buffer.set_char(row(row_idx) + col(col_idx), create_test_char('X'));
+            }
+        }
+
+        // Erase entire screen.
+        buffer.erase_display(EraseDisplayMode::EntireScreen);
+
+        // All rows should be entirely erased.
+        for row_idx in 0..5 {
+            for col_idx in 0..4 {
+                assert_eq!(
+                    buffer.get_char(row(row_idx) + col(col_idx)).unwrap(),
+                    create_plain_test_char(' ')
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_erase_display_entire_screen_and_scrollback() {
+        let mut buffer = create_test_buffer();
+        buffer.cursor_pos = row(2) + col(2);
+
+        // Fill the entire buffer with test characters.
+        for row_idx in 0..5 {
+            for col_idx in 0..4 {
+                let _unused =
+                    buffer.set_char(row(row_idx) + col(col_idx), create_test_char('X'));
+            }
+        }
+
+        // Erase entire screen and scrollback.
+        buffer.erase_display(EraseDisplayMode::EntireScreenAndScrollback);
+
+        // All rows should be entirely erased.
+        for row_idx in 0..5 {
+            for col_idx in 0..4 {
+                assert_eq!(
+                    buffer.get_char(row(row_idx) + col(col_idx)).unwrap(),
+                    create_plain_test_char(' ')
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Implement EL (Erase Line) and ED (Erase Display) escape sequence handling for the VT-100 PTY mux shim layer. These are standard ANSI terminal sequences used by terminal applications to clear portions of the screen.

### Changes

- **EL (Erase Line)** — `CSI n K` with modes:
  - `FromCursorToEnd` (0): erase from cursor to end of line
  - `FromStartToCursor` (1): erase from start of line to cursor
  - `EntireLine` (2): erase entire line

- **ED (Erase Display)** — `CSI n J` with modes:
  - `FromCursorToEnd` (0): erase from cursor to end of screen
  - `FromStartToCursor` (1): erase from start of screen to cursor
  - `EntireScreen` (2): erase entire visible screen
  - `EntireScreenAndScrollback` (3): erase entire screen and scrollback buffer

### Design

- SGR style (colors, bold, italic, etc.) applied at the time of erasure is preserved in the fill characters, matching real terminal behavior
- Cursor position is preserved (these are non-destructive operations that only affect display content)
- VT-100 no-op semantics are respected when cursor is beyond buffer bounds
- Parser parameter extraction uses the existing safe helper (`extract_nth_single_opt_raw`)

### Testing

- Unit tests for all EL/ED modes
- SGR style preservation tests verify that erasures carry the correct styling
- Screen rendered integration test (`test_paint_after_clear_sequence_rendered`) validates the full render pipeline

Before:
<img width="960" height="1080" alt="screenshot1" src="https://github.com/user-attachments/assets/ae46d5c0-e9cf-41b0-970f-a97e7d0e63db" />

After:
<img width="960" height="1080" alt="screenshot2" src="https://github.com/user-attachments/assets/137f0cba-34ad-4314-b117-7d053335247c" />