### PR TITLE
fix: implement VT100 pending-wrap and scroll region bounds for OffscreenBuffer

### DIFF
--- a/tui/src/tui/terminal_lib_backends/offscreen_buffer/ofs_buf_core.rs
+++ b/tui/src/tui/terminal_lib_backends/offscreen_buffer/ofs_buf_core.rs
@@ -769,6 +769,42 @@ impl OffscreenBuffer {
         }
     }
 
+    /// Resize the buffer to a new window size, preserving as much content as fits.
+    /// Cursor position is clamped to the new bounds.
+    pub fn resize(&mut self, arg_new_size: impl Into<Size>) {
+        let new_size: Size = arg_new_size.into();
+        let old_height = self.buffer.len();
+        let old_width = self.buffer.first().map_or(0, |l| l.len());
+        let new_height = new_size.row_height.as_usize();
+        let new_width = new_size.col_width.as_usize();
+
+        let mut new_lines = PixelCharLines::new_empty(new_size);
+
+        let copy_rows = old_height.min(new_height);
+        let copy_cols = old_width.min(new_width);
+        for i in 0..copy_rows {
+            let src = &self.buffer[i].pixel_chars;
+            let dst = &mut new_lines[i].pixel_chars;
+            dst[..copy_cols].copy_from_slice(&src[..copy_cols]);
+        }
+
+        self.buffer = new_lines;
+        self.window_size = new_size;
+
+        let cur_row = self.cursor_pos.row_index.as_usize().min(new_height.saturating_sub(1));
+        let cur_col = self.cursor_pos.col_index.as_usize().min(new_width.saturating_sub(1));
+        self.cursor_pos = Pos {
+            row_index: row(cur_row),
+            col_index: col(cur_col),
+        };
+
+        self.memory_size = MemorySize::new(
+            self.buffer.get_mem_size()
+                + std::mem::size_of::<Size>()
+                + std::mem::size_of::<Pos>(),
+        );
+    }
+
     // Make sure each line is full of empty chars.
     pub fn clear(&mut self) {
         for line in self.buffer.iter_mut() {

--- a/tui/src/tui/terminal_lib_backends/offscreen_buffer/ofs_buf_core.rs
+++ b/tui/src/tui/terminal_lib_backends/offscreen_buffer/ofs_buf_core.rs
@@ -167,6 +167,23 @@ pub struct AnsiParserSupport {
     /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
     pub auto_wrap_mode: AutoWrapState,
 
+    /// Tracks the VT100 "pending wrap" (aka "wrapneeded") state.
+    ///
+    /// When auto-wrap mode is enabled and a printable character is written to the
+    /// last column, the terminal does **not** immediately wrap to the next line.
+    /// Instead, it enters a "pending wrap" state where the cursor stays at the
+    /// right margin (visual column = width) but the next printable character
+    /// triggers the actual wrap. Cursor movement commands (CR, LF, CUP, etc.)
+    /// and screen scrolling cancel the pending wrap.
+    ///
+    /// This behavior is critical for correct fish-shell rendering where
+    /// `abandon_line_string` does: write to last col, then `\r` — the `\r`
+    /// must cancel the pending wrap and move to column 0 of the *same* line.
+    ///
+    /// When `true`: the next printable character must wrap to start of next line
+    /// before being printed. When `false`: normal printing behavior.
+    pub pending_wrap: bool,
+
     /// Complete computed style combining attributes and colors for efficient rendering.
     pub current_style: TuiStyle,
 
@@ -248,6 +265,7 @@ impl Default for AnsiParserSupport {
             cursor_pos_for_esc_save_and_restore: None,
             character_set: CharacterSet::default(),
             auto_wrap_mode: AutoWrapState::Enabled, // DECAWM default: Enabled
+            pending_wrap: false,
             current_style: TuiStyle::default(),
             pending_osc_events: Vec::new(),
             pending_dsr_responses: Vec::new(),

--- a/tui/src/tui/terminal_lib_backends/offscreen_buffer/vt_100_ansi_impl/vt_100_impl_char_ops.rs
+++ b/tui/src/tui/terminal_lib_backends/offscreen_buffer/vt_100_ansi_impl/vt_100_impl_char_ops.rs
@@ -32,8 +32,8 @@
 
 #[allow(clippy::wildcard_imports)]
 use super::super::*;
-use crate::{ArrayBoundsCheck, ArrayOverflowResult, AutoWrapState, ColIndex, Length, NumericValue,
-            RowIndex, col,
+use crate::{ArrayBoundsCheck, ArrayOverflowResult, ArrayUnderflowResult, AutoWrapState, ColIndex,
+            Length, NumericValue, col,
             core::coordinates::bounds_check::{CursorBoundsCheck, LengthOps,
                                               RangeBoundsExt, RangeConvertExt},
             height, ok, width};
@@ -280,13 +280,22 @@ impl OffscreenBuffer {
     }
 
     /// Apply the VT100 "pending wrap" state if set.
+    ///
+    /// Respects [`DECSTBM`] scroll region bounds: if the cursor is at the bottom of the
+    /// scroll region, the region scrolls up instead of clamping the cursor.
     pub fn apply_pending_wrap(&mut self) {
         if self.ansi_parser_support.pending_wrap {
             self.ansi_parser_support.pending_wrap = false;
-            let row_max = self.window_size.row_height;
-            let next_row: RowIndex = self.cursor_pos.row_index + 1;
-            if next_row.overflows(row_max) == ArrayOverflowResult::Within {
-                self.cursor_pos.row_index = next_row;
+            let scroll_bottom = *self.get_scroll_range_inclusive().end();
+            if self
+                .cursor_pos
+                .row_index
+                .underflows(scroll_bottom)
+                == ArrayUnderflowResult::Underflowed
+            {
+                self.cursor_pos.row_index = self.cursor_pos.row_index + 1;
+            } else {
+                let _unused = self.index_down();
             }
             self.cursor_pos.col_index = col(0);
         }

--- a/tui/src/tui/terminal_lib_backends/offscreen_buffer/vt_100_ansi_impl/vt_100_impl_char_ops.rs
+++ b/tui/src/tui/terminal_lib_backends/offscreen_buffer/vt_100_ansi_impl/vt_100_impl_char_ops.rs
@@ -279,6 +279,19 @@ impl OffscreenBuffer {
         self.fill_char_range(at.row_index, erase_range, PixelChar::Spacer)
     }
 
+    /// Apply the VT100 "pending wrap" state if set.
+    pub fn apply_pending_wrap(&mut self) {
+        if self.ansi_parser_support.pending_wrap {
+            self.ansi_parser_support.pending_wrap = false;
+            let row_max = self.window_size.row_height;
+            let next_row: RowIndex = self.cursor_pos.row_index + 1;
+            if next_row.overflows(row_max) == ArrayOverflowResult::Within {
+                self.cursor_pos.row_index = next_row;
+            }
+            self.cursor_pos.col_index = col(0);
+        }
+    }
+
     /// Handles printable characters with character set translation, bounds checking, and
     /// line wrapping.
     ///
@@ -292,12 +305,14 @@ impl OffscreenBuffer {
     /// * `ch` - The character to print
     ///
     /// # Behavior
-    /// 1. Applies character set translation if in graphics mode
-    /// 2. Writes character to buffer at current cursor position (if within bounds)
-    /// 3. Advances cursor, handling line wrap based on DECAWM mode
+    /// 1. Applies pending wrap if set (VT100 wrapneeded semantics)
+    /// 2. Applies character set translation if in graphics mode
+    /// 3. Writes character to buffer at current cursor position (if within bounds)
+    /// 4. Advances cursor, entering pending-wrap state when at last column
     ///
     /// # Line Wrapping
-    /// - **DECAWM enabled** (default): wraps to next line when reaching right margin
+    /// - **DECAWM enabled** (default): enters pending-wrap state on last column;
+    ///   actual wrap happens on the *next* printable character
     /// - **DECAWM disabled**: cursor stays at right margin, new chars overwrite
     ///
     /// # Returns
@@ -310,6 +325,8 @@ impl OffscreenBuffer {
     ///
     /// [`DEC`]: https://en.wikipedia.org/wiki/Digital_Equipment_Corporation
     pub fn print_char(&mut self, ch: char) -> miette::Result<()> {
+        self.apply_pending_wrap();
+
         // Apply character set translation if in graphics mode.
         let display_char = match self.ansi_parser_support.character_set {
             CharacterSet::DECGraphics => Self::translate_dec_graphics(ch),
@@ -342,12 +359,9 @@ impl OffscreenBuffer {
             // Handle line wrap based on DECAWM (Auto Wrap Mode).
             if new_col.overflows(col_max) == ArrayOverflowResult::Overflowed {
                 if self.ansi_parser_support.auto_wrap_mode == AutoWrapState::Enabled {
-                    // DECAWM enabled: wrap to next line (default behavior).
-                    self.cursor_pos.col_index = col(0);
-                    let next_row: RowIndex = current_row + 1;
-                    if next_row.overflows(row_max) == ArrayOverflowResult::Within {
-                        self.cursor_pos.row_index = next_row;
-                    }
+                    // DECAWM enabled: enter pending-wrap state.
+                    // Actual wrap to next line happens on the next printable char.
+                    self.ansi_parser_support.pending_wrap = true;
                 } else {
                     // DECAWM disabled: stay at right margin (clamp cursor position).
                     self.cursor_pos.col_index = col_max.convert_to_index();
@@ -364,7 +378,7 @@ impl OffscreenBuffer {
 #[cfg(test)]
 mod tests_shifting_ops {
     use super::*;
-    use crate::{TuiStyle, len, row,
+    use crate::{RowIndex, TuiStyle, len, row,
                 test_fixtures_ofs_buf::{create_plain_test_char,
                                         create_test_buffer_with_size}};
 
@@ -1018,7 +1032,7 @@ mod tests_shifting_ops {
 #[cfg(test)]
 mod tests_print_char {
     use super::*;
-    use crate::{row, test_fixtures_ofs_buf::create_test_buffer_with_size};
+    use crate::{AutoWrapState, row, test_fixtures_ofs_buf::create_test_buffer_with_size};
 
     #[test]
     fn test_print_char_basic() {
@@ -1062,7 +1076,7 @@ mod tests_print_char {
     }
 
     #[test]
-    fn test_print_char_line_wrap() {
+    fn test_print_char_line_wrap_pending() {
         let mut buffer = create_test_buffer_with_size(width(5), height(3));
 
         // Ensure DECAWM is enabled (default).
@@ -1071,7 +1085,8 @@ mod tests_print_char {
         // Position cursor at end of line (column 4 in 5-width buffer).
         buffer.cursor_pos = row(1) + col(4);
 
-        // Print a character - should wrap to next line.
+        // Print a character — should NOT immediately wrap. Cursor stays on current line
+        // and pending_wrap is set.
         let _unused = buffer.print_char('X');
 
         // Verify character was printed at end of current line.
@@ -1081,7 +1096,78 @@ mod tests_print_char {
             _ => panic!("Expected PlainText with 'X'"),
         }
 
-        // Verify cursor wrapped to beginning of next line.
+        // Verify cursor stays on same line (pending wrap, not immediate wrap).
+        assert!(buffer.ansi_parser_support.pending_wrap);
+        assert_eq!(buffer.cursor_pos.row_index, row(1));
+
+        // Next printable character triggers the actual wrap.
+        let _unused = buffer.print_char('Y');
+        assert!(!buffer.ansi_parser_support.pending_wrap);
+        // Y should be printed at start of next line.
+        let printed_char = buffer.get_char(row(2) + col(0)).unwrap();
+        match printed_char {
+            PixelChar::PlainText { display_char, .. } => assert_eq!(display_char, 'Y'),
+            _ => panic!("Expected PlainText with 'Y'"),
+        }
+    }
+
+    #[test]
+    fn test_print_char_no_wrap_when_decawn_disabled() {
+        let mut buffer = create_test_buffer_with_size(width(5), height(3));
+
+        buffer.ansi_parser_support.auto_wrap_mode = AutoWrapState::Disabled;
+        buffer.cursor_pos = row(0) + col(4);
+
+        let _unused = buffer.print_char('Z');
+        assert!(!buffer.ansi_parser_support.pending_wrap);
+        // Cursor clamped to right margin.
+        assert_eq!(buffer.cursor_pos.col_index, col(4));
+    }
+
+    #[test]
+    fn test_apply_pending_wrap_wraps_to_next_line() {
+        let mut buffer = create_test_buffer_with_size(width(5), height(3));
+
+        buffer.cursor_pos = row(0) + col(4);
+        buffer.ansi_parser_support.pending_wrap = true;
+
+        buffer.apply_pending_wrap();
+
+        assert!(!buffer.ansi_parser_support.pending_wrap);
+        assert_eq!(buffer.cursor_pos, row(1) + col(0));
+    }
+
+    #[test]
+    fn test_apply_pending_wrap_noop_when_false() {
+        let mut buffer = create_test_buffer_with_size(width(5), height(3));
+
+        buffer.cursor_pos = row(0) + col(4);
+        buffer.ansi_parser_support.pending_wrap = false;
+
+        buffer.apply_pending_wrap();
+
+        // Cursor unchanged.
+        assert_eq!(buffer.cursor_pos, row(0) + col(4));
+    }
+
+    #[test]
+    fn test_apply_pending_wrap_clamped_at_bottom() {
+        let mut buffer = create_test_buffer_with_size(width(5), height(3));
+
+        // Last row of 3-height buffer is row(2).
+        buffer.cursor_pos = row(2) + col(4);
+        buffer.ansi_parser_support.pending_wrap = true;
+
+        buffer.apply_pending_wrap();
+
+        assert!(!buffer.ansi_parser_support.pending_wrap);
+        // Stays on same row since next row would overflow. Col resets.
         assert_eq!(buffer.cursor_pos, row(2) + col(0));
+    }
+
+    #[test]
+    fn test_pending_wrap_defaults_to_false() {
+        let buffer = create_test_buffer_with_size(width(5), height(3));
+        assert!(!buffer.ansi_parser_support.pending_wrap);
     }
 }

--- a/tui/src/tui/terminal_lib_backends/offscreen_buffer/vt_100_ansi_impl/vt_100_impl_clear_ops.rs
+++ b/tui/src/tui/terminal_lib_backends/offscreen_buffer/vt_100_ansi_impl/vt_100_impl_clear_ops.rs
@@ -47,6 +47,7 @@ impl OffscreenBuffer {
     ///
     /// Returns an error if the operation fails (though bounded safely).
     pub fn erase_line_from_cursor_to_end(&mut self) -> miette::Result<()> {
+        self.ansi_parser_support.pending_wrap = false;
         let cursor_row = self.cursor_pos.row_index;
         let cursor_col = self.cursor_pos.col_index;
         let empty_char = self.create_empty_pixel_char();
@@ -93,6 +94,7 @@ impl OffscreenBuffer {
     ///
     /// Returns an error if the operation fails (though bounded safely).
     pub fn erase_line_from_start_to_cursor(&mut self) -> miette::Result<()> {
+        self.ansi_parser_support.pending_wrap = false;
         let cursor_row = self.cursor_pos.row_index;
         let cursor_col = self.cursor_pos.col_index;
         let empty_char = self.create_empty_pixel_char();
@@ -138,6 +140,7 @@ impl OffscreenBuffer {
     ///
     /// Returns an error if the operation fails (though bounded safely).
     pub fn erase_line_entire(&mut self) -> miette::Result<()> {
+        self.ansi_parser_support.pending_wrap = false;
         let cursor_row = self.cursor_pos.row_index;
         let empty_char = self.create_empty_pixel_char();
 
@@ -188,6 +191,7 @@ impl OffscreenBuffer {
     ///
     /// Returns an error if the operation fails.
     pub fn erase_display_from_cursor_to_end(&mut self) -> miette::Result<()> {
+        self.ansi_parser_support.pending_wrap = false;
         self.erase_line_from_cursor_to_end()?;
 
         let cursor_row = self.cursor_pos.row_index;
@@ -245,6 +249,7 @@ impl OffscreenBuffer {
     ///
     /// Returns an error if the operation fails.
     pub fn erase_display_from_start_to_cursor(&mut self) -> miette::Result<()> {
+        self.ansi_parser_support.pending_wrap = false;
         let cursor_row = self.cursor_pos.row_index;
         let empty_char = self.create_empty_pixel_char();
 
@@ -297,6 +302,7 @@ impl OffscreenBuffer {
     ///
     /// Returns an error if the operation fails.
     pub fn erase_display_entire(&mut self) -> miette::Result<()> {
+        self.ansi_parser_support.pending_wrap = false;
         let empty_char = self.create_empty_pixel_char();
         for row in self.buffer.iter_mut() {
             row.fill(empty_char);

--- a/tui/src/tui/terminal_lib_backends/offscreen_buffer/vt_100_ansi_impl/vt_100_impl_control_ops.rs
+++ b/tui/src/tui/terminal_lib_backends/offscreen_buffer/vt_100_ansi_impl/vt_100_impl_control_ops.rs
@@ -36,6 +36,7 @@ impl OffscreenBuffer {
     /// Handles backspace control character (0x08).
     /// Moves cursor left one position if not at leftmost column.
     pub fn handle_backspace(&mut self) {
+        self.ansi_parser_support.pending_wrap = false;
         let current_col = self.cursor_pos.col_index;
         if !current_col.is_zero() {
             self.cursor_pos.col_index = current_col - 1;
@@ -45,6 +46,7 @@ impl OffscreenBuffer {
     /// Handles tab control character (0x09).
     /// Moves cursor to next 8-column tab stop boundary.
     pub fn handle_tab(&mut self) {
+        self.ansi_parser_support.pending_wrap = false;
         let current_col = self.cursor_pos.col_index;
         let max_col = self.window_size.col_width;
 
@@ -69,11 +71,18 @@ impl OffscreenBuffer {
     /// Handles line feed control character (0x0A).
     /// Moves cursor down one line. If at the bottom of the scroll region,
     /// it scrolls the region up by one line.
-    pub fn handle_line_feed(&mut self) { let _unused = self.index_down(); }
+    pub fn handle_line_feed(&mut self) {
+        self.ansi_parser_support.pending_wrap = false;
+        let _unused = self.index_down();
+        self.cursor_pos.col_index = col(0);
+    }
 
     /// Handles carriage return control character (0x0D).
     /// Moves cursor to start of current line (column 0).
-    pub fn handle_carriage_return(&mut self) { self.cursor_pos.col_index = col(0); }
+    pub fn handle_carriage_return(&mut self) {
+        self.ansi_parser_support.pending_wrap = false;
+        self.cursor_pos.col_index = col(0);
+    }
 }
 
 #[cfg(test)]
@@ -154,7 +163,7 @@ mod tests_control_ops {
         buffer.handle_line_feed();
 
         assert_eq!(buffer.cursor_pos.row_index, row(3));
-        assert_eq!(buffer.cursor_pos.col_index, col(5)); // column preserved
+        assert_eq!(buffer.cursor_pos.col_index, col(0)); // column reset to 0 per VT100
     }
 
     #[test]
@@ -166,7 +175,7 @@ mod tests_control_ops {
 
         // Should not move when at bottom.
         assert_eq!(buffer.cursor_pos.row_index, row(5));
-        assert_eq!(buffer.cursor_pos.col_index, col(3));
+        assert_eq!(buffer.cursor_pos.col_index, col(0)); // column reset to 0 per VT100
     }
 
     #[test]
@@ -190,5 +199,50 @@ mod tests_control_ops {
         // Should work correctly when already at start.
         assert_eq!(buffer.cursor_pos.row_index, row(3));
         assert_eq!(buffer.cursor_pos.col_index, col(0));
+    }
+
+    #[test]
+    fn test_handle_carriage_return_clears_pending_wrap() {
+        let mut buffer = create_test_buffer();
+        buffer.cursor_pos = row(3) + col(7);
+        buffer.ansi_parser_support.pending_wrap = true;
+
+        buffer.handle_carriage_return();
+
+        assert!(!buffer.ansi_parser_support.pending_wrap);
+        assert_eq!(buffer.cursor_pos.col_index, col(0));
+    }
+
+    #[test]
+    fn test_handle_line_feed_clears_pending_wrap() {
+        let mut buffer = create_test_buffer();
+        buffer.cursor_pos = row(2) + col(5);
+        buffer.ansi_parser_support.pending_wrap = true;
+
+        buffer.handle_line_feed();
+
+        assert!(!buffer.ansi_parser_support.pending_wrap);
+    }
+
+    #[test]
+    fn test_handle_tab_clears_pending_wrap() {
+        let mut buffer = create_test_buffer();
+        buffer.cursor_pos = row(1) + col(3);
+        buffer.ansi_parser_support.pending_wrap = true;
+
+        buffer.handle_tab();
+
+        assert!(!buffer.ansi_parser_support.pending_wrap);
+    }
+
+    #[test]
+    fn test_handle_backspace_clears_pending_wrap() {
+        let mut buffer = create_test_buffer();
+        buffer.cursor_pos = row(2) + col(5);
+        buffer.ansi_parser_support.pending_wrap = true;
+
+        buffer.handle_backspace();
+
+        assert!(!buffer.ansi_parser_support.pending_wrap);
     }
 }

--- a/tui/src/tui/terminal_lib_backends/offscreen_buffer/vt_100_ansi_impl/vt_100_impl_cursor_ops.rs
+++ b/tui/src/tui/terminal_lib_backends/offscreen_buffer/vt_100_ansi_impl/vt_100_impl_cursor_ops.rs
@@ -56,6 +56,7 @@ impl OffscreenBuffer {
     ///
     /// [`DECSTBM`]: https://vt100.net/docs/vt510-rm/DECSTBM.html
     pub fn cursor_up(&mut self, how_many: RowHeight) {
+        self.ansi_parser_support.pending_wrap = false;
         let current_row = self.cursor_pos.row_index;
         let scroll_top_boundary = *self.get_scroll_range_inclusive().start();
 
@@ -70,6 +71,7 @@ impl OffscreenBuffer {
     ///
     /// [`DECSTBM`]: https://vt100.net/docs/vt510-rm/DECSTBM.html
     pub fn cursor_down(&mut self, how_many: RowHeight) {
+        self.ansi_parser_support.pending_wrap = false;
         let current_row = self.cursor_pos.row_index;
         let scroll_bottom_boundary = *self.get_scroll_range_inclusive().end();
 
@@ -102,6 +104,7 @@ impl OffscreenBuffer {
     /// Result: Cursor moved forward 3 columns, clamped to screen width
     /// ```
     pub fn cursor_forward(&mut self, how_many: ColWidth) {
+        self.ansi_parser_support.pending_wrap = false;
         let new_col = self.cursor_pos.col_index + how_many;
         self.cursor_pos.col_index =
             new_col.clamp_to_max_length(self.window_size.col_width);
@@ -109,6 +112,7 @@ impl OffscreenBuffer {
 
     /// Move cursor backward by n columns.
     pub fn cursor_backward(&mut self, how_many: ColWidth) {
+        self.ansi_parser_support.pending_wrap = false;
         let current_col = self.cursor_pos.col_index;
         self.cursor_pos.col_index = current_col - how_many;
     }
@@ -116,6 +120,7 @@ impl OffscreenBuffer {
     /// Set cursor position to specific row and column coordinates.
     /// Coordinates are clamped to valid screen boundaries and scroll regions.
     pub fn cursor_to_position(&mut self, row: RowIndex, col: ColIndex) {
+        self.ansi_parser_support.pending_wrap = false;
         let scroll_region = self.get_scroll_range_inclusive();
 
         // Clamp row to scroll region boundaries.
@@ -131,16 +136,21 @@ impl OffscreenBuffer {
     }
 
     /// Move cursor to beginning of current line.
-    pub fn cursor_to_line_start(&mut self) { self.cursor_pos.col_index = col(0); }
+    pub fn cursor_to_line_start(&mut self) {
+        self.ansi_parser_support.pending_wrap = false;
+        self.cursor_pos.col_index = col(0);
+    }
 
     /// Move cursor to beginning of next line.
     pub fn cursor_to_next_line_start(&mut self) {
+        self.ansi_parser_support.pending_wrap = false;
         self.cursor_pos.col_index = col(0);
         self.cursor_down(crate::RowHeight::from(1));
     }
 
     /// Move cursor to specific column on current line.
     pub fn cursor_to_column(&mut self, target_col: ColIndex) {
+        self.ansi_parser_support.pending_wrap = false;
         // Convert from 1-based to 0-based, clamp to buffer width.
         self.cursor_pos.col_index =
             target_col.clamp_to_max_length(self.window_size.col_width);
@@ -163,6 +173,7 @@ impl OffscreenBuffer {
 
     /// Move cursor to specific row on current column.
     pub fn cursor_to_row(&mut self, target_row: RowIndex) {
+        self.ansi_parser_support.pending_wrap = false;
         // Clamp to valid range (conversion from 1-based to 0-based already done).
         let new_row = target_row.clamp_to_max_length(self.window_size.row_height);
         // Update only the row, preserve column.
@@ -256,5 +267,81 @@ mod tests_cursor_ops {
         buffer.restore_cursor_position();
 
         assert_eq!(buffer.cursor_pos, initial_pos);
+    }
+
+    #[test]
+    fn test_cursor_to_position_clears_pending_wrap() {
+        let mut buffer = create_test_buffer();
+        buffer.ansi_parser_support.pending_wrap = true;
+
+        buffer.cursor_to_position(row(2), col(5));
+
+        assert!(!buffer.ansi_parser_support.pending_wrap);
+    }
+
+    #[test]
+    fn test_cursor_up_clears_pending_wrap() {
+        let mut buffer = create_test_buffer();
+        buffer.cursor_pos = row(3) + col(2);
+        buffer.ansi_parser_support.pending_wrap = true;
+
+        buffer.cursor_up(crate::RowHeight::from(2));
+
+        assert!(!buffer.ansi_parser_support.pending_wrap);
+    }
+
+    #[test]
+    fn test_cursor_down_clears_pending_wrap() {
+        let mut buffer = create_test_buffer();
+        buffer.cursor_pos = row(1) + col(2);
+        buffer.ansi_parser_support.pending_wrap = true;
+
+        buffer.cursor_down(crate::RowHeight::from(2));
+
+        assert!(!buffer.ansi_parser_support.pending_wrap);
+    }
+
+    #[test]
+    fn test_cursor_forward_clears_pending_wrap() {
+        let mut buffer = create_test_buffer();
+        buffer.cursor_pos = row(1) + col(2);
+        buffer.ansi_parser_support.pending_wrap = true;
+
+        buffer.cursor_forward(crate::ColWidth::from(3));
+
+        assert!(!buffer.ansi_parser_support.pending_wrap);
+    }
+
+    #[test]
+    fn test_cursor_backward_clears_pending_wrap() {
+        let mut buffer = create_test_buffer();
+        buffer.cursor_pos = row(1) + col(5);
+        buffer.ansi_parser_support.pending_wrap = true;
+
+        buffer.cursor_backward(crate::ColWidth::from(2));
+
+        assert!(!buffer.ansi_parser_support.pending_wrap);
+    }
+
+    #[test]
+    fn test_cursor_to_line_start_clears_pending_wrap() {
+        let mut buffer = create_test_buffer();
+        buffer.cursor_pos = row(1) + col(5);
+        buffer.ansi_parser_support.pending_wrap = true;
+
+        buffer.cursor_to_line_start();
+
+        assert!(!buffer.ansi_parser_support.pending_wrap);
+    }
+
+    #[test]
+    fn test_cursor_to_column_clears_pending_wrap() {
+        let mut buffer = create_test_buffer();
+        buffer.cursor_pos = row(1) + col(2);
+        buffer.ansi_parser_support.pending_wrap = true;
+
+        buffer.cursor_to_column(col(5));
+
+        assert!(!buffer.ansi_parser_support.pending_wrap);
     }
 }

--- a/tui/src/tui/terminal_lib_backends/offscreen_buffer/vt_100_ansi_impl/vt_100_impl_line_ops.rs
+++ b/tui/src/tui/terminal_lib_backends/offscreen_buffer/vt_100_ansi_impl/vt_100_impl_line_ops.rs
@@ -72,6 +72,7 @@ impl OffscreenBuffer {
     ///
     /// Returns an error if the row is out of bounds.
     pub fn clear_line(&mut self, row: RowIndex) -> miette::Result<()> {
+        self.ansi_parser_support.pending_wrap = false;
         // Use type-safe row validation via validation helpers.
         let next_row = RowIndex::from(row.as_usize() + 1);
         let row_range = row..next_row;


### PR DESCRIPTION
## Summary

Implement correct VT100 pending-wrap (wrapneeded) state and respect DECSTBM scroll region bounds in `apply_pending_wrap()`.

### Changes

- **pending-wrap state** — `print_char()` at the last column now sets `pending_wrap=true` instead of immediately wrapping. The actual wrap happens on the *next* printable character via `apply_pending_wrap()`. Cursor movement commands (BS, TAB, LF, CR, CUP, etc.) clear the pending wrap state.
- **scroll region bounds** — `apply_pending_wrap()` now checks against DECSTBM scroll region bounds instead of `window_size.row_height`. At the bottom of the scroll region, `index_down()` is called to scroll the region instead of clamping.
- **`resize()`** — added `OffscreenBuffer::resize()` to support terminal pane resizing.

### Fixes

- fish-shell \u23ce marker and blank line issue in `pty_mux_example` (where fish's `abandon_line_string` relies on \r cancelling pending wrap)
- Programs like `htop` that set a scroll region and rely on pending-wrap at the region bottom