### PR TITLE
test: verify scroll-up behavior on LF at bottom row

### DIFF
--- a/tui/src/tui/terminal_lib_backends/offscreen_buffer/vt_100_ansi_impl/vt_100_impl_control_ops.rs
+++ b/tui/src/tui/terminal_lib_backends/offscreen_buffer/vt_100_ansi_impl/vt_100_impl_control_ops.rs
@@ -160,12 +160,32 @@ mod tests_control_ops {
     #[test]
     fn test_handle_line_feed_at_bottom() {
         let mut buffer = create_test_buffer();
-        buffer.cursor_pos = row(5) + col(3); // bottom row for height 6
+        let bottom = row(5); // bottom row for height 6 (0-based)
+        let row_above = row(4);
+
+        // Place a marker char at row above bottom.
+        let _unused = buffer.set_char(
+            row_above + col(0),
+            PixelChar::PlainText {
+                display_char: 'A',
+                style: Default::default(),
+            },
+        );
+
+        buffer.cursor_pos = bottom + col(3);
 
         buffer.handle_line_feed();
 
-        // Should not move when at bottom.
-        assert_eq!(buffer.cursor_pos.row_index, row(5));
+        // Buffer scrolled up: char from row 4 moved to row 3.
+        let scrolled_up = row(3) + col(0);
+        let ch = buffer.get_char(scrolled_up).unwrap();
+        match ch {
+            PixelChar::PlainText { display_char, .. } => assert_eq!(display_char, 'A'),
+            _ => panic!("Expected PlainText with 'A'"),
+        }
+
+        // Cursor stays at bottom row, column preserved.
+        assert_eq!(buffer.cursor_pos.row_index, bottom);
         assert_eq!(buffer.cursor_pos.col_index, col(3));
     }
 


### PR DESCRIPTION
## Summary

Update `test_handle_line_feed_at_bottom` to actually verify that content scrolls up when `handle_line_feed()` is called at the bottom row, instead of just asserting that cursor position stays clamped.

## Motivation

Commit 69c4d25c (Phase 2 of the VT100 shim improvement) updated `handle_line_feed` to call `index_down()` — enabling proper scroll-up behavior for interactive apps like `less` and `bash` inside the PTY multiplexer. However, the test was never updated to validate scrolling; it still asserted the old clamping behavior.

This PR fixes the test gap by placing a marker character above the bottom row and asserting it moved up after the LF scroll, making the test correctly reflect and validate the scroll-up behavior.

## Changes

| File | Change |
|---|---|
| `vt_100_impl_control_ops.rs` | Replaced trivial cursor clamping assertions with marker-char scroll verification. Cursor column assertion preserved (col stays at 3 since `index_down()` does not reset column). |

## Related

- Task: improve-immature-vt100-shim.md (Phase 2 — scroll fix)
- Task: prepare-v0.8.0-meta-task.md (release tracking)