### PR TITLE
fix: respond to DA1 (Device Attributes) queries to prevent fish shell timeout

### DIFF
--- a/tui/src/core/ansi/vt_100_pty_output_parser/ansi_parser_public_api.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ansi_parser_public_api.rs
@@ -20,13 +20,14 @@
 //!     SgrCode::ForegroundBasic(ANSIBasicColor::Red),
 //!     SgrCode::Reset
 //! );
-//! let (osc_events, dsr_responses) = buffer.apply_ansi_bytes(pty_output);
-//! // Buffer now contains styled text, events contain any OSC/DSR commands
+//! let (osc_events, dsr_responses, _da_responses) = buffer.apply_ansi_bytes(pty_output);
+//! // Buffer now contains styled text, events contain any OSC/DSR/DA commands
 //! ```
 //!
 //! # Returns
 //!
-//! [`OSC`] events (window titles, etc.) and [`DSR`] responses (terminal status queries).
+//! [`OSC`] events (window titles, etc.), [`DSR`] responses (terminal status queries),
+//! and [`DA`] responses (device attributes queries).
 //!
 //! For implementation details, architecture patterns, and testing strategy, see the the
 //! architecture and testing strategy which covers the shim → impl → test design pattern.
@@ -214,6 +215,11 @@ impl OffscreenBuffer {
     ///   detected.
     /// - A vector of [`DSR response events`] that need to be sent back to the child
     ///   process through the [`PTY`] input channel.
+    /// - A vector of [`DA`] (Device Attributes) response strings that need to be sent
+    ///   back to the child process through the [`PTY`] input channel. Terminal apps
+    ///   (fish, vim, etc.) send `CSI c` to detect terminal capabilities; these
+    ///   pre-formatted ANSI strings (e.g. `"\x1b[?62;22c"`) must be written back to
+    ///   the PTY to prevent timeouts.
     ///
     /// # Example
     ///
@@ -224,7 +230,7 @@ impl OffscreenBuffer {
     /// let red_text = format!("Hello{a}Red Text{b}",
     ///     a = SgrCode::ForegroundBasic(ANSIBasicColor::DarkRed),
     ///     b = SgrCode::Reset);
-    /// let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(red_text);
+    /// let (osc_events, dsr_responses, _da_responses) = ofs_buf.apply_ansi_bytes(red_text);
     /// ```
     ///
     /// # Processing details
@@ -256,7 +262,7 @@ impl OffscreenBuffer {
     pub fn apply_ansi_bytes(
         &mut self,
         bytes: impl AsRef<[u8]>,
-    ) -> (Vec<OscEvent>, Vec<DsrRequestFromPtyEvent>) {
+    ) -> (Vec<OscEvent>, Vec<DsrRequestFromPtyEvent>, Vec<String>) {
         let mut performer = AnsiToOfsBufPerformer::new(self);
         performer.apply_ansi_bytes(bytes.as_ref());
 
@@ -265,8 +271,10 @@ impl OffscreenBuffer {
             take(&mut performer.ofs_buf.ansi_parser_support.pending_osc_events);
         let pending_dsr_requests =
             take(&mut performer.ofs_buf.ansi_parser_support.pending_dsr_responses);
+        let pending_da_responses =
+            take(&mut performer.ofs_buf.ansi_parser_support.pending_da_responses);
 
-        (osc_events, pending_dsr_requests)
+        (osc_events, pending_dsr_requests, pending_da_responses)
     }
 }
 
@@ -302,7 +310,7 @@ mod tests {
         //                               ╰─ cursor ends here
 
         // Test that the public API processes text correctly.
-        let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(TEXT);
+        let (osc_events, dsr_responses, _da_responses) = ofs_buf.apply_ansi_bytes(TEXT);
 
         // Should not produce any OSC events for SGR sequences.
         assert_eq!(osc_events.len(), 0, "no OSC events expected");
@@ -341,7 +349,7 @@ mod tests {
         // Sequence: ESC[31m + "Red Text" + ESC[0m
 
         // Test processing with ANSI color codes.
-        let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(format!(
+        let (osc_events, dsr_responses, _da_responses) = ofs_buf.apply_ansi_bytes(format!(
             "{red_fg}{text}{reset}",
             red_fg = SgrCode::ForegroundBasic(ANSIBasicColor::Red),
             text = TEXT,
@@ -397,7 +405,7 @@ mod tests {
         // 5. Write 'D' at (0,4) → cursor moves to (0,5)
 
         // Test cursor movement sequences.
-        let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(format!(
+        let (osc_events, dsr_responses, _da_responses) = ofs_buf.apply_ansi_bytes(format!(
             "A{right_2}B{up_1}D",
             // SAFETY: 2 and 1 are non-zero
             right_2 = CsiSequence::CursorForward(term_col_delta(2).unwrap()),
@@ -428,7 +436,7 @@ mod tests {
 
         // First call with OSC sequence (set title).
         let osc_title = OscSequence::SetTitleAndIcon("First Title".into()).to_string();
-        let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(&osc_title);
+        let (osc_events, dsr_responses, _da_responses) = ofs_buf.apply_ansi_bytes(&osc_title);
 
         assert_eq!(osc_events.len(), 1, "should get one OSC event");
         assert_eq!(dsr_responses.len(), 0, "no DSR responses expected");
@@ -442,7 +450,7 @@ mod tests {
 
         // Second call with another OSC sequence.
         let osc_title2 = OscSequence::SetTitleAndIcon("Second Title".into()).to_string();
-        let (osc_events2, dsr_responses2) = ofs_buf.apply_ansi_bytes(&osc_title2);
+        let (osc_events2, dsr_responses2, _da_responses2) = ofs_buf.apply_ansi_bytes(&osc_title2);
 
         assert_eq!(
             osc_events2.len(),
@@ -463,7 +471,7 @@ mod tests {
 
         // Third call with no OSC sequences.
         let plain_text = "Hello";
-        let (osc_events3, dsr_responses3) = ofs_buf.apply_ansi_bytes(plain_text);
+        let (osc_events3, dsr_responses3, _da_responses3) = ofs_buf.apply_ansi_bytes(plain_text);
 
         assert_eq!(
             osc_events3.len(),
@@ -479,7 +487,7 @@ mod tests {
 
         // First DSR request (status report).
         let dsr_status = DSR_STATUS_REQUEST.to_string();
-        let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(&dsr_status);
+        let (osc_events, dsr_responses, _da_responses) = ofs_buf.apply_ansi_bytes(&dsr_status);
 
         assert_eq!(osc_events.len(), 0, "no OSC events expected");
         assert_eq!(dsr_responses.len(), 1, "should get one DSR response");
@@ -487,7 +495,7 @@ mod tests {
 
         // Second call with cursor position request.
         let dsr_cursor = DSR_CURSOR_POSITION_REQUEST.to_string();
-        let (osc_events2, dsr_responses2) = ofs_buf.apply_ansi_bytes(&dsr_cursor);
+        let (osc_events2, dsr_responses2, _da_responses2) = ofs_buf.apply_ansi_bytes(&dsr_cursor);
 
         assert_eq!(osc_events2.len(), 0, "no OSC events expected");
         assert_eq!(
@@ -516,7 +524,7 @@ mod tests {
 
         // Third call with no DSR requests.
         let plain_text = "Test";
-        let (osc_events3, dsr_responses3) = ofs_buf.apply_ansi_bytes(plain_text);
+        let (osc_events3, dsr_responses3, _da_responses3) = ofs_buf.apply_ansi_bytes(plain_text);
 
         assert_eq!(osc_events3.len(), 0, "no OSC events expected");
         assert_eq!(
@@ -538,7 +546,7 @@ mod tests {
             crate::DSR_CURSOR_POSITION_REQUEST                  // DSR: Cursor position
         );
 
-        let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(&mixed_sequence);
+        let (osc_events, dsr_responses, _da_responses) = ofs_buf.apply_ansi_bytes(&mixed_sequence);
 
         // Should get exactly one OSC event.
         assert_eq!(osc_events.len(), 1, "should get one OSC event");
@@ -566,7 +574,7 @@ mod tests {
         }
 
         // Verify both are drained on next call.
-        let (osc_events2, dsr_responses2) = ofs_buf.apply_ansi_bytes("text");
+        let (osc_events2, dsr_responses2, _da_responses2) = ofs_buf.apply_ansi_bytes("text");
         assert_eq!(osc_events2.len(), 0, "OSC events should be drained");
         assert_eq!(dsr_responses2.len(), 0, "DSR responses should be drained");
     }
@@ -583,7 +591,7 @@ mod tests {
             OscSequence::SetIcon("Icon Name".into())          // OSC 1
         );
 
-        let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(&multi_osc);
+        let (osc_events, dsr_responses, _da_responses) = ofs_buf.apply_ansi_bytes(&multi_osc);
 
         assert_eq!(osc_events.len(), 3, "should get three OSC events");
         assert_eq!(dsr_responses.len(), 0, "no DSR responses expected");
@@ -597,7 +605,7 @@ mod tests {
         }
 
         // Next call should have empty events.
-        let (osc_events2, dsr_responses2) = ofs_buf.apply_ansi_bytes("normal text");
+        let (osc_events2, dsr_responses2, _da_responses2) = ofs_buf.apply_ansi_bytes("normal text");
         assert_eq!(osc_events2.len(), 0, "OSC events should be drained");
         assert_eq!(dsr_responses2.len(), 0, "DSR responses should be drained");
     }
@@ -631,7 +639,7 @@ mod tests {
     fn test_public_api_csi_position_change() {
         let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
 
-        let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(format!(
+        let (osc_events, dsr_responses, _da_responses) = ofs_buf.apply_ansi_bytes(format!(
             "Start{move_to_r2_c3}Mid{move_to_r1_c1}Home{move_to_r8_c8}End",
             move_to_r2_c3 = csi_seq_cursor_pos(term_row(nz(2)) + term_col(nz(3))),
             move_to_r1_c1 = csi_seq_cursor_pos(term_row(nz(1)) + term_col(nz(1))),

--- a/tui/src/core/ansi/vt_100_pty_output_parser/performer.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/performer.rs
@@ -642,15 +642,41 @@ impl Perform for AnsiToOfsBufPerformer<'_> {
                 });
             }
             'c' => {
-                // DA (Device Attributes) - Request terminal type/capabilities
-                // Not needed: Multiplexer doesn't respond to queries, parent terminal
-                // does. See [mod-level docs](crate::vt_100_pty_output_parser) for
-                // rationale
-                DEBUG_TUI_VT100_PARSER.then(|| {
-                    tracing::warn!(
-                    "CSI c: Device Attributes query not supported in multiplexer"
-                );
-                });
+                // DA (Device Attributes) - Request terminal type/capabilities.
+                // CSI c without params or with param 0 is a DA1 (Primary Device
+                // Attributes) query. Terminal apps like fish, vim, and neovim send
+                // this to detect terminal capabilities. If the multiplexer doesn't
+                // respond, the app waits ~10s and falls back with reduced features
+                // (fish shows a warning, vim treats colors as 8-color, etc.).
+                //
+                // We respond with CSI ? 62 ; 22 c:
+                //   62 = VT220 (basic terminal with scrolling regions)
+                //   22 = ANSI color support (enables 256-color mode in fish/vim)
+                //
+                // This is a conservative response that enables ANSI colors and basic
+                // VT features without claiming capabilities we don't implement.
+                // Params greater than 0 or '>' prefix (DA2/DA3) are ignored -
+                // responding to DA1 is sufficient for all common terminal apps.
+                let params_empty_or_zero = params
+                    .iter()
+                    .all(|p| p.len() == 0 || (p.len() == 1 && p[0] == 0));
+                if intermediates.is_empty() && params_empty_or_zero {
+                    self.ofs_buf
+                        .ansi_parser_support
+                        .pending_da_responses
+                        .push("\x1b[?62;22c".to_string());
+                    DEBUG_TUI_VT100_PARSER.then(|| {
+                        tracing::debug!("CSI c: DA1 responded with CSI ? 62 ; 22 c");
+                    });
+                } else {
+                    DEBUG_TUI_VT100_PARSER.then(|| {
+                        tracing::debug!(
+                            "CSI c: DA query ignored (params={:?}, intermediates={:?})",
+                            params,
+                            intermediates
+                        );
+                    });
+                }
             }
             'q' => {
                 // DECSCUSR (Set Cursor Style) - Change cursor shape/blink

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/conformance_data/mod.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/conformance_data/mod.rs
@@ -146,7 +146,7 @@
 //!
 //!     // Apply sequence using conformance data
 //!     let sequence = vim_sequences::vim_status_line("INSERT", 25);
-//!     let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(sequence);
+//!     let (osc_events, dsr_responses, _da_responses) = ofs_buf.apply_ansi_bytes(sequence);
 //!
 //!     // Validate behavior
 //!     assert_eq!(osc_events.len(), 0);

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/mod.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/mod.rs
@@ -322,7 +322,7 @@
 //!
 //! // Apply vim status line sequence
 //! let sequence = vim_sequences::vim_status_line("INSERT", 25);
-//! let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(sequence);
+//! let (osc_events, dsr_responses, _da_responses) = ofs_buf.apply_ansi_bytes(sequence);
 //!
 //! // Verify status line appears at bottom with correct styling
 //! assert_styled_char_at(&ofs_buf, 24, 0, '-', |style| {

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/mod.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/mod.rs
@@ -59,6 +59,9 @@ pub mod vt_100_test_control_ops;
 pub mod vt_100_test_cursor_ops;
 
 #[cfg(any(test, doc))]
+pub mod vt_100_test_da_ops;
+
+#[cfg(any(test, doc))]
 pub mod vt_100_test_dsr_ops;
 
 #[cfg(any(test, doc))]

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_da_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_da_ops.rs
@@ -1,0 +1,88 @@
+// Copyright (c) 2025 R3BL LLC. Licensed under Apache License, Version 2.0.
+
+//! Tests for Device Attributes ([`DA`]) response generation.
+//!
+//! Terminal apps like fish, vim, and neovim send `CSI c` (DA1 - Primary Device
+//! Attributes) to detect terminal capabilities. If the terminal emulator doesn't
+//! respond, the app times out after ~10 seconds and falls back with reduced
+//! features.
+//!
+//! [`DA`]: https://vt100.net/docs/vt100-ug/chapter3.html#T3-6
+
+use super::super::test_fixtures_vt_100_ansi_conformance::
+    create_test_offscreen_buffer_10r_by_10c;
+use crate::tui::terminal_lib_backends::offscreen_buffer::test_fixtures_ofs_buf::
+    assert_plain_text_at;
+
+#[test]
+fn test_da1_no_params_responds() {
+    let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+
+    let (osc_events, dsr_responses, da_responses) =
+        ofs_buf.apply_ansi_bytes("\x1b[c");
+
+    assert_eq!(osc_events.len(), 0, "no OSC events expected");
+    assert_eq!(dsr_responses.len(), 0, "no DSR responses expected");
+    assert_eq!(da_responses.len(), 1, "expected exactly one DA response");
+    assert_eq!(
+        da_responses[0], "\x1b[?62;22c",
+        "expected CSI ? 62 ; 22 c (VT220 + ANSI color)"
+    );
+}
+
+#[test]
+fn test_da1_param_zero_responds() {
+    let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+
+    let (osc_events, dsr_responses, da_responses) =
+        ofs_buf.apply_ansi_bytes("\x1b[0c");
+
+    assert_eq!(osc_events.len(), 0, "no OSC events expected");
+    assert_eq!(dsr_responses.len(), 0, "no DSR responses expected");
+    assert_eq!(da_responses.len(), 1, "expected exactly one DA response");
+    assert_eq!(
+        da_responses[0], "\x1b[?62;22c",
+        "expected CSI ? 62 ; 22 c"
+    );
+}
+
+#[test]
+fn test_da2_ignored() {
+    let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+
+    let (osc_events, dsr_responses, da_responses) =
+        ofs_buf.apply_ansi_bytes("\x1b[>c");
+
+    assert_eq!(osc_events.len(), 0, "no OSC events expected");
+    assert_eq!(dsr_responses.len(), 0, "no DSR responses expected");
+    assert_eq!(
+        da_responses.len(), 0,
+        "DA2 should be ignored (intermediates present)"
+    );
+}
+
+#[test]
+fn test_da1_with_nonzero_param_ignored() {
+    let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+
+    let (osc_events, dsr_responses, da_responses) =
+        ofs_buf.apply_ansi_bytes("\x1b[1c");
+
+    assert_eq!(osc_events.len(), 0, "no OSC events expected");
+    assert_eq!(dsr_responses.len(), 0, "no DSR responses expected");
+    assert_eq!(
+        da_responses.len(), 0,
+        "DA1 with param 1 should be ignored"
+    );
+}
+
+#[test]
+fn test_da1_no_param_does_not_affect_buffer() {
+    let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+
+    let (osc_events, _dsr_responses, _da_responses) =
+        ofs_buf.apply_ansi_bytes("\x1b[cafter");
+
+    assert_eq!(osc_events.len(), 0, "no OSC events expected");
+    assert_plain_text_at(&ofs_buf, 0, 0, "after");
+}

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_dsr_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_dsr_ops.rs
@@ -23,7 +23,7 @@ fn test_dsr_status_report() {
         "{}",
         CsiSequence::DeviceStatusReport(DsrRequestType::RequestStatus)
     );
-    let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(&dsr_request);
+    let (osc_events, dsr_responses, _da_responses) = ofs_buf.apply_ansi_bytes(&dsr_request);
 
     // Should not produce OSC events.
     assert_eq!(osc_events.len(), 0, "no OSC events expected");
@@ -59,7 +59,7 @@ fn test_dsr_cursor_position_report() {
         "{}",
         CsiSequence::DeviceStatusReport(DsrRequestType::RequestCursorPosition)
     );
-    let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(&dsr_request);
+    let (osc_events, dsr_responses, _da_responses) = ofs_buf.apply_ansi_bytes(&dsr_request);
 
     // Should not produce OSC events.
     assert_eq!(osc_events.len(), 0, "no OSC events expected");
@@ -99,7 +99,7 @@ fn test_dsr_cursor_position_at_origin() {
         "{}",
         CsiSequence::DeviceStatusReport(DsrRequestType::RequestCursorPosition)
     );
-    let (_osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(&dsr_request);
+    let (_osc_events, dsr_responses, _da_responses) = ofs_buf.apply_ansi_bytes(&dsr_request);
 
     // Should produce cursor position report at (1, 1) in 1-based coordinates
     assert_eq!(
@@ -130,7 +130,7 @@ fn test_dsr_unknown_request() {
         "{}",
         CsiSequence::DeviceStatusReport(DsrRequestType::Other(99))
     );
-    let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(&dsr_request);
+    let (osc_events, dsr_responses, _da_responses) = ofs_buf.apply_ansi_bytes(&dsr_request);
 
     // Should not produce any events for unknown DSR requests.
     assert_eq!(osc_events.len(), 0, "no OSC events expected");
@@ -155,7 +155,7 @@ fn test_multiple_dsr_requests() {
         CsiSequence::DeviceStatusReport(DsrRequestType::RequestCursorPosition), /* Cursor position */
         CsiSequence::DeviceStatusReport(DsrRequestType::Other(99)) // Unknown
     );
-    let (_osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(&dsr_requests);
+    let (_osc_events, dsr_responses, _da_responses) = ofs_buf.apply_ansi_bytes(&dsr_requests);
 
     // Should produce exactly two DSR responses (status and cursor position)
     assert_eq!(dsr_responses.len(), 2, "expected two DSR responses");
@@ -180,12 +180,12 @@ fn test_dsr_events_are_cleared_after_processing() {
         "{}",
         CsiSequence::DeviceStatusReport(DsrRequestType::RequestStatus)
     );
-    let (_, dsr_responses1) = ofs_buf.apply_ansi_bytes(&dsr_request);
+    let (_, dsr_responses1, _da_responses1) = ofs_buf.apply_ansi_bytes(&dsr_request);
     assert_eq!(dsr_responses1.len(), 1, "expected one DSR response");
 
     // Second call without any DSR request.
     let plain_text = "Hello";
-    let (_, dsr_responses2) = ofs_buf.apply_ansi_bytes(plain_text);
+    let (_, dsr_responses2, _da_responses2) = ofs_buf.apply_ansi_bytes(plain_text);
     assert_eq!(
         dsr_responses2.len(),
         0,
@@ -197,7 +197,7 @@ fn test_dsr_events_are_cleared_after_processing() {
         "{}",
         CsiSequence::DeviceStatusReport(DsrRequestType::RequestCursorPosition)
     );
-    let (_, dsr_responses3) = ofs_buf.apply_ansi_bytes(&dsr_request);
+    let (_, dsr_responses3, _da_responses3) = ofs_buf.apply_ansi_bytes(&dsr_request);
     assert_eq!(
         dsr_responses3.len(),
         1,

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_integration_real_world.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_integration_real_world.rs
@@ -32,7 +32,7 @@ fn test_vim_status_line_pattern() {
 
     // Use the vim_sequences builder to create a realistic status line
     let sequence = vim_sequences::vim_status_line("INSERT", nz(25));
-    let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(sequence);
+    let (osc_events, dsr_responses, _da_responses) = ofs_buf.apply_ansi_bytes(sequence);
 
     // Verify no OSC/DSR events for this operation
     assert_eq!(osc_events.len(), 0);

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_osc_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_osc_ops.rs
@@ -14,7 +14,7 @@ fn test_osc_title_sequences() {
 
     // Test OSC 0 (set title and icon)
     let sequence1 = OscSequence::SetTitleAndIcon("Test Title".to_string()).to_string();
-    let (osc_events1, dsr_responses1) = ofs_buf.apply_ansi_bytes(sequence1);
+    let (osc_events1, dsr_responses1, _da_responses1) = ofs_buf.apply_ansi_bytes(sequence1);
 
     // Should get one OSC event.
     assert_eq!(osc_events1.len(), 1);
@@ -29,7 +29,7 @@ fn test_osc_title_sequences() {
 
     // Test OSC 2 (set title only)
     let sequence2 = OscSequence::SetTitle("Window Title".to_string()).to_string();
-    let (osc_events2, dsr_responses2) = ofs_buf.apply_ansi_bytes(sequence2);
+    let (osc_events2, dsr_responses2, _da_responses2) = ofs_buf.apply_ansi_bytes(sequence2);
 
     // Should get one new OSC event (not accumulated)
     assert_eq!(osc_events2.len(), 1);
@@ -54,7 +54,7 @@ fn test_osc_hyperlink() {
     };
     let hyperlink_end = OscSequence::HyperlinkEnd;
     let sequence = format!("{hyperlink_start}Link Text{hyperlink_end}");
-    let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(sequence);
+    let (osc_events, dsr_responses, _da_responses) = ofs_buf.apply_ansi_bytes(sequence);
 
     // Should get two OSC events (start and end hyperlink)
     assert_eq!(osc_events.len(), 2);
@@ -71,7 +71,7 @@ fn test_osc_hyperlink() {
     assert_plain_text_at(&ofs_buf, 0, 0, "Link Text");
 
     // Verify events are drained on next call.
-    let (osc_events2, dsr_responses2) = ofs_buf.apply_ansi_bytes("more text");
+    let (osc_events2, dsr_responses2, _da_responses2) = ofs_buf.apply_ansi_bytes("more text");
     assert_eq!(osc_events2.len(), 0, "OSC events should be drained");
     assert_eq!(dsr_responses2.len(), 0, "DSR responses should be empty");
 }

--- a/tui/src/core/pty/pty_mux/process_manager.rs
+++ b/tui/src/core/pty/pty_mux/process_manager.rs
@@ -110,7 +110,7 @@ impl Process {
     pub fn process_pty_output_and_update_buffer(&mut self, output: Vec<u8>) {
         if !output.is_empty() {
             // Process bytes and extract any OSC and DSR events.
-            let (osc_events, dsr_requests) = self.ofs_buf.apply_ansi_bytes(&output);
+            let (osc_events, dsr_requests, da_responses) = self.ofs_buf.apply_ansi_bytes(&output);
 
             // Handle any OSC events that were detected.
             for event in osc_events {
@@ -144,6 +144,24 @@ impl Process {
                     let _unused = session
                         .tx_input_event
                         .try_send(crate::PtyInputEvent::Write(response_bytes));
+                }
+            }
+
+            // Handle any DA response strings - send them back through PTY.
+            if !da_responses.is_empty()
+                && let Some(session) = &self.session
+            {
+                for da_response in da_responses {
+                    tracing::debug!(
+                        "Process '{}' sending DA response: {:?}",
+                        self.name,
+                        da_response
+                    );
+                    let _unused = session
+                        .tx_input_event
+                        .try_send(crate::PtyInputEvent::Write(
+                            da_response.into_bytes(),
+                        ));
                 }
             }
             self.has_unrendered_output = true;

--- a/tui/src/tui/terminal_lib_backends/direct_to_ansi/output/direct_to_ansi_output_integration_tests/test_helpers_rendered.rs
+++ b/tui/src/tui/terminal_lib_backends/direct_to_ansi/output/direct_to_ansi_output_integration_tests/test_helpers_rendered.rs
@@ -108,7 +108,7 @@ pub fn execute_and_render_to_buffer_with_size(
     // Step 4: Create OffscreenBuffer and apply bytes.
     let mut ofs_buf =
         OffscreenBuffer::new_empty(buffer_size.row_height + buffer_size.col_width);
-    let (_osc_events, _dsr_responses) = ofs_buf.apply_ansi_bytes(ansi_bytes);
+    let (_osc_events, _dsr_responses, _da_responses) = ofs_buf.apply_ansi_bytes(ansi_bytes);
 
     ofs_buf
 }

--- a/tui/src/tui/terminal_lib_backends/offscreen_buffer/ofs_buf_core.rs
+++ b/tui/src/tui/terminal_lib_backends/offscreen_buffer/ofs_buf_core.rs
@@ -182,6 +182,16 @@ pub struct AnsiParserSupport {
     /// [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
     pub pending_dsr_responses: Vec<DsrRequestFromPtyEvent>,
 
+    /// DA (Device Attributes) response strings accumulated during processing - need to
+    /// be sent back to [`PTY`]. Terminal apps (fish, vim, etc.) send CSI c (DA1) to
+    /// detect terminal capabilities. If the terminal emulator (us) doesn't respond, the
+    /// app waits ~10s and falls back with limited features.
+    ///
+    /// Each entry is a raw ANSI response string (e.g. `"\x1b[?62;22c"`).
+    ///
+    /// [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
+    pub pending_da_responses: Vec<String>,
+
     /// Top margin for the **scrollable region** ([`DECSTBM`]) - 1-based row number.
     ///
     /// This variable defines the **upper boundary** of the area where scrolling occurs.
@@ -251,6 +261,7 @@ impl Default for AnsiParserSupport {
             current_style: TuiStyle::default(),
             pending_osc_events: Vec::new(),
             pending_dsr_responses: Vec::new(),
+            pending_da_responses: Vec::new(),
             scroll_region_top: None, // Default: no top margin (uses row 1)
             scroll_region_bottom: None, // Default: no bottom margin (uses last row)
             cursor_visibility: CursorVisibilityState::Visible, // DECTCEM default: visible


### PR DESCRIPTION
## Summary

Handle DA1 (Primary Device Attributes, `CSI c`) queries in the PTY mux shim to prevent fish shell and other terminal applications from timing out while waiting for a terminal capability response.

### Problem

Fish shell (and vim, neovim, etc.) send `CSI c` to detect terminal capabilities. The r3bl VT-100 parser was silently ignoring these queries, causing a ~10 second timeout and warnings about missing terminal features.

### Changes

- Respond with `CSI ? 62 ; 22 c` on DA1 (VT220 + ANSI color)
- Extended `apply_ansi_bytes()` return type from 2-tuple to 3-tuple to propagate DA responses alongside existing OSC and DSR channels
- DA responses forwarded back to the PTY child via `PtyInputEvent::Write`
- Ignores DA2 (`CSI > c`), DA3 (`CSI = c`), and parameterized variants
- Conformance tests for DA1/DA2 behavior and buffer side-effect verification

### Questions

👋 Hey Nazmul — this is a draft PR, not ready for review yet. Before I sink more time into refining it, I wanted to check: **are you already working on DA1 support**, or is this something nobody has started yet? Happy to let this sit if you've got it covered, or to polish it up if not.

Before:

<img width="960" height="1080" alt="screenshot1" src="https://github.com/user-attachments/assets/dba49a3c-d50c-4ccb-9d41-869e3dca1b80" />

After:

<img width="960" height="1080" alt="screenshot4" src="https://github.com/user-attachments/assets/2b4d6d1e-53a0-42c6-8185-4253261f3e6d" />
