### PR TITLE
Docs: Design architectural fix for cursor display bug

### DIFF
--- a/.agents/commands/create-pr.md
+++ b/.agents/commands/create-pr.md
@@ -1,0 +1,5 @@
+# Create PR
+
+Invoke the `create-pr` skill to push the current branch and create a GitHub Pull Request.
+
+This command is useful when you have local changes that you want to turn into a PR (`gh pr create --fill`), but you didn't start the journey using the formal `/fix-issue` design process. Once you are done, you can use `/merge-pr` to merge it.

--- a/.agents/commands/fix-issue.md
+++ b/.agents/commands/fix-issue.md
@@ -1,0 +1,5 @@
+# Fix Issue
+
+Invoke the `fix-issue` skill to start a deep exploration and design process before writing code for an issue.
+
+This command creates a structured design document in `task/fix-<id>.md` and forces an iterative, thoughtful approach to problem-solving.

--- a/.agents/commands/merge-pr.md
+++ b/.agents/commands/merge-pr.md
@@ -1,0 +1,5 @@
+# Merge PR
+
+Invoke the `merge-pr` skill to push the current branch, create a GitHub Pull Request, and merge it into `main` via rebase.
+
+This command streamlines the final step of a task by automatically handling the push (`git push -f`) and linear merging of the existing PR while simultaneously cleaning up the remote branch (`gh pr merge --rebase --delete-branch`).

--- a/.agents/commands/review-pr.md
+++ b/.agents/commands/review-pr.md
@@ -1,0 +1,5 @@
+# Review PR
+
+Invoke the `review-pr` skill to systematically integrate and review a community Pull Request.
+
+This command fetches the PR, breaks it down into a review plan, and ensures each fix is audited and applied to a clean local branch before eventually triggering `/merge-pr` to merge it.

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: create-pr
+description:
+  Push local changes and create a GitHub Pull Request.
+---
+
+# Create PR Workflow
+
+Use this skill when the user explicitly invokes `/create-pr` or asks to create a PR from their local branch.
+
+## The Workflow
+
+### Step 1: Ensure Clean State & Push
+
+- Verify the git working tree is clean. If not, ask the user to commit or stash changes.
+- Push the current branch to origin using `git push -u origin HEAD`.
+
+### Step 2: Create the Pull Request
+
+- Create a PR using the GitHub CLI: `gh pr create --fill`.
+- This automatically uses the commit messages to populate the PR title and body.
+
+### Step 3: Next Steps
+
+- Tell the user the PR has been created and provide the link if available.
+- Remind the user they can use the `/merge-pr` slash command when they are ready to merge it into `main`.

--- a/.agents/skills/fix-issue/SKILL.md
+++ b/.agents/skills/fix-issue/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: issue-fix
+name: fix-issue
 description:
   Guidelines for deeply exploring the problem space first and designing the best solution
   before implementing.
@@ -41,9 +41,10 @@ Before proposing any changes or writing a task file, gather context on the probl
 
 ### Step 2: Design Doc (Task File Creation)
 
-Create the task file under `task/issue-<id>-fix.md` or `task/<name>.md`. Instead of a
-simple todo list, format this task file as a **Design Document** with the following
-sections:
+Create the task file under `task/issue-<id>-fix.md` or `task/<name>.md`. 
+Create a new git branch for this task, push it, and open a Draft PR using `gh pr create --draft --fill` to track the work.
+
+Instead of a simple todo list, format this task file as a **Design Document** with the following sections:
 
 #### 1. Overview
 
@@ -96,3 +97,8 @@ Only after the design doc is approved, load the task and begin implementation
 step-by-step.
 
 - Run quality checks (`./check.fish`) and pause for manual reviews frequently.
+
+### Step 5: Merge & Complete
+
+Once the implementation is fully tested and manually reviewed:
+- Remind the user to run the `/merge-pr` slash command to push the final code and merge the existing Pull Request into `main`.

--- a/.agents/skills/merge-pr/SKILL.md
+++ b/.agents/skills/merge-pr/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: merge-pr
+description:
+  Workflow for rebasing and merging a local branch to main via a GitHub Pull Request.
+---
+
+# Merge PR Workflow
+
+This skill codifies the workflow for taking a completed local task branch, pushing it to GitHub, creating a Pull Request, and merging it via rebase.
+
+## When to Use
+
+Use this skill when the user asks to "close the pr by rebasing and merging to main" or explicitly invokes `/merge-pr`.
+
+## The Workflow
+
+### Step 1: Ensure Clean State & Push
+
+- Verify the git working tree is clean. If not, ask the user to commit or stash changes.
+- Push the current branch to origin using `git push -f origin HEAD`. We use `-f` because local commits are frequently amended during code reviews.
+
+### Step 2: Merge via Rebase
+
+- Merge the existing PR into main using the rebase strategy and delete the remote branch: `gh pr merge --rebase --delete-branch`.
+- This ensures a linear commit history on the main branch without ugly merge commits.
+
+### Step 3: Cleanup
+
+- Switch back to the main branch: `git checkout main`.
+- Pull the latest changes to sync up with origin: `git pull`.
+- Prune stale remote tracking branches: `git fetch --prune`.
+- Delete the local task branch you just merged: `git branch -D <branch-name>`.

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: pr-review
+name: review-pr
 description: Create a structured integration and review plan for a Pull Request
 ---
 
 # PR Review and Integration Workflow
 
-Use this skill when the user runs the `/pr-review <number>` slash command or uses any of these natural language triggers:
+Use this skill when the user runs the `/review-pr <number>` slash command or uses any of these natural language triggers:
 - "lets review pr <number>"
 - "lets work on pr <number>"
 - "lets take a look at pr <number>"
@@ -64,15 +64,7 @@ _(Once all headings are successfully implemented and checked off, we will procee
 ### Final Verification & Cleanup
 
 - [ ] Verify full test suite coverage using `./check.fish --full`.
-- [ ] Hijack the PR branch to apply our rewritten code while preserving their authorship credit:
-  - `git checkout main` and identify our rewrite commit (`FIX_COMMIT`) and the commit before it (`MAIN_COMMIT`).
-  - `git reset --hard <MAIN_COMMIT>` and `git push --force origin main` to cleanly separate our fix from main.
-  - `gh pr checkout <number>` to pull down their branch.
-  - `AUTHOR=$(git log -1 --format="%an <%ae>")` to extract their authorship.
-  - `git reset --hard <FIX_COMMIT>` to wipe their changes and plonk our code into their branch.
-  - `git commit --amend --author="$AUTHOR" --no-edit` to give them credit for our rewrite.
-  - `git push --force` to update the PR on GitHub.
-- [ ] Merge the PR into `main` (`gh pr merge <number>`).
+- [ ] When ready to merge, invoke the `/merge-pr` slash command to push the changes, optionally update the author, and cleanly merge to `main`.
 - [ ] Update the current meta-task (e.g. `task/prepare-vX.Y.Z-meta-task.md`) to check off PR #<number>.
 - [ ] **Mandatory manual review:** Verify every file modified in this task for correct implementation and ensure no regressions.
   - [ ] `path/to/modified_file_1.rs`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,7 +211,11 @@ in that skill's directory (e.g., `patterns.md`, `reference.md`, `examples.md`).
 - **release-crate** - Full crate release workflow: version bump, changelog, publish to crates.io,
   git tag, GitHub release. Use when releasing a new version of any workspace crate.
 
-- **pr-review** - Create a structured integration and review plan for a Pull Request. Use when the user wants to systematically integrate a community PR.
+- **review-pr** - Create a structured integration and review plan for a Pull Request. Use when the user wants to systematically integrate a community PR.
+
+- **create-pr** - Push local changes and create a GitHub Pull Request. Use when you have local changes that need a PR but didn't start with `/fix-issue`.
+
+- **merge-pr** - Workflow for pushing a completed task branch, creating a Pull Request, and merging it to main via rebase.
 
 ### Log Analysis
 
@@ -240,7 +244,9 @@ in that skill's directory (e.g., `patterns.md`, `reference.md`, `examples.md`).
 | `/check-regression` | analyze-performance |
 | `/analyze-logs` | analyze-log-files |
 | `/release` | release-crate |
-| `/pr-review` | pr-review |
+| `/review-pr` | review-pr |
+| `/create-pr` | create-pr |
+| `/merge-pr` | merge-pr |
 | `/r3bl-task` | Task management (see below) |
 | `/boxes` | Unicode box-drawing character set |
 
@@ -336,6 +342,21 @@ For testing interactive terminal applications, use (both are installed):
 - `screen`
 
 ## Git Workflow
+
+### PR Lifecycle & Commands
+
+We have a cohesive, interconnected lifecycle for Pull Requests codified in `.agents/skills/`:
+
+1. **Start a new task:** `/fix-issue`
+   - Creates the branch, pushes it, and opens a Draft PR (`gh pr create --draft`) to track the work.
+2. **Review community work:** `/review-pr`
+   - Fetches an existing PR to systematically audit, test, and rewrite locally.
+3. **Manual PR creation:** `/create-pr`
+   - For when you have local changes on a branch and just want to push and open a PR (`gh pr create --fill`) without going through the full `/fix-issue` design process.
+4. **Merge and complete:** `/merge-pr`
+   - The endpoint for all of the above. Pushes the finalized local branch and linearly merges the existing PR (`gh pr merge --rebase`), then cleans up the local workspace.
+
+### General Rules
 
 - **No Destructive Resets**: NEVER use `git reset HEAD~n`, `git reset --hard`, or `git clean`
   unless explicitly and specifically commanded to do so by the user. These commands are

--- a/task/done/improve-immature-vt100-shim.md
+++ b/task/done/improve-immature-vt100-shim.md
@@ -231,12 +231,12 @@ buffers, and cursor visibility events.
 - bash
   - problem with cursor - its parked on the bottom right of the window, exactly like less
 
-### Phase 3.1: Virtualized Hardware Cursor & Compositor Fixes
+### Phase 3.1: Virtualized Terminal Cursor & Compositor Fixes
 
-- [x] **Hide the Global Hardware Cursor**:
+- [x] **Hide the Global Terminal Cursor**:
   - Update `paint_buffer()` in `tui/src/core/pty/pty_mux/output_renderer.rs` to explicitly
     pass `CursorVisibilityState::Hidden` instead of the parsed cursor state. This
-    permanently suppresses the hardware cursor when the multiplexer is active.
+    permanently suppresses the terminal cursor when the multiplexer is active.
 - [x] **Rename Stale Variable**:
   - Rename `crossterm_impl` to `ofs_buf_paint_impl` in `paint_buffer()`.
 - [x] **Composite the Virtual Cursor**:
@@ -264,7 +264,7 @@ buffers, and cursor visibility events.
   - Check the output logs with `DEBUG_TUI_PTY_MUX=true` to verify no more warning entries
     exist for `CSI J`, `CSI K`, or `CSI ?1049h/l`.
 - [x] **Verify Specific Use Cases**:
-  - **Bash & Less**: The blinking hardware cursor is gone, replaced by a clean,
+  - **Bash & Less**: The blinking terminal cursor is gone, replaced by a clean,
     virtualized inverted-block cursor that moves correctly in sync with typing.
   - **Less & Htop Find Bar**: Hitting `/` correctly opens the search/find bar on the PTY's
     bottom line immediately above the multiplexer status bar, completely eliminating the
@@ -287,9 +287,9 @@ All updates were made within
    cursor is currently located. Since R3BL TUI has already handled wide characters (jumbo
    emojis, grapheme clusters) by this stage, this safely inverts the colors of the cell
    without breaking layout alignment.
-2. **Global Hardware Cursor Suppression**: When `paint_buffer()` is finally called, we
+2. **Global Terminal Cursor Suppression**: When `paint_buffer()` is finally called, we
    explicitly pass `CursorVisibilityState::Hidden` instead of the child's requested
-   visibility. This permanently suppresses the hardware cursor in the multiplexer,
+   visibility. This permanently suppresses the terminal cursor in the multiplexer,
    ensuring no more flickering or "parking" at the bottom right.
 3. **Preserved PTY Bottom Row (The `/` find bar fix)**: The critical bug causing the
    `less`/`htop` find bar to disappear has been fixed. Previously, the `composite_buffer`
@@ -307,7 +307,7 @@ All updates were made within
   - Ran `./check.fish --clippy` to verify clean compilation with no warnings or style
     lints.
 - **Integration & Manual Verification**:
-  - **Bash & Less**: The blinking hardware cursor is gone, replaced by a clean,
+  - **Bash & Less**: The blinking terminal cursor is gone, replaced by a clean,
     virtualized inverted-block cursor that moves correctly in sync with typing.
   - **Less & Htop Find Bar**: Hitting `/` correctly opens the search/find bar on the PTY's
     bottom line immediately above the multiplexer status bar, completely eliminating the

--- a/task/done/issue-461-fix.md
+++ b/task/done/issue-461-fix.md
@@ -199,3 +199,92 @@ memory overhead. Here is the exact list of places we would need to migrate to
    - `OutputRenderer`: Will accept the `VT100TerminalState`, do its virtual cursor
      compositing, and then pass the inner `OffscreenBuffer` to the generic
      `paint_buffer()` engine.
+
+### Composition (Structural Split) Implementation Plan
+
+- [x] **Step 1: Define `VT100TerminalState` & Strip `OffscreenBuffer`**
+  - [x] In `tui/src/tui/terminal_lib_backends/offscreen_buffer/ofs_buf_core.rs`:
+    - Define `VT100TerminalState` containing `ofs_buf: OffscreenBuffer`,
+      `parser_global_state: ParserGlobalState`, `hidden_screen_state: HiddenScreenState`,
+      and `terminal_mode: TerminalModeState`.
+    - Strip `OffscreenBuffer` to contain only `buffer`, `window_size`, `cursor_pos`, and
+      `memory_size`.
+    - Implement `Deref` and `DerefMut` for `VT100TerminalState` pointing to
+      `OffscreenBuffer`.
+    - Update `GetMemSize` for both structs.
+    - Implement `new_empty()` constructors for both structs.
+  - [x] In `tui/src/tui/terminal_lib_backends/compositor_render_ops_to_ofs_buf.rs`:
+    - Remove the mutations to `ofs_buf.terminal_mode` in `process_common_render_op` (e.g.,
+      for `EnterRawMode`, `EnterAlternateScreen`, `EnableMouseTracking`,
+      `EnableBracketedPaste`), as they are terminal-only state operations and
+      `OffscreenBuffer` no longer holds this state.
+
+- [x] **Step 2: Update ANSI Parser Performer & Public API**
+  - [x] In `tui/src/core/ansi/vt_100_pty_output_parser/ansi_parser_public_api.rs`:
+    - Update `AnsiToOfsBufPerformer`'s `ofs_buf` field to type
+      `&'a mut VT100TerminalState`.
+    - Move `apply_ansi_bytes` implementation block to `VT100TerminalState`.
+  - [x] In `tui/src/core/ansi/vt_100_pty_output_parser/performer.rs`:
+    - Update imports and performer definition to type-reference `VT100TerminalState`.
+
+- [x] **Step 3: Migrate VT100 Emulator Implementations**
+  - [x] For all 14 files in
+        `tui/src/tui/terminal_lib_backends/offscreen_buffer/vt_100_ansi_impl/`:
+    - Change `impl OffscreenBuffer` to `impl VT100TerminalState`.
+    - Update `create_test_buffer()` and other test/unit helper functions to use/return
+      `VT100TerminalState`.
+  - [x] In
+        `tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/`:
+    - Update `test_fixtures_vt_100_ansi_conformance.rs` to return `VT100TerminalState`.
+    - Update all conformance tests to use `VT100TerminalState`.
+
+- [x] **Step 4: Update PTY Multiplexer & Processes**
+  - [x] Update `ProcessManager` and active process state to track `VT100TerminalState`
+        instead of `OffscreenBuffer`.
+  - [x] In `tui/src/core/pty/pty_mux/output_renderer.rs`:
+    - Update `render_from_active_buffer`, `composite_virtual_cursor_into_buffer`, and
+      other methods to accept/use `VT100TerminalState`.
+    - In `paint_buffer()`, pass `&terminal_state.ofs_buf` (the inner `OffscreenBuffer`) to
+      the generic canvas painting pipeline.
+
+- [x] **Step 5: Integration & Verification**
+  - [x] Run `./check.fish --check` to verify compilation.
+  - [x] Run `./check.fish --test` to verify all tests pass.
+- [x] **Mandatory manual review**:
+  - [x] `ofs_buf_core.rs`
+  - [x] `ansi_parser_public_api.rs`
+  - [x] `performer.rs`
+  - [x] `output_renderer.rs`
+  - [x] Conformance tests and visual check success verified.
+
+## Phase 5: Relocate VT100 Terminal State Code
+
+The `vt_100_terminal_state.rs` file (renamed to `ofs_buf_vt_100.rs`) and the
+`vt_100_ansi_impl/` directory were intrinsically part of the VT100 parsing system, not the
+generic offscreen buffer. They have been relocated from
+`tui/src/tui/terminal_lib_backends/offscreen_buffer/` to their new home.
+
+- [x] Move and rename `vt_100_terminal_state.rs` to
+      `tui/src/core/ansi/vt_100_pty_output_parser/ofs_buf_vt_100.rs`.
+- [x] Move the entire `vt_100_ansi_impl/` directory to
+      `tui/src/core/ansi/vt_100_pty_output_parser/`.
+- [x] Update `mod.rs` files and visibility appropriately.
+- [x] Run `./check.fish --check` to ensure no broken imports.
+- [x] **Mandatory manual review**:
+  - [x] `tui/src/core/ansi/vt_100_pty_output_parser/mod.rs`
+  - [x] `tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/mod.rs`
+  - [x] `tui/src/core/ansi/vt_100_pty_output_parser/ofs_buf_vt_100.rs`
+
+## Phase 6: DX and Folder Structure Alignment
+
+Made DX improvements for IDE and CLI tooling (like fd-find):
+- Renamed the parent folder `operations` -> `ops`
+- Renamed the impl folder to match -> `ops_impl_ofs_buf`. This is the impl for OffscreenBuffer. In the future this opens the door to be able to impl this for other structs.
+- Prefixed `vt_100_` in front of all 3 types of files (`shim`, `impl`, and `test`).
+
+This ensures they sort lexicographically and related domains group beautifully together. For example, searching for `vt_100_char_ops` returns:
+- ops/vt_100_shim_char_ops.rs
+- ops_impl_ofs_buf/vt_100_impl_char_ops.rs
+- tests/vt_100_test_char_ops.rs
+
+In the future, this opens the door to be able to have ops_impl_XYZ/.

--- a/task/fix-esc-code-formatting.md
+++ b/task/fix-esc-code-formatting.md
@@ -1,0 +1,32 @@
+# Task: Fix ESC Code Formatting in Rustdocs
+
+## 1. Overview
+- **Goal**: Standardize and fix the formatting of ANSI escape sequences in rustdoc comments across the workspace.
+- **Problem**: There are over 260 instances where `[`ESC`]` is used inside a literal sequence in documentation comments. This mix of bracketed intra-doc links and loose text (e.g., `/// Cursor Up (CUU) - [`ESC`] [ n A.`) makes the sequences jarring and difficult to read.
+- **Solution**: Convert these instances into fully wrapped markdown code blocks so the entire sequence renders as a single, readable monospaced block (e.g., `` `ESC [ n A` ``).
+
+## 2. Examples of the Pattern
+
+The problematic pattern appears widely in files such as `sequence.rs`, `performer.rs`, and others.
+
+**Current (Confusing) Format:**
+- `/// Cursor Up (CUU) - [`ESC`] [ n A.`
+- `/// Erase Line (EL) - [`ESC`] [ n K.`
+- `/// Enable Private Mode - [`ESC`] [ ? n h`
+
+**Desired (Clean) Format:**
+- ``/// Cursor Up (CUU) - `ESC [ n A`.``
+- ``/// Erase Line (EL) - `ESC [ n K`.``
+- ``/// Enable Private Mode - `ESC [ ? n h` ``
+
+## 3. Scope of Work
+- Perform a workspace-wide search for `[`ESC`]` followed by literal sequence characters (like `[`, `(`, etc.).
+- Carefully refactor these comments to use inline code blocks for the entire sequence.
+- Ensure that standalone `[`ESC`]` links (which refer to `crate::EscSequence` or similar) are preserved if they are correctly used as structural links rather than embedded inside a literal terminal sequence string.
+
+## 4. Checklist
+- [ ] Sweep `tui/src/core/ansi/` for all `[`ESC`]` string occurrences.
+- [ ] Convert mixed link/literal sequences to inline code blocks.
+- [ ] Run `./check.fish --doc` to ensure no intra-doc links were broken and everything renders beautifully.
+- [ ] **Mandatory manual review**:
+  - [ ] Target files to be populated during implementation.

--- a/task/issue-461-fix.md
+++ b/task/issue-461-fix.md
@@ -1,0 +1,201 @@
+# Task: Fix Cursor Display Issues in Component Pipeline (Issue #461)
+
+# 1. Overview
+
+- **Goal**: Fix the bug where the native terminal cursor is incorrectly and permanently
+  shown in all TUI applications using the component pipeline, while preserving virtual
+  cursors for `pty_mux`.
+- **Context**: [Issue #461](https://github.com/r3bl-org/r3bl-open-core/issues/461),
+  introduced by commit `f33c6a3c`.
+
+# 2. Problem Space & Constraints
+
+The original author of `f33c6a3c` wanted to ensure `pty_mux` forcefully hid the terminal
+cursor. To achieve this, they modified the global rendering engine (`paint_impl.rs`) to
+accept a visibility parameter and injected visibility commands into the render stream.
+
+This inadvertently broke the global component pipeline (`paint.rs`), which also calls
+`paint_impl.rs`. To fix the resulting compile error, the author lazily extracted
+`OffscreenBuffer::ansi_parser_support.cursor_visibility` and passed it down. Because the
+VT100 standard dictates this defaults to `Visible`, the global pipeline began spamming
+`ShowCursor` on every frame, overriding the apps' initial startup commands to hide the
+cursor.
+
+## The Exact Origin of the Bug
+
+Here are the exact files and lines where the bug was born:
+
+### 1. The Extraction: `tui/src/tui/terminal_lib_backends/paint.rs`
+
+The author modified the orchestration functions to reach into the `OffscreenBuffer` and
+extract the default visibility state:
+
+- In `perform_diff_paint` (Lines 65-66):
+
+  ```rust
+  fn perform_diff_paint(ofs_buf: &OffscreenBuffer, /* ... */) {
+      let cursor_visibility = ofs_buf.ansi_parser_support.cursor_visibility;
+  ```
+
+- In `perform_full_paint` (Lines 112-113):
+  ```rust
+  fn perform_full_paint(ofs_buf: &OffscreenBuffer, /* ... */) {
+      let cursor_visibility = ofs_buf.ansi_parser_support.cursor_visibility;
+  ```
+
+(They then passed this extracted state down into the backend calls below).
+
+### 2. The Injection: `tui/src/tui/terminal_lib_backends/offscreen_buffer/paint_impl.rs`
+
+The author added code to the final rendering step to dynamically push `ShowCursor` /
+`HideCursor` commands to the terminal based on the state passed down from `paint.rs`.
+
+- In `paint()` (Lines 111-114):
+
+  ```rust
+  // Apply cursor visibility state.
+  match cursor_visibility {
+      CursorVisibilityState::Visible => render_ops.push(RenderOpCommon::ShowCursor),
+      CursorVisibilityState::Hidden => render_ops.push(RenderOpCommon::HideCursor),
+  }
+  ```
+
+- In `paint_diff()` (Lines 157-160):
+  ```rust
+  // Apply cursor visibility state.
+  match cursor_visibility {
+      CursorVisibilityState::Visible => render_ops.push(RenderOpCommon::ShowCursor),
+      CursorVisibilityState::Hidden => render_ops.push(RenderOpCommon::HideCursor),
+  }
+  ```
+
+By extracting the `Visible` default in `paint.rs` and injecting the `ShowCursor` command
+into the stream in `paint_impl.rs`, they unknowingly forced the cursor visible on every
+frame for the entire component pipeline.
+
+## Hard Constraints & Core Intent
+
+1. **`pty_mux` must continue to work**: The terminal emulator relies on hiding the real
+   terminal cursor so it can draw multiple _virtual cursors_ via styling.
+2. **Component pipeline must be decoupled**: Standard TUI applications do not need
+   continuous cursor visibility injection. They hide the cursor once at initialization and
+   expect the render pipeline to leave it alone.
+3. **No needless compositor changes**: Modifying `compositor_render_ops_to_ofs_buf.rs` is
+   a non-starter and a distraction.
+
+# 3. Proposed Design: Clean Reversion and Localized Injection
+
+Instead of hacking around the damage done by `f33c6a3c`, we will completely revert its
+architectural mistake. We will remove cursor visibility logic from the shared rendering
+engine and isolate it entirely within `pty_mux`.
+
+- **How it works**:
+  1. Remove the `cursor_visibility` argument and injection logic from `paint_impl.rs`.
+  2. Remove the state extraction from `paint.rs`.
+  3. Modify `pty_mux`'s custom renderer (`output_renderer.rs`) to manually push a
+     `RenderOpCommon::HideCursor` into its _own_ stream before calling the paint engine.
+- **Why it's correct**: It completely decouples the component pipeline from PTY parser
+  state, returning it to the flawless state it was in before the bug existed, while
+  cleanly satisfying `pty_mux`'s requirement to hide the physical cursor.
+
+# 4. Implementation Plan
+
+## Phase 1: Reverting the Global Pipeline
+
+- [x] In `tui/src/tui/terminal_lib_backends/offscreen_buffer/paint_impl.rs`:
+  - Remove the `cursor_visibility` argument from `paint()` and `paint_diff()`.
+  - Remove the `match cursor_visibility` blocks that push `ShowCursor`/`HideCursor`.
+- [x] In `tui/src/tui/terminal_lib_backends/paint.rs`:
+  - Remove `let cursor_visibility = ofs_buf.ansi_parser_support.cursor_visibility;` from
+    `perform_full_paint` and `perform_diff_paint`.
+  - Remove the `cursor_visibility` argument passed to the backend calls.
+- [x] **Mandatory manual review**:
+  - [x] `paint_impl.rs`
+  - [x] `paint.rs`
+
+## Phase 2: Localizing the Fix to PTY Mux
+
+- [x] In `tui/src/core/pty/pty_mux/output_renderer.rs`:
+  - In `paint_buffer()`, change `let render_ops` to `let mut render_ops`.
+  - Push `RenderOpCommon::HideCursor` into `render_ops` before calling
+    `ofs_buf_paint_impl.paint()`.
+  - Remove the `CursorVisibilityState::Hidden` argument from the `paint()` call.
+- [x] **Mandatory manual review**:
+  - [x] `output_renderer.rs`
+
+## Phase 3: Integration & Testing
+
+- [x] Run `cargo run --example tui_apps` and select `ex_app_no_layout` to verify the
+      terminal cursor remains hidden.
+- [x] Run `./check.fish --check` to verify no compilation errors.
+- [x] Run `./check.fish --test` to ensure tests pass.
+- [x] **Mandatory manual review**:
+  - [x] Compile and Test success visually verified.
+
+## Phase 4: How to fix the underlying problem
+
+The underlying architectural problem is **Dual-Use**. Currently, `OffscreenBuffer` serves
+two completely different masters:
+
+1. **The Component Pipeline**: Uses it as a simple 2D pixel canvas. `ansi_parser_support`
+   is useless dead weight.
+2. **The PTY Multiplexer**: Uses it as a full VT100 emulator screen where parsing state
+   must be tracked alongside the pixels.
+
+To permanently fix this, we will cleanly separate the ANSI parser state from the generic
+UI canvas using a Composition (Structural Split) approach.
+
+### The Composition Approach
+
+Physically break `OffscreenBuffer` into two distinct structs:
+
+1. **`OffscreenBuffer`**: Keep the existing name, but strip it down to a pure struct
+   containing _only_ the 2D grid (`PixelCharLines`), `cursor_pos`, and `window_size`.
+2. **`VT100TerminalState`**: A new struct containing an `OffscreenBuffer` **PLUS** the
+   `ansi_parser_support` and `alt_screen_support`.
+
+- Standard TUI components and `paint.rs` continue using `OffscreenBuffer` (meaning minimal
+  renaming is needed in the component pipeline).
+- The ANSI parser and `pty_mux` would operate on `VT100TerminalState`. When `pty_mux` is
+  ready to paint, it simply extracts its internal `OffscreenBuffer` and hands it to the
+  generic `paint.rs` layer. **Pros**: Purity. UI components stop carrying heavy VT100
+  baggage (like an entire alternate screen memory allocation). The compiler naturally
+  enforces the boundary because `OffscreenBuffer` physically lacks the parser state.
+  Keeping the name `OffscreenBuffer` drastically reduces the refactoring scope.
+- **Future-Proofing (Scrollback Buffers)**: Scrollback memory is inherently a Terminal
+  Emulator feature, not a generic UI feature. If a `scroll_back_buffer` was added to the
+  monolithic `OffscreenBuffer`, every single UI component (like a simple `Button` or
+  `DialogBox`) would wastefully allocate memory for thousands of lines of hidden history.
+  By using this split, `VT100TerminalState` becomes the perfect, dedicated home for
+  historical scrollback data, while `OffscreenBuffer` stays small and fast representing
+  _only_ the currently visible screen pixels.
+
+### Codebase Audit for Structural Split
+
+By keeping the name `OffscreenBuffer` for the core grid, the entire standard TUI engine
+(Layouts, Dialogs, Editors, Buttons) remains completely untouched, but drops all the
+memory overhead. Here is the exact list of places we would need to migrate to
+`VT100TerminalState`:
+
+1. **The Struct Definitions (`ofs_buf_core.rs`)**
+   - Remove `ansi_parser_support` and `alt_screen_support` from `OffscreenBuffer`.
+   - Create `VT100TerminalState` containing an `OffscreenBuffer` plus the two VT100
+     fields.
+
+2. **The VT100 Implementations (`vt_100_ansi_impl/` directory)**
+   - Move `impl Vt100TerminalOps for OffscreenBuffer` to
+     `impl Vt100TerminalOps for VT100TerminalState`.
+   - When the implementation needs to mutate pixels, it will access `self.ofs_buf.buffer`
+     instead of `self.buffer`.
+
+3. **The ANSI Parser (`performer.rs` & `ansi_parser_public_api.rs`)**
+   - `AnsiToOfsBufPerformer` (the engine that interprets ANSI escape codes) currently
+     holds an `OffscreenBuffer`.
+   - Update it to hold a `VT100TerminalState` instead.
+
+4. **The PTY Multiplexer (`pty_mux/` module)**
+   - `ProcessManager`: Currently tracks an `OffscreenBuffer` for each running shell.
+     Update it to track a `VT100TerminalState`.
+   - `OutputRenderer`: Will accept the `VT100TerminalState`, do its virtual cursor
+     compositing, and then pass the inner `OffscreenBuffer` to the generic
+     `paint_buffer()` engine.

--- a/task/pending/add-github-workflow-lifecycle-to-giti.md
+++ b/task/pending/add-github-workflow-lifecycle-to-giti.md
@@ -1,0 +1,41 @@
+# Task: Add GitHub Workflow Lifecycle to Giti
+
+## 1. Overview
+- **Goal:** Elevate `giti` from a standard git client to a full-fledged GitHub workflow orchestrator by porting our agentic `<verb>-<noun>` PR lifecycle.
+- **Context:** We recently codified a highly successful, interconnected Git/GitHub lifecycle for our AI agents using slash commands (`/fix-issue`, `/review-pr`, `/create-pr`, `/merge-pr`). This workflow dramatically reduces cognitive load and ensures repository cleanliness. `giti` should formalize these journeys as first-class TUI features.
+
+## 2. Problem Space & Constraints
+- `giti` currently handles basic git operations (checkout, branch creation, deletion) but lacks GitHub orchestration.
+- Developers currently have to drop out of `giti` and use `gh` CLI or a browser to create, review, and merge PRs.
+- **Constraints:** Needs to shell out to the `gh` CLI (or use a GitHub API crate). Must fit naturally into `giti`'s existing interactive TUI design patterns (list selections, dialogs).
+
+## 3. The Workflows to Formalize
+
+We need to build interactive TUI journeys inside `giti` that perfectly mirror our agent slash commands:
+
+### A. The Start: Issue & PR Creation
+- **Mirroring `/fix-issue`:** A TUI flow that queries open GitHub issues, lets the user select one, automatically creates a new branch (e.g., `issue-<id>`), and immediately opens a Draft PR to track the work.
+- **Mirroring `/create-pr`:** A shortcut to take an ad-hoc local branch the user just made, push it to origin, and instantly open a PR (`gh pr create --fill`).
+
+### B. The Middle: Reviewing Community Code
+- **Mirroring `/review-pr`:** A TUI flow that lists open community PRs, fetches the selected one, checks it out locally, and prepares the workspace for an audit and rewrite.
+
+### C. The End: Clean Merging (The Capstone)
+- **Mirroring `/merge-pr`:** The ultimate endpoint. When the user is done with a branch, `giti` should offer a one-button "Merge and Clean" action. This macro-action will:
+  1. Force-push any final local commits.
+  2. Merge the PR linearly via rebase, whilst deleting the remote branch (`gh pr merge --rebase --delete-branch`).
+  3. Clean up the local workspace automatically (`git checkout main`, `git pull`, `git fetch --prune`, `git branch -D`).
+
+## 4. Implementation Plan
+
+- [ ] **Phase 1: Architecture & Auth**
+  - Add `gh` CLI integration or a GitHub API client to `giti`.
+  - Ensure authentication state is handled gracefully.
+- [ ] **Phase 2: The "Start" Flows**
+  - Implement the Issue Picker UI.
+  - Implement automatic branch and Draft PR creation.
+- [ ] **Phase 3: The "End" Flows**
+  - Implement the "Merge & Clean" macro that flawlessly executes the 4-step `/merge-pr` cleanup pipeline.
+- [ ] **Phase 4: Integration & Testing**
+  - Ensure shell-outs to `gh` or `git` are non-blocking and display proper loading states in the TUI.
+  - **Mandatory manual review:** Test all 4 flows on a dummy repository.

--- a/task/prepare-v0.8.0-meta-task.md
+++ b/task/prepare-v0.8.0-meta-task.md
@@ -7,11 +7,14 @@
   - [x] [fix-mio-poller-edge-triggered-polling.md](done/fix-mio-poller-edge-triggered-polling.md)
   - [x] [Fix bug introduce by mio-poller-edge-triggered-polling](https://github.com/r3bl-org/r3bl-open-core/issues/453)
 - [x] Terminal Parsing (Pending PRs)
-  - [x] [improve-immature-vt100-shim.md](improve-immature-vt100-shim.md)
-  - [x] [pr-448-fix.md](done/pr-448-fix.md) - https://github.com/r3bl-org/r3bl-open-core/pull/448
+  - [x] [improve-immature-vt100-shim.md](done/improve-immature-vt100-shim.md)
+  - [x] [pr-448-fix.md](done/pr-448-fix.md) -
+        https://github.com/r3bl-org/r3bl-open-core/pull/448
 - [x] RRT API (Pending PRs & Issues)
-  - [x] [pr-452-fix.md](done/pr-452-fix.md) - https://github.com/r3bl-org/r3bl-open-core/pull/452
-  - [x] [issue-451-fix.md](done/issue-451-fix.md) - https://github.com/r3bl-org/r3bl-open-core/issues/451
+  - [x] [pr-452-fix.md](done/pr-452-fix.md) -
+        https://github.com/r3bl-org/r3bl-open-core/pull/452
+  - [x] [issue-451-fix.md](done/issue-451-fix.md) -
+        https://github.com/r3bl-org/r3bl-open-core/issues/451
 - [ ] Cursor display issues
   - [ ] https://github.com/r3bl-org/r3bl-open-core/issues/461
 - [ ] PRs from Cecile

--- a/task/prepare-v0.8.0-meta-task.md
+++ b/task/prepare-v0.8.0-meta-task.md
@@ -8,13 +8,13 @@
   - [x] [Fix bug introduce by mio-poller-edge-triggered-polling](https://github.com/r3bl-org/r3bl-open-core/issues/453)
 - [x] Terminal Parsing (Pending PRs)
   - [x] [improve-immature-vt100-shim.md](done/improve-immature-vt100-shim.md)
-  - [x] [pr-448-fix.md](done/pr-448-fix.md) -
-        https://github.com/r3bl-org/r3bl-open-core/pull/448
+  - [x] [pr-448-fix.md](done/pr-448-fix.md) - https://github.com/r3bl-org/r3bl-open-core/pull/448
+  - [x] [issue-451-fix.md](done/issue-451-fix.md) - https://github.com/r3bl-org/r3bl-open-core/issues/451
+  - [ ] [remove crossterm mental model pollution](remove-crossterm-mental-model-pollution.md)
+  - [ ] [rustdocs - fix readability of esc codes](fix-esc-code-formatting.md)
 - [x] RRT API (Pending PRs & Issues)
   - [x] [pr-452-fix.md](done/pr-452-fix.md) -
         https://github.com/r3bl-org/r3bl-open-core/pull/452
-  - [x] [issue-451-fix.md](done/issue-451-fix.md) -
-        https://github.com/r3bl-org/r3bl-open-core/issues/451
 - [ ] Cursor display issues
   - [ ] https://github.com/r3bl-org/r3bl-open-core/issues/461
 - [ ] PRs from Cecile

--- a/task/prepare-v0.8.0-meta-task.md
+++ b/task/prepare-v0.8.0-meta-task.md
@@ -10,13 +10,13 @@
   - [x] [improve-immature-vt100-shim.md](done/improve-immature-vt100-shim.md)
   - [x] [pr-448-fix.md](done/pr-448-fix.md) - https://github.com/r3bl-org/r3bl-open-core/pull/448
   - [x] [issue-451-fix.md](done/issue-451-fix.md) - https://github.com/r3bl-org/r3bl-open-core/issues/451
-  - [ ] [remove crossterm mental model pollution](remove-crossterm-mental-model-pollution.md)
-  - [ ] [rustdocs - fix readability of esc codes](fix-esc-code-formatting.md)
 - [x] RRT API (Pending PRs & Issues)
   - [x] [pr-452-fix.md](done/pr-452-fix.md) -
         https://github.com/r3bl-org/r3bl-open-core/pull/452
-- [ ] Cursor display issues
-  - [ ] https://github.com/r3bl-org/r3bl-open-core/issues/461
+- [x] Cursor display issues
+  - [x] [issue-461-fix.md](done/issue-461-fix.md) - https://github.com/r3bl-org/r3bl-open-core/issues/461
+  - [ ] [remove crossterm mental model pollution](remove-crossterm-mental-model-pollution.md)
+  - [ ] [rustdocs - fix readability of esc codes](fix-esc-code-formatting.md)
 - [ ] PRs from Cecile
   - [ ] https://github.com/r3bl-org/r3bl-open-core/pull/455
   - [ ] https://github.com/r3bl-org/r3bl-open-core/pull/456

--- a/task/remove-crossterm-mental-model-pollution.md
+++ b/task/remove-crossterm-mental-model-pollution.md
@@ -1,0 +1,104 @@
+# Task: Remove Crossterm Mental Model Pollution from RenderOps
+
+## 1. Overview
+
+- **Goal**: Decouple Terminal Lifecycle/Global State management from Terminal Rendering
+  operations.
+- **Problem**: The `RenderOpCommon` enum contains variants like `EnterRawMode`,
+  `ExitRawMode`, `ShowCursor`, `HideCursor`, `EnterAlternateScreen`, etc. This is a
+  vestigial remain from when the project relied heavily on Crossterm's `Command` queue
+  model.
+  - The Compositor has to explicitly ignore these variants because they don't apply to the
+    2D layout domain.
+  - Lifecycle operations like `EnterRawMode` trigger OS-level syscalls
+    (`tcgetattr`/`tcsetattr`) which shouldn't happen midway through a buffered rendering
+    flush loop.
+  - UI components shouldn't be responsible for emitting global environment changes.
+  - **Historical Context**: The compositor used to explicitly track these states (see code
+    below in `tui/src/tui/terminal_lib_backends/compositor_render_ops_to_ofs_buf.rs`), but
+    this was removed during the `OfsBufVT100` refactor, leaving behind empty match arms.
+    This proves these variants no longer belong in the rendering layer.
+    ```rust
+    // Old code (removed):
+    // ...
+    // These operations update the OffscreenBuffer's terminal mode state while also
+    // being executed by the terminal backend to affect actual terminal behavior.
+    RenderOpCommon::EnterRawMode => {
+        ofs_buf.terminal_mode.raw_mode = RawModeState::Enabled;
+    }
+    RenderOpCommon::ExitRawMode => {
+        ofs_buf.terminal_mode.raw_mode = RawModeState::Disabled;
+    }
+    RenderOpCommon::EnterAlternateScreen => {
+        ofs_buf.terminal_mode.alternate_screen = AlternateScreenState::Active;
+    }
+    RenderOpCommon::ExitAlternateScreen => {
+        ofs_buf.terminal_mode.alternate_screen = AlternateScreenState::Inactive;
+    }
+    RenderOpCommon::EnableMouseTracking => {
+        ofs_buf.terminal_mode.mouse_tracking = MouseTrackingState::Enabled;
+    }
+    RenderOpCommon::DisableMouseTracking => {
+        ofs_buf.terminal_mode.mouse_tracking = MouseTrackingState::Disabled;
+    }
+    RenderOpCommon::EnableBracketedPaste => {
+        ofs_buf.terminal_mode.bracketed_paste = BracketedPasteState::Enabled;
+    }
+    RenderOpCommon::DisableBracketedPaste => {
+        ofs_buf.terminal_mode.bracketed_paste = BracketedPasteState::Disabled;
+    }
+    // ...
+    ```
+
+## 2. Proposed Architecture
+
+### Clean up `RenderOpCommon`
+
+Strip all non-drawing operations from the enum.
+
+- **Remove**: `EnterRawMode`, `ExitRawMode`, `EnterAlternateScreen`,
+  `ExitAlternateScreen`, `EnableMouseTracking`, `DisableMouseTracking`, `ShowCursor`,
+  `HideCursor`, `EnableBracketedPaste`, `DisableBracketedPaste`.
+- **Keep**: Pure visual instructions only (e.g., `PrintText`, `SetFgColor`, `SetBgColor`,
+  `MoveCursorPosition`, `ClearScreen`).
+
+### Introduce a Terminal Lifecycle API
+
+Move these state changes to explicit, synchronous function calls on the backend or output
+device (e.g., a `TerminalState` trait).
+
+```rust
+// Application Startup
+backend.enter_raw_mode()?;
+backend.enter_alternate_screen()?;
+backend.hide_cursor()?;
+
+// ... Event loop and purely visual RenderOps happen here ...
+
+// Application Shutdown
+backend.show_cursor()?;
+backend.exit_alternate_screen()?;
+backend.exit_raw_mode()?;
+```
+
+### Refactor Multiplexer (`pty_mux`)
+
+Currently, `pty_mux` explicitly injects `RenderOpCommon::HideCursor` into the render
+stream to suppress the native cursor. Under the new model, it should simply call
+`backend.hide_cursor()` upon initialization, as it inherently takes over the global
+terminal environment.
+
+## 3. Scope of Work (Checklist)
+
+- [ ] Audit `RenderOpCommon` and identify all lifecycle/state variants to be removed.
+- [ ] Create a new API surface (e.g. `TerminalLifecycle` or methods on
+      `OutputDevice`/Backend) for explicit terminal state control.
+- [ ] Implement the new synchronous syscall/ANSI sequence triggers for `direct_to_ansi`
+      and `crossterm` backends.
+- [ ] Remove the defunct variants from `RenderOpCommon`, `RenderOpIR`, and
+      `RenderOpOutput`.
+- [ ] Update `pty_mux` to use the new synchronous cursor hiding API.
+- [ ] Update app startup/shutdown sequences across the workspace to use the new lifecycle
+      API instead of emitting `RenderOp`s.
+- [ ] Run comprehensive code quality checks (`./check.fish --full`) to ensure full
+      cross-platform compatibility.

--- a/tui/src/core/ansi/constants/esc.rs
+++ b/tui/src/core/ansi/constants/esc.rs
@@ -18,22 +18,25 @@ use crate::define_ansi_const;
 
 // Cursor Save/Restore Operations
 
-/// Save Cursor (DECSC): Saves the current cursor position and attributes.
+/// Save Cursor ([`DECSC`]): Saves the current cursor position and attributes.
 ///
 /// Value: `55` dec, `37` hex.
 ///
 /// Sequence: `ESC 7`.
 ///
+/// [`DECSC`]: https://vt100.net/docs/vt510-rm/DECSC.html
 /// [`ESC`]: crate::EscSequence
 /// [VT-100]: https://vt100.net/docs/vt100-ug/chapter3.html
 pub const DECSC_SAVE_CURSOR: u8 = b'7';
 
-/// Restore Cursor (DECRC): Restores the previously saved cursor position and attributes.
+/// Restore Cursor ([`DECRC`]): Restores the previously saved cursor position and
+/// attributes.
 ///
 /// Value: `56` dec, `38` hex.
 ///
 /// Sequence: `ESC 8`.
 ///
+/// [`DECRC`]: https://vt100.net/docs/vt510-rm/DECRC.html
 /// [`ESC`]: crate::EscSequence
 /// [VT-100]: https://vt100.net/docs/vt100-ug/chapter3.html
 pub const DECRC_RESTORE_CURSOR: u8 = b'8';

--- a/tui/src/core/ansi/generator/ansi_sequence_generator_output.rs
+++ b/tui/src/core/ansi/generator/ansi_sequence_generator_output.rs
@@ -77,7 +77,7 @@ use crate::{ColIndex, ColorTarget, EraseDisplayMode, EraseLineMode, RowIndex,
 /// [`CsiSequence`]: crate::CsiSequence
 /// [`FastStringify`]: crate::fast_stringify::FastStringify
 /// [`SgrColorSequence`]: crate::SgrColorSequence
-/// [`vt_100_pty_output_parser`]: mod@crate::vt_100_pty_output_parser
+/// [`vt_100_pty_output_parser`]: mod@crate::core::ansi::vt_100_pty_output_parser
 #[derive(Debug)]
 pub struct AnsiSequenceGenerator;
 
@@ -207,7 +207,7 @@ mod color_ops {
         /// infrastructure
         ///
         /// [`SGR`]: crate::SgrCode
-        /// [`vt_100_pty_output_parser`]: mod@crate::vt_100_pty_output_parser
+        /// [`vt_100_pty_output_parser`]: mod@crate::core::ansi::vt_100_pty_output_parser
         #[must_use]
         pub fn text_attributes(style: &TuiStyle) -> String {
             // Build SGR sequence with all applicable attributes
@@ -288,17 +288,17 @@ mod cursor_save_restore {
     use super::*;
 
     impl AnsiSequenceGenerator {
-        /// Save cursor position
-        /// [`CSI`] s (DECSC: Save Cursor)
+        /// Save cursor position - [`CSI`] s (Save Cursor, i.e., [`DECSC`]).
         ///
         /// [`CSI`]: crate::CsiSequence
+        /// [`DECSC`]: https://vt100.net/docs/vt510-rm/DECSC.html
         #[must_use]
         pub fn save_cursor_position() -> String { CsiSequence::SaveCursor.to_string() }
 
-        /// Restore cursor position
-        /// [`CSI`] u (DECRC: Restore Cursor)
+        /// Restore cursor position - [`CSI`] u (Restore Cursor, i.e., [`DECRC`]).
         ///
         /// [`CSI`]: crate::CsiSequence
+        /// [`DECRC`]: https://vt100.net/docs/vt510-rm/DECRC.html
         #[must_use]
         pub fn restore_cursor_position() -> String {
             CsiSequence::RestoreCursor.to_string()

--- a/tui/src/core/ansi/generator/esc_sequence.rs
+++ b/tui/src/core/ansi/generator/esc_sequence.rs
@@ -39,10 +39,10 @@
 //! [`reset`]: https://man7.org/linux/man-pages/man1/reset.1.html
 //! [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
 
-use crate::{generate_impl_display_for_fast_stringify, ok};
 use crate::{BufTextStorage, ESC_INDEX_DOWN_STR, ESC_RESET_TERMINAL_STR,
             ESC_RESTORE_CURSOR_STR, ESC_REVERSE_INDEX_STR, ESC_SAVE_CURSOR_STR,
-            ESC_SELECT_ASCII_STR, ESC_SELECT_DEC_GRAPHICS_STR, FastStringify};
+            ESC_SELECT_ASCII_STR, ESC_SELECT_DEC_GRAPHICS_STR, FastStringify,
+            generate_impl_display_for_fast_stringify, ok};
 use std::fmt;
 
 /// Builder for [`ESC`] ([`ESC` spec]) sequences.
@@ -54,9 +54,13 @@ use std::fmt;
 /// [`SgrCode`]: crate::SgrCode
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum EscSequence {
-    /// `ESC 7` - Save cursor position (`DECSC`).
+    /// `ESC 7` - Save cursor position ([`DECSC`]).
+    ///
+    /// [`DECSC`]: https://vt100.net/docs/vt510-rm/DECSC.html
     SaveCursor,
-    /// `ESC 8` - Restore cursor position (`DECRC`).
+    /// `ESC 8` - Restore cursor position ([`DECRC`]).
+    ///
+    /// [`DECRC`]: https://vt100.net/docs/vt510-rm/DECRC.html
     RestoreCursor,
     /// `ESC D` - Index down (`IND`).
     IndexDown,

--- a/tui/src/core/ansi/generator/sgr_code.rs
+++ b/tui/src/core/ansi/generator/sgr_code.rs
@@ -58,7 +58,7 @@
 //!
 //! Note: Our [`VT-100`] *parser* accepts both formats for maximum compatibility when
 //! parsing output from other applications. See
-//! [`crate::vt_100_pty_output_parser`].
+//! [`crate::core::ansi::vt_100_pty_output_parser`].
 //!
 //! More info:
 //! - <https://doc.rust-lang.org/reference/tokens.html#ascii-escapes>

--- a/tui/src/core/ansi/mod.rs
+++ b/tui/src/core/ansi/mod.rs
@@ -226,7 +226,7 @@
 //! [`SgrCode`]: crate::SgrCode
 //! [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
 //! [`VT100InputEventIR`]: crate::vt_100_terminal_input_parser::VT100InputEventIR
-//! [`vt_100_pty_output_parser`]: mod@crate::vt_100_pty_output_parser
+//! [`vt_100_pty_output_parser`]: mod@crate::core::ansi::vt_100_pty_output_parser
 //! [`vt_100_terminal_input_parser`]: mod@crate::vt_100_terminal_input_parser
 //! [`VTE`]: mod@vte
 

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ansi_parser_public_api.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ansi_parser_public_api.rs
@@ -15,12 +15,12 @@
 //! use r3bl_tui::{*, height, width};
 //!
 //! // Entry point: Process ANSI sequences from PTY output
-//! let mut buffer = OffscreenBuffer::new_empty(height(24) + width(80));
+//! let mut ofs_buf_vt_100 = OfsBufVT100::new_empty(height(24) + width(80));
 //! let pty_output = format!("{}Red text{}",
 //!     SgrCode::ForegroundBasic(ANSIBasicColor::Red),
 //!     SgrCode::Reset
 //! );
-//! let (osc_events, dsr_responses) = buffer.apply_ansi_bytes(pty_output);
+//! let (osc_events, dsr_responses) = ofs_buf_vt_100.apply_ansi_bytes(pty_output);
 //! // Buffer now contains styled text, events contain any OSC/DSR commands
 //! ```
 //!
@@ -121,7 +121,7 @@
 //! that don't need parameters.
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
-//! [`apply_ansi_bytes`]: crate::OffscreenBuffer::apply_ansi_bytes
+//! [`apply_ansi_bytes`]: crate::OfsBufVT100::apply_ansi_bytes
 //! [`ASCII`]: https://en.wikipedia.org/wiki/ASCII
 //! [`CSI`]: crate::CsiSequence
 //! [`DSR`]: crate::DsrSequence
@@ -132,15 +132,15 @@
 //! [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
 //! [`vte`]: https://docs.rs/vte
 
-use crate::{DsrRequestFromPtyEvent, OffscreenBuffer, core::osc::OscEvent};
+use crate::{DsrRequestFromPtyEvent, OfsBufVT100, core::osc::OscEvent};
 use std::mem::take;
 
 /// Terminal state context for [`ANSI`] sequence processing.
 ///
-/// This performer is created by [`OffscreenBuffer::apply_ansi_bytes`] and passed to the
+/// This performer is created by [`OfsBufVT100::apply_ansi_bytes`] and passed to the
 /// [`VTE`] [`Parser`] implementation. It provides direct access to persistent terminal
-/// state stored in the buffer's [`OffscreenBuffer::ansi_parser_support`] field. All state
-/// is stored directly in the buffer and persisted between performer instances.
+/// state stored in the buffer's [`OfsBufVT100::parser_global_state`] field. All state is
+/// stored directly in the buffer and persisted between performer instances.
 ///
 /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 /// [`Parser`]: vte::Parser
@@ -149,19 +149,22 @@ use std::mem::take;
 pub struct AnsiToOfsBufPerformer<'a> {
     /// Target buffer receiving processed terminal output and storing all persistent
     /// terminal state. Characters are written at the current cursor position, and the
-    /// buffer's viewport and scrolling are managed automatically as content flows
-    /// beyond boundaries.
-    pub ofs_buf: &'a mut OffscreenBuffer,
+    /// buffer's viewport and scrolling are managed automatically as content flows beyond
+    /// boundaries.
+    pub ofs_buf_vt_100: &'a mut OfsBufVT100,
 }
 
 impl<'a> AnsiToOfsBufPerformer<'a> {
-    /// Creates a new performer for the given `ofs_buf`.
+    /// Creates a new performer for the given `ofs_buf_vt_100`.
     ///
     /// This creates a performer instance that provides direct access to persistent
-    /// terminal state stored in the buffer's `ansi_parser_support` field.
-    /// All terminal state is maintained in the buffer and persists between performer
-    /// instances.
-    pub fn new(ofs_buf: &'a mut OffscreenBuffer) -> Self { Self { ofs_buf } }
+    /// terminal state stored in the buffer's [`parser_global_state`] field. All terminal
+    /// state is maintained in the buffer and persists between performer instances.
+    ///
+    /// [`parser_global_state`]: OfsBufVT100::parser_global_state
+    pub fn new(ofs_buf_vt_100: &'a mut OfsBufVT100) -> Self {
+        Self { ofs_buf_vt_100 }
+    }
 
     /// Handles the core parsing loop where each byte is fed to the [`VTE parser`], which
     /// in turn calls methods on the performer (via the [`Perform`] trait).
@@ -178,11 +181,11 @@ impl<'a> AnsiToOfsBufPerformer<'a> {
 }
 
 /// Public API to process [`ANSI`]/[`VT-100`] sequences and apply them to an
-/// [`OffscreenBuffer`].
+/// [`OfsBufVT100`].
 ///
 /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
-impl OffscreenBuffer {
+impl OfsBufVT100 {
     /// Process & apply [`ANSI`]/[`VT-100`] sequences directly to this buffer.
     ///
     /// ## Data Flow:
@@ -218,13 +221,13 @@ impl OffscreenBuffer {
     /// # Example
     ///
     /// ```
-    /// use r3bl_tui::{OffscreenBuffer, Size, height, width, SgrCode, ANSIBasicColor};
+    /// use r3bl_tui::{OfsBufVT100, Size, height, width, SgrCode, ANSIBasicColor};
     ///
-    /// let mut ofs_buf = OffscreenBuffer::new_empty(height(10) + width(10));
+    /// let mut ofs_buf_vt_100 = OfsBufVT100::new_empty(height(10) + width(10));
     /// let red_text = format!("Hello{a}Red Text{b}",
     ///     a = SgrCode::ForegroundBasic(ANSIBasicColor::DarkRed),
     ///     b = SgrCode::Reset);
-    /// let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(red_text);
+    /// let (osc_events, dsr_responses) = ofs_buf_vt_100.apply_ansi_bytes(red_text);
     /// ```
     ///
     /// # Processing details
@@ -235,17 +238,20 @@ impl OffscreenBuffer {
     /// - Style attributes (`bold`, `fg_color`, etc.) are [`SGR`] (Select Graphic
     ///   Rendition) attributes that apply to characters being written. These styles get
     ///   baked into the [`PixelChar`] objects in the buffer and stored in the buffer's
-    ///   `ansi_parser_support` field for persistence.
-    /// - Cursor position is read from and written directly to `buffer.my_pos` during
-    ///   processing - no copying or synchronization is needed.
+    ///   [`parser_global_state`] field for persistence.
+    /// - Cursor position is read from and written directly to the buffer's [`cursor_pos`]
+    ///   field during processing - no copying or synchronization is needed.
     /// - All persistent state lives in the [`OffscreenBuffer`], accessed directly by the
     ///   performer through mutable references.
     /// - The [`VTE Parser`] (which must maintain state across reads for split sequences)
     ///   is kept separately in the [`Process`] struct.
     ///
     /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
+    /// [`cursor_pos`]: crate::OffscreenBuffer::cursor_pos
     /// [`DSR response events`]: crate::DsrRequestFromPtyEvent
+    /// [`OffscreenBuffer`]: crate::OffscreenBuffer
     /// [`OSC events`]: crate::core::osc::OscEvent
+    /// [`parser_global_state`]: OfsBufVT100::parser_global_state
     /// [`PixelChar`]: crate::PixelChar
     /// [`Process`]: crate::pty_mux::Process
     /// [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
@@ -261,10 +267,18 @@ impl OffscreenBuffer {
         performer.apply_ansi_bytes(bytes.as_ref());
 
         // Use std::mem::take to move events out and leave empty vectors.
-        let osc_events =
-            take(&mut performer.ofs_buf.ansi_parser_support.pending_osc_events);
-        let pending_dsr_requests =
-            take(&mut performer.ofs_buf.ansi_parser_support.pending_dsr_responses);
+        let osc_events = take(
+            &mut performer
+                .ofs_buf_vt_100
+                .parser_global_state
+                .pending_osc_events,
+        );
+        let pending_dsr_requests = take(
+            &mut performer
+                .ofs_buf_vt_100
+                .parser_global_state
+                .pending_dsr_responses,
+        );
 
         (osc_events, pending_dsr_requests)
     }
@@ -286,7 +300,7 @@ mod tests {
     #[test]
     #[allow(clippy::items_after_statements)]
     fn test_public_api_plain_text() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         const TEXT: &str = "Hello";
 
@@ -302,18 +316,18 @@ mod tests {
         //                               ╰─ cursor ends here
 
         // Test that the public API processes text correctly.
-        let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(TEXT);
+        let (osc_events, dsr_responses) = ofs_buf_vt_100.apply_ansi_bytes(TEXT);
 
         // Should not produce any OSC events for SGR sequences.
         assert_eq!(osc_events.len(), 0, "no OSC events expected");
         assert_eq!(dsr_responses.len(), 0, "no DSR responses expected");
 
         // Verify "Hello" is in the buffer.
-        assert_plain_text_at(&ofs_buf, 0, 0, TEXT);
+        assert_plain_text_at(&ofs_buf_vt_100, 0, 0, TEXT);
 
         // Verify cursor position is updated correctly.
         assert_eq!(
-            ofs_buf.cursor_pos,
+            ofs_buf_vt_100.cursor_pos,
             row(0) + col(TEXT.len()),
             "cursor should be at end of text"
         );
@@ -322,7 +336,7 @@ mod tests {
     #[test]
     #[allow(clippy::items_after_statements)]
     fn test_public_api_with_colors() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         const TEXT: &str = "Red Text";
 
@@ -341,7 +355,7 @@ mod tests {
         // Sequence: ESC[31m + "Red Text" + ESC[0m
 
         // Test processing with ANSI color codes.
-        let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(format!(
+        let (osc_events, dsr_responses) = ofs_buf_vt_100.apply_ansi_bytes(format!(
             "{red_fg}{text}{reset}",
             red_fg = SgrCode::ForegroundBasic(ANSIBasicColor::Red),
             text = TEXT,
@@ -355,7 +369,7 @@ mod tests {
         // Verify the text with proper styling.
         for (col, expected_char) in TEXT.chars().enumerate() {
             assert_styled_char_at(
-                &ofs_buf,
+                &ofs_buf_vt_100,
                 0,
                 col,
                 expected_char,
@@ -368,7 +382,7 @@ mod tests {
 
         // Verify cursor position is updated correctly.
         assert_eq!(
-            ofs_buf.cursor_pos,
+            ofs_buf_vt_100.cursor_pos,
             row(0) + col(TEXT.len()),
             "cursor should be at end of text"
         );
@@ -376,7 +390,7 @@ mod tests {
 
     #[test]
     fn test_public_api_cursor_movement() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Note: OffscreenBuffer uses 0-based index, and terminal (CSI, ESC seq, etc) uses
         // 1-based index.
@@ -397,7 +411,7 @@ mod tests {
         // 5. Write 'D' at (0,4) → cursor moves to (0,5)
 
         // Test cursor movement sequences.
-        let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(format!(
+        let (osc_events, dsr_responses) = ofs_buf_vt_100.apply_ansi_bytes(format!(
             "A{right_2}B{up_1}D",
             // SAFETY: 2 and 1 are non-zero
             right_2 = CsiSequence::CursorForward(term_col_delta(2).unwrap()),
@@ -410,25 +424,25 @@ mod tests {
 
         // Verify cursor position after all operations.
         assert_eq!(
-            ofs_buf.cursor_pos,
+            ofs_buf_vt_100.cursor_pos,
             row(0) + col(5),
             "cursor should be at (0,5) after writing 'D'"
         );
 
         // Verify characters at specific positions instead of continuous string.
-        assert_plain_char_at(&ofs_buf, 0, 0, 'A');
-        assert_empty_at(&ofs_buf, 0, 1); // Empty space
-        assert_empty_at(&ofs_buf, 0, 2); // Empty space
-        assert_plain_text_at(&ofs_buf, 0, 3, "BD");
+        assert_plain_char_at(&ofs_buf_vt_100, 0, 0, 'A');
+        assert_empty_at(&ofs_buf_vt_100, 0, 1); // Empty space
+        assert_empty_at(&ofs_buf_vt_100, 0, 2); // Empty space
+        assert_plain_text_at(&ofs_buf_vt_100, 0, 3, "BD");
     }
 
     #[test]
     fn test_osc_events_are_drained_not_accumulated() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // First call with OSC sequence (set title).
         let osc_title = OscSequence::SetTitleAndIcon("First Title".into()).to_string();
-        let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(&osc_title);
+        let (osc_events, dsr_responses) = ofs_buf_vt_100.apply_ansi_bytes(&osc_title);
 
         assert_eq!(osc_events.len(), 1, "should get one OSC event");
         assert_eq!(dsr_responses.len(), 0, "no DSR responses expected");
@@ -442,7 +456,7 @@ mod tests {
 
         // Second call with another OSC sequence.
         let osc_title2 = OscSequence::SetTitleAndIcon("Second Title".into()).to_string();
-        let (osc_events2, dsr_responses2) = ofs_buf.apply_ansi_bytes(&osc_title2);
+        let (osc_events2, dsr_responses2) = ofs_buf_vt_100.apply_ansi_bytes(&osc_title2);
 
         assert_eq!(
             osc_events2.len(),
@@ -463,7 +477,7 @@ mod tests {
 
         // Third call with no OSC sequences.
         let plain_text = "Hello";
-        let (osc_events3, dsr_responses3) = ofs_buf.apply_ansi_bytes(plain_text);
+        let (osc_events3, dsr_responses3) = ofs_buf_vt_100.apply_ansi_bytes(plain_text);
 
         assert_eq!(
             osc_events3.len(),
@@ -475,11 +489,11 @@ mod tests {
 
     #[test]
     fn test_dsr_events_are_drained_in_public_api() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // First DSR request (status report).
         let dsr_status = DSR_STATUS_REQUEST.to_string();
-        let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(&dsr_status);
+        let (osc_events, dsr_responses) = ofs_buf_vt_100.apply_ansi_bytes(&dsr_status);
 
         assert_eq!(osc_events.len(), 0, "no OSC events expected");
         assert_eq!(dsr_responses.len(), 1, "should get one DSR response");
@@ -487,7 +501,7 @@ mod tests {
 
         // Second call with cursor position request.
         let dsr_cursor = DSR_CURSOR_POSITION_REQUEST.to_string();
-        let (osc_events2, dsr_responses2) = ofs_buf.apply_ansi_bytes(&dsr_cursor);
+        let (osc_events2, dsr_responses2) = ofs_buf_vt_100.apply_ansi_bytes(&dsr_cursor);
 
         assert_eq!(osc_events2.len(), 0, "no OSC events expected");
         assert_eq!(
@@ -516,7 +530,7 @@ mod tests {
 
         // Third call with no DSR requests.
         let plain_text = "Test";
-        let (osc_events3, dsr_responses3) = ofs_buf.apply_ansi_bytes(plain_text);
+        let (osc_events3, dsr_responses3) = ofs_buf_vt_100.apply_ansi_bytes(plain_text);
 
         assert_eq!(osc_events3.len(), 0, "no OSC events expected");
         assert_eq!(
@@ -528,7 +542,7 @@ mod tests {
 
     #[test]
     fn test_mixed_osc_and_dsr_events() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Send a mix of OSC and DSR sequences in one call.
         let mixed_sequence = format!(
@@ -538,7 +552,8 @@ mod tests {
             crate::DSR_CURSOR_POSITION_REQUEST                  // DSR: Cursor position
         );
 
-        let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(&mixed_sequence);
+        let (osc_events, dsr_responses) =
+            ofs_buf_vt_100.apply_ansi_bytes(&mixed_sequence);
 
         // Should get exactly one OSC event.
         assert_eq!(osc_events.len(), 1, "should get one OSC event");
@@ -566,14 +581,14 @@ mod tests {
         }
 
         // Verify both are drained on next call.
-        let (osc_events2, dsr_responses2) = ofs_buf.apply_ansi_bytes("text");
+        let (osc_events2, dsr_responses2) = ofs_buf_vt_100.apply_ansi_bytes("text");
         assert_eq!(osc_events2.len(), 0, "OSC events should be drained");
         assert_eq!(dsr_responses2.len(), 0, "DSR responses should be drained");
     }
 
     #[test]
     fn test_multiple_osc_events_in_one_call() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Send multiple OSC sequences in one call.
         let multi_osc = format!(
@@ -583,7 +598,7 @@ mod tests {
             OscSequence::SetIcon("Icon Name".into())          // OSC 1
         );
 
-        let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(&multi_osc);
+        let (osc_events, dsr_responses) = ofs_buf_vt_100.apply_ansi_bytes(&multi_osc);
 
         assert_eq!(osc_events.len(), 3, "should get three OSC events");
         assert_eq!(dsr_responses.len(), 0, "no DSR responses expected");
@@ -597,7 +612,8 @@ mod tests {
         }
 
         // Next call should have empty events.
-        let (osc_events2, dsr_responses2) = ofs_buf.apply_ansi_bytes("normal text");
+        let (osc_events2, dsr_responses2) =
+            ofs_buf_vt_100.apply_ansi_bytes("normal text");
         assert_eq!(osc_events2.len(), 0, "OSC events should be drained");
         assert_eq!(dsr_responses2.len(), 0, "DSR responses should be drained");
     }
@@ -629,9 +645,9 @@ mod tests {
     /// [`OffscreenBuffer`]: crate::OffscreenBuffer
     #[test]
     fn test_public_api_csi_position_change() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
-        let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(format!(
+        let (osc_events, dsr_responses) = ofs_buf_vt_100.apply_ansi_bytes(format!(
             "Start{move_to_r2_c3}Mid{move_to_r1_c1}Home{move_to_r8_c8}End",
             move_to_r2_c3 = csi_seq_cursor_pos(term_row(nz(2)) + term_col(nz(3))),
             move_to_r1_c1 = csi_seq_cursor_pos(term_row(nz(1)) + term_col(nz(1))),
@@ -642,13 +658,13 @@ mod tests {
         assert_eq!(dsr_responses.len(), 0, "no DSR responses expected");
 
         // Verify layout matches diagram.
-        assert_plain_text_at(&ofs_buf, 0, 0, "Homet");
-        assert_plain_text_at(&ofs_buf, 1, 2, "Mid");
-        assert_plain_text_at(&ofs_buf, 7, 7, "End");
+        assert_plain_text_at(&ofs_buf_vt_100, 0, 0, "Homet");
+        assert_plain_text_at(&ofs_buf_vt_100, 1, 2, "Mid");
+        assert_plain_text_at(&ofs_buf_vt_100, 7, 7, "End");
 
         // Cursor wraps from (7,10) to (8,0).
         assert_eq!(
-            ofs_buf.cursor_pos,
+            ofs_buf_vt_100.cursor_pos,
             row(8) + col(0),
             "cursor should be at (8,0) wrapping after 'End'"
         );

--- a/tui/src/core/ansi/vt_100_pty_output_parser/mod.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/mod.rs
@@ -3,14 +3,14 @@
 //! [`ANSI`]/[`VT-100`] sequence parsing for terminal emulation
 //!
 //! This module provides a comprehensive [`VT-100`]-compliant [`ANSI`] escape sequence
-//! parser that processes terminal output and converts it into structured operations.
+//! parser that processes terminal output and converts it into structured ops.
 //!
 //! ## Architecture
 //!
 //! - **[`performer`]**: [`VTE`] [`Perform`] trait implementation - handles state
 //!   transitions
 //! - **[`protocols`]**: [`ANSI`] sequence types and constants
-//! - **[`operations`]**: Protocol handlers that translate sequences into operations
+//! - **[`ops`]**: Protocol handlers that translate sequences into ops
 //! - **[`vt_100_pty_output_conformance_tests`]**: Comprehensive [`VT-100`] conformance
 //!   tests
 //!
@@ -22,7 +22,7 @@
 //!
 //! ## Primary Consumer
 //!
-//! This parser is primarily used by [`OffscreenBuffer::apply_ansi_bytes`], which
+//! This parser is primarily used by [`OfsBufVT100::apply_ansi_bytes`], which
 //! processes [`PTY`] output from child processes and updates the terminal display state.
 //!
 //! ```text
@@ -30,7 +30,7 @@
 //!    │
 //!    │ Receives bytes from child process (bash, vim, etc.)
 //!    ▼
-//! OffscreenBuffer::apply_ansi_bytes()
+//! OfsBufVT100::apply_ansi_bytes()
 //!    │
 //!    │ Delegates to this parser
 //!    ▼
@@ -44,7 +44,7 @@
 //! For terminal multiplexer architecture, see the [`pty_mux`] module.
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
-//! [`OffscreenBuffer::apply_ansi_bytes`]: crate::OffscreenBuffer::apply_ansi_bytes
+//! [`OfsBufVT100::apply_ansi_bytes`]: crate::OfsBufVT100::apply_ansi_bytes
 //! [`Perform`]: vte::Perform
 //! [`pty_mux`]: mod@crate::core::pty_mux
 //! [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
@@ -52,14 +52,29 @@
 //! [`VTE`]: mod@vte
 
 pub mod ansi_parser_public_api;
-pub mod operations;
+pub mod ofs_buf_vt_100;
 pub mod performer;
 pub mod protocols;
+
+#[cfg(any(test, doc))]
+pub mod ops;
+#[cfg(not(any(test, doc)))]
+mod ops;
+
+
+
+#[cfg(any(test, doc))]
+pub mod ops_impl_ofs_buf;
+#[cfg(not(any(test, doc)))]
+mod ops_impl_ofs_buf;
+
+pub use ops_impl_ofs_buf::*;
 
 // `VT-100` conformance tests module
 pub mod vt_100_pty_output_conformance_tests;
 
 // Re-export public API
 pub use ansi_parser_public_api::*;
-pub use operations::*;
+pub use ofs_buf_vt_100::*;
+pub use ops::*;
 pub use protocols::*;

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ofs_buf_vt_100.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ofs_buf_vt_100.rs
@@ -1,0 +1,629 @@
+// Copyright (c) 2022-2025 R3BL LLC. Licensed under Apache License, Version 2.0.
+
+use crate::{DsrRequestFromPtyEvent, GetMemSize, MemorySize, OffscreenBuffer,
+            PixelCharLines, Pos, Size, TermRow, TuiStyle, osc::OscEvent};
+use std::{fmt::Debug,
+          mem::size_of,
+          ops::{Deref, DerefMut}};
+
+/// State for the [`VT-100`] [`ANSI`] parser, which is used by the [`PTY`] multiplexer.
+///
+/// This struct composites:
+/// 1. The screen buffer [`OffscreenBuffer`]
+/// 2. The [`VT-100`] [`ANSI`] [parser] state machine, which includes:
+///    - The [`ANSI`] parser state - [`ParserGlobalState`]
+///    - The terminal mode flags - [`TerminalModeState`]
+///    - The hidden screen parking state - [`HiddenScreenState`]
+///
+/// It is used specifically by the [`PTY`] [multiplexer]. The underlying machinery to
+/// parse [`VT-100`] is in the [parser] module.
+///
+/// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
+/// [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
+/// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
+/// [multiplexer]: mod@crate::pty_mux
+/// [parser]: mod@crate::core::ansi::vt_100_pty_output_parser
+#[derive(Clone, Debug, PartialEq)]
+pub struct OfsBufVT100 {
+    pub ofs_buf: OffscreenBuffer,
+    pub parser_global_state: ParserGlobalState,
+    pub hidden_screen_state: HiddenScreenState,
+    pub terminal_mode: TerminalModeState,
+}
+
+mod vt_100_terminal_state_impl {
+    #[allow(clippy::wildcard_imports)]
+    use super::*;
+
+    impl Deref for OfsBufVT100 {
+        type Target = OffscreenBuffer;
+        fn deref(&self) -> &Self::Target { &self.ofs_buf }
+    }
+
+    impl DerefMut for OfsBufVT100 {
+        fn deref_mut(&mut self) -> &mut Self::Target { &mut self.ofs_buf }
+    }
+
+    impl GetMemSize for OfsBufVT100 {
+        /// Fast `O(1)` memory footprint calculation.
+        ///
+        /// This avoids expensive `O(rows * columns)` calculations by relying on the
+        /// `O(1)` cached memory retrieval of both the primary [`OffscreenBuffer`] and
+        /// the alternate screen buffer ([`HiddenScreenState`]).
+        fn get_mem_size(&self) -> usize {
+            self.ofs_buf.get_mem_size()
+                + self.hidden_screen_state.get_mem_size()
+                + size_of::<ParserGlobalState>()
+                + size_of::<TerminalModeState>()
+                + size_of::<Self>()
+        }
+    }
+
+    impl OfsBufVT100 {
+        #[must_use]
+        pub fn new_empty(arg_window_size: impl Into<Size>) -> Self {
+            let window_size = arg_window_size.into();
+            Self {
+                ofs_buf: OffscreenBuffer::new_empty(window_size),
+                parser_global_state: ParserGlobalState::default(),
+                hidden_screen_state: HiddenScreenState::new_empty(window_size),
+                terminal_mode: TerminalModeState::default(),
+            }
+        }
+    }
+}
+
+/// Encapsulated runtime state tracking active graphic renditions, terminal attributes,
+/// and protocol requests for [`ANSI`] sequence parsing.
+///
+/// This struct maintains the global terminal states that persist across individual parser
+/// sequences and must be inherited when transitioning between different screen buffers
+/// (e.g., from the primary grid to the alternate grid).
+///
+/// It acts as the central holding area for:
+/// - Graphic renditions ([`SGR`]) such as active foreground/background colors, text
+///   styling (bold, italic, etc.), ensuring [`BCE`] (Background Color Erase) compliance.
+/// - The active character set mapping (e.g., standard [`ASCII`] vs. [`DEC`] Line
+///   Drawing).
+/// - Cursor visibility states toggled via escape codes.
+/// - Pending Device Status Report ([`DSR`]) requests that need to be flushed back to the
+///   [`PTY`].
+///
+/// ## Primary and Alt Screen State Management
+///
+/// This struct manages global terminal settings. Why is the active cursor position
+/// intentionally omitted here?
+///
+/// Under the [`VT-100`]/[`xterm`] spec, when switching to the alternate screen:
+/// - **Global state shared between primary and alternate screens**: Graphic renditions
+///   (colors, bold, etc.), active character sets (`ESC ( B`), and cursor visibility
+///   settings persist across screen switches. They belong to the terminal's global state
+///   machine, not to a specific text grid. That's why they are stored here in
+///   [`ParserGlobalState`].
+/// - **Screen (primary or alternate) specific state**: The active cursor position (`row`,
+///   `col`) is not shared. The primary screen and alternate screen maintain entirely
+///   independent cursors.
+///   - To keep primary and alternate screen drawing logic simple, we use
+///     [`std::mem::swap()`] in [`set_alt_screen_mode()`] to physically swap the screen's
+///     underlying [`OffscreenBuffer`] data when switching to another screen.
+///   - Because of this, the [`OffscreenBuffer`] and its [`OffscreenBuffer::cursor_pos`]
+///     **always** represent the currently visible screen (regardless of whether it is
+///     primary or alternate).
+///   - The hidden screen's data and its specific cursor position are parked in
+///     [`HiddenScreenState`] (in its [`hidden_buffer`] and [`hidden_cursor_pos`]) until
+///     they are swapped back when the screen switches.
+///
+/// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
+/// [`ASCII`]: https://en.wikipedia.org/wiki/ASCII
+/// [`BCE`]:
+///     https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters
+/// [`DEC`]: https://en.wikipedia.org/wiki/Digital_Equipment_Corporation
+/// [`DECRC`]: https://vt100.net/docs/vt510-rm/DECRC.html
+/// [`DECSC`]: https://vt100.net/docs/vt510-rm/DECSC.html
+/// [`DSR`]: crate::DsrRequestFromPtyEvent
+/// [`hidden_buffer`]: crate::HiddenScreenState::hidden_buffer
+/// [`hidden_cursor_pos`]: crate::HiddenScreenState::hidden_cursor_pos
+/// [`OffscreenBuffer::cursor_pos`]: crate::OffscreenBuffer::cursor_pos
+/// [`OffscreenBuffer`]: crate::OffscreenBuffer
+/// [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
+/// [`set_alt_screen_mode()`]: crate::OfsBufVT100::set_alt_screen_mode
+/// [`SGR`]: crate::SgrCode
+/// [`std::mem::swap()`]: std::mem::swap
+/// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
+/// [`xterm`]: https://en.wikipedia.org/wiki/Xterm
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct ParserGlobalState {
+    /// Temporary cursor position storage for [`DECSC`]/[`DECRC`] escape sequences only.
+    ///
+    /// This field is ONLY used for `ESC 7` ([`DECSC`]) save and `ESC 8` ([`DECRC`])
+    /// restore operations, as well as their [`CSI`] equivalents (`CSI s` and `CSI
+    /// u`). It does NOT track the current cursor position - that's stored in
+    /// [`OffscreenBuffer::cursor_pos`].
+    ///
+    /// Used by [`AnsiToOfsBufPerformer`] to implement the [`DECSC`] (`ESC 7`) and
+    /// [`DECRC`] (`ESC 8`) escape sequences for saving and restoring cursor
+    /// position.
+    ///
+    /// ## Data Flow:
+    /// ```text
+    /// 1. Child process (e.g., vim) sends ESC 7 to save cursor
+    ///                             ↓
+    /// 2. AnsiToOfsBufPerformer::esc_dispatch() handles ESC 7
+    ///                             ↓
+    /// 3. Saves current cursor_pos to buffer.parser_global_state.
+    ///     `cursor_pos_for_esc_save_and_restore`.
+    ///                             ↓
+    /// 4. Later, child sends ESC 8 to restore cursor
+    ///                             ↓
+    /// 5. AnsiToOfsBufPerformer::esc_dispatch() handles ESC 8
+    ///                             ↓
+    /// 6. Restores cursor_pos from buffer.parser_global_state.cursor_pos_for_esc_save_and_restore
+    /// ```
+    ///
+    /// [`AnsiToOfsBufPerformer`]: crate::core::ansi::vt_100_pty_output_parser::AnsiToOfsBufPerformer
+    /// [`CSI`]: crate::CsiSequence
+    /// [`DECRC`]: https://vt100.net/docs/vt510-rm/DECRC.html
+    /// [`DECSC`]: https://vt100.net/docs/vt510-rm/DECSC.html
+    pub cursor_pos_for_esc_save_and_restore: Option<Pos>,
+
+    /// Active character set for [`ANSI`] escape sequence support.
+    ///
+    /// Used by [`AnsiToOfsBufPerformer`] to implement character set switching via the
+    /// sequences:
+    /// - `ESC ( B` for [`ASCII`].
+    /// - `ESC ( 0` for [`DEC`] graphics.
+    ///
+    /// When in Graphics mode, characters like 'q' are translated to box-drawing
+    /// characters like '─' during the [`print()`] operation.
+    ///
+    /// ## Character Set Usage:
+    /// ```text
+    /// ASCII Mode    : ESC ( B  : 'q' → 'q' (literal)
+    /// Graphics Mode : ESC ( 0  : 'q' → '─' (horizontal line)
+    /// ```
+    ///
+    /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
+    /// [`AnsiToOfsBufPerformer`]: crate::AnsiToOfsBufPerformer
+    /// [`ASCII`]: https://en.wikipedia.org/wiki/ASCII
+    /// [`DEC`]: https://en.wikipedia.org/wiki/Digital_Equipment_Corporation
+    /// [`ESC`]: crate::EscSequence
+    /// [`print()`]: vte::Perform::print
+    pub character_set: CharacterSet,
+
+    /// Auto-wrap mode ([`DECAWM`]) for [`ANSI`] escape sequence support.
+    ///
+    /// Used by [`AnsiToOfsBufPerformer`] to control line wrapping behavior when printing
+    /// characters. This implements the [`VT-100`] [`DECAWM`] (Auto Wrap Mode)
+    /// specification.
+    ///
+    /// ## [`DECAWM`] Control:
+    ///
+    /// ```text
+    /// ESC[ ? 7h : Enable auto-wrap (default)  - Characters wrap to next line
+    /// ESC[ ? 7l : Disable auto-wrap           - Characters overwrite at right margin
+    /// ```
+    ///
+    /// When enabled (default), characters that would exceed the right margin
+    /// automatically wrap to the beginning of the next line. When disabled, the cursor
+    /// stays at the right margin and subsequent characters overwrite.
+    ///
+    /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
+    /// [`AnsiToOfsBufPerformer`]: crate::AnsiToOfsBufPerformer
+    /// [`DECAWM`]: https://vt100.net/docs/vt510-rm/DECAWM.html
+    /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
+    pub auto_wrap_mode: AutoWrapState,
+
+    /// Currently active [`SGR`] (Select Graphic Rendition) text formatting.
+    ///
+    /// Accumulates text attributes (bold, italic, etc.) and colors from `ESC [ ... m`
+    /// sequences. These styles are stamped onto all subsequent characters printed to the
+    /// buffer.
+    ///
+    /// [`SGR`]: crate::SgrCode
+    pub current_style: TuiStyle,
+
+    /// [`OSC`] events (hyperlinks, titles, etc.) accumulated during processing.
+    ///
+    /// [`OSC`]: crate::osc_codes::OscSequence
+    pub pending_osc_events: Vec<OscEvent>,
+
+    /// [`DSR`] response events accumulated during processing - need to be sent back to
+    /// [`PTY`].
+    ///
+    /// [`DSR`]: crate::DsrSequence
+    /// [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
+    pub pending_dsr_responses: Vec<DsrRequestFromPtyEvent>,
+
+    /// Top margin for the **scrollable region** ([`DECSTBM`]) - 1-based row number.
+    ///
+    /// This variable defines the **upper boundary** of the area where scrolling occurs.
+    /// Rows above this boundary are part of the **static top region** and do not scroll.
+    ///
+    /// Used by [`AnsiToOfsBufPerformer`] to implement [`DECSTBM`] (Set Top and Bottom
+    /// Margins) functionality via the sequence: `ESC [ <top> ; <bottom> r`.
+    ///
+    /// When [`None`], the default top margin is row 1 (first row), making the entire
+    /// terminal screen the scrollable region. When [`Some(n)`], scrolling operations
+    /// only affect rows from n to [`scroll_region_bottom`].
+    ///
+    /// ## [`DECSTBM`] Usage:
+    /// ```text
+    /// ESC [ 5 ; 20 r   - Set scrolling region from row 5 to row 20
+    /// ESC [ r          - Reset to full screen (clears both margins)
+    /// ```
+    ///
+    /// [`AnsiToOfsBufPerformer`]: crate::AnsiToOfsBufPerformer
+    /// [`DECSTBM`]: https://vt100.net/docs/vt510-rm/DECSTBM.html
+    /// [`ESC`]: crate::EscSequence
+    /// [`scroll_region_bottom`]: Self::scroll_region_bottom
+    /// [`Some(n)`]: Some
+    pub scroll_region_top: Option<TermRow>,
+
+    /// Bottom margin for the **scrollable region** ([`DECSTBM`]) - 1-based row number.
+    ///
+    /// This variable defines the **lower boundary** of the area where scrolling occurs.
+    /// Rows below this boundary are part of the **static bottom region** and do not
+    /// scroll.
+    ///
+    /// Used by [`AnsiToOfsBufPerformer`] to implement [`DECSTBM`] (Set Top and Bottom
+    /// Margins) functionality via the sequence: `ESC [ <top> ; <bottom> r`.
+    ///
+    /// When [`None`], the default bottom margin is the last row of the terminal, making
+    /// the entire terminal screen the scrollable region. When [`Some(n)`], scrolling
+    /// operations only affect rows from [`scroll_region_top`] to n.
+    ///
+    /// ## [`DECSTBM`] Behavior:
+    /// - Scrolling commands ([`ESC`] D, [`ESC`] M, [`CSI`] S, [`CSI`] T) only affect the
+    ///   region
+    /// - Cursor movement is constrained to the region boundaries
+    /// - Content outside the region remains unchanged during scrolling
+    ///
+    /// [`AnsiToOfsBufPerformer`]: crate::AnsiToOfsBufPerformer
+    /// [`CSI`]: crate::CsiSequence
+    /// [`DECSTBM`]: https://vt100.net/docs/vt510-rm/DECSTBM.html
+    /// [`ESC`]: crate::EscSequence
+    /// [`scroll_region_top`]: Self::scroll_region_top
+    /// [`Some(n)`]: Some
+    pub scroll_region_bottom: Option<TermRow>,
+
+    /// Controls whether the terminal cursor is visible.
+    ///
+    /// Corresponds to the [`DECTCEM`] (`?25`) private mode.
+    ///
+    /// [`DECTCEM`]: https://vt100.net/docs/vt510-rm/DECTCEM.html
+    pub cursor_visibility: CursorVisibilityState,
+}
+
+/// Character set modes for terminal emulation.
+///
+/// Used by [`AnsiToOfsBufPerformer`] to handle `ESC ( <char>` sequences that switch
+/// between [`ASCII`] and [`DEC`] line-drawing graphics.
+///
+/// [`AnsiToOfsBufPerformer`]: crate::AnsiToOfsBufPerformer
+/// [`ASCII`]: https://en.wikipedia.org/wiki/ASCII
+/// [`DEC`]: https://en.wikipedia.org/wiki/Digital_Equipment_Corporation
+/// [`ESC`]: crate::EscSequence
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CharacterSet {
+    /// Normal [`ASCII`] character set:
+    /// - `ESC ( B`
+    /// - or `[27, 40, 66]` in decimal
+    ///
+    /// [`ASCII`]: https://en.wikipedia.org/wiki/ASCII
+    /// [`ESC`]: crate::EscSequence
+    #[default]
+    Ascii,
+    /// [`DEC`] Special Graphics character set for line drawing:
+    /// - `ESC ( 0`
+    /// - or `[27, 40, 48]` in decimal
+    ///
+    /// Maps [`ASCII`] characters to box-drawing Unicode characters.
+    ///
+    /// [`ASCII`]: https://en.wikipedia.org/wiki/ASCII
+    /// [`DEC`]: https://en.wikipedia.org/wiki/Digital_Equipment_Corporation
+    /// [`ESC`]: crate::EscSequence
+    DECGraphics,
+}
+
+/// Auto-wrap mode ([`DECAWM`]) state.
+///
+/// Controls line wrapping behavior when text reaches the right margin.
+///
+/// [`DECAWM`]: https://vt100.net/docs/vt510-rm/DECAWM.html
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AutoWrapState {
+    /// Characters automatically wrap to the next line (DECAWM `?7h`)
+    #[default]
+    Enabled,
+    /// Characters overwrite at the right margin (DECAWM `?7l`)
+    Disabled,
+}
+
+/// Terminal cursor visibility state.
+///
+/// Controls whether the terminal cursor is displayed or hidden. Corresponds to the
+/// [`DECTCEM`] (`?25`) private mode.
+///
+/// # Usage in [`PTY`] Mux
+///
+/// When used inside [`ParserGlobalState::cursor_visibility`], it stores the *requested*
+/// visibility state of the child process. The [`PTY Mux`] compositor
+/// ([`OutputRenderer::composite_virtual_cursor_into_buffer`]) reads this to determine if
+/// it needs to paint a simulated, virtual block cursor into the [`OffscreenBuffer`].
+///
+/// > Note: The host terminal emulator's actual cursor is permanently suppressed via
+/// > [`RenderOpCommon::HideCursor`] when the multiplexer is active. We rely exclusively
+/// > on the virtual block cursor rendering (which allows us to have multiple cursors).
+///
+/// [`DECTCEM`]: https://vt100.net/docs/vt510-rm/DECTCEM.html
+/// [`OffscreenBuffer`]: crate::OffscreenBuffer
+/// [`OutputRenderer::composite_virtual_cursor_into_buffer`]:
+///     crate::core::pty::OutputRenderer::composite_virtual_cursor_into_buffer
+/// [`ParserGlobalState::cursor_visibility`]: crate::ParserGlobalState::cursor_visibility
+/// [`PTY Mux`]: crate::PTYMux
+/// [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
+/// [`RenderOpCommon::HideCursor`]: crate::RenderOpCommon::HideCursor
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CursorVisibilityState {
+    /// Cursor is visible ([`DECTCEM`] `ESC [ ? 25 h`)
+    ///
+    /// [`DECTCEM`]: https://vt100.net/docs/vt510-rm/DECTCEM.html
+    #[default]
+    Visible,
+    /// Cursor is hidden ([`DECTCEM`] `ESC [ ? 25 l`)
+    ///
+    /// [`DECTCEM`]: https://vt100.net/docs/vt510-rm/DECTCEM.html
+    Hidden,
+}
+
+/// State tracking for terminal operational modes.
+///
+/// Used by the [`VT-100`] [`ANSI`] parser performer ([`AnsiToOfsBufPerformer`])
+/// to maintain state information about the operational modes requested by the
+/// underlying [`PTY`] process.
+///
+/// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
+/// [`AnsiToOfsBufPerformer`]: crate::AnsiToOfsBufPerformer
+/// [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
+/// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct TerminalModeState {
+    /// Alternate screen buffer status.
+    ///
+    /// When active, terminal output is redirected to an alternate screen buffer,
+    /// preserving the original screen content.
+    ///
+    /// Toggled by the [`AnsiToOfsBufPerformer`] when processing the `ESC [ ? 1049 h`
+    /// and `ESC [ ? 1049 l` sequences.
+    ///
+    /// [`AnsiToOfsBufPerformer`]: crate::AnsiToOfsBufPerformer
+    pub alternate_screen: AlternateScreenState,
+
+    /// Mouse event tracking status.
+    ///
+    /// **TODO**: The parser currently ignores this [`VT-100`] sequence
+    /// (`vt_100_shim_mode_ops.rs`) because the [`PTY`] multiplexer does not yet route
+    /// complex input events. When supported, this field should be wired up to the
+    /// [`ANSI`] parser and the `dead_code` allowance removed.
+    ///
+    /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
+    /// [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
+    /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
+    #[allow(dead_code)]
+    pub mouse_tracking: terminal_mode_state_todo::MouseTrackingState,
+
+    /// Bracketed paste mode status.
+    ///
+    /// **TODO**: The parser currently ignores this [`VT-100`] sequence
+    /// (`vt_100_shim_mode_ops.rs`) because the [`PTY`] multiplexer does not yet route
+    /// complex input events. When supported, this field should be wired up to the
+    /// [`ANSI`] parser and the `dead_code` allowance removed.
+    ///
+    /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
+    /// [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
+    /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
+    #[allow(dead_code)]
+    pub bracketed_paste: terminal_mode_state_todo::BracketedPasteState,
+}
+
+mod terminal_mode_state_todo {
+    #[allow(clippy::wildcard_imports)]
+    use super::*;
+
+    /// Mouse event tracking state.
+    ///
+    /// Controls whether the terminal captures mouse click, movement, and scroll events.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+    #[allow(dead_code)]
+    pub enum MouseTrackingState {
+        /// Mouse tracking enabled - terminal sends mouse events
+        Enabled,
+        /// Mouse tracking disabled
+        #[default]
+        Disabled,
+    }
+
+    /// Bracketed paste mode state.
+    ///
+    /// Controls whether text pasted from clipboard is wrapped with special escape
+    /// sequences (`OSC 52`), allowing applications to distinguish pasted text from
+    /// keyboard input.
+    ///
+    /// [`OSC`]: crate::osc_codes::OscSequence
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+    #[allow(dead_code)]
+    pub enum BracketedPasteState {
+        /// Bracketed paste mode enabled
+        Enabled,
+        /// Bracketed paste mode disabled
+        #[default]
+        Disabled,
+    }
+}
+
+/// Alternate screen buffer state.
+///
+/// Controls whether terminal output is redirected to an alternate screen buffer,
+/// preserving the original screen content. This is used by full-screen applications
+/// (`vim`, `less`, etc.) to avoid cluttering the shell history.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AlternateScreenState {
+    /// Alternate screen buffer active
+    Active,
+    /// Alternate screen buffer inactive, using primary screen
+    #[default]
+    Inactive,
+}
+
+/// The requested screen buffer mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestedScreenMode {
+    Primary,
+    Alternate,
+}
+
+/// Encapsulated state representing the alternate screen support and its independent
+/// cursor positions.
+///
+/// # [`SGR`] Style Inheritance & [`BCE`] (Background Color Erase) Compliance
+///
+/// Under [`VT-100`], [`xterm`], and standard [`ANSI`] specifications, graphic rendition
+/// states (foreground/background colors, bold, italic) are globally shared and preserved
+/// across screen buffer switches.
+///
+/// This struct implements this specification by separating the alternate buffer
+/// ([`hidden_buffer`]) from the overall parser emulation state. When entering the
+/// alternate screen:
+/// - The alternate buffer inherits the active graphic style from the main buffer.
+/// - The buffer is cleared utilizing [`create_empty_pixel_char()`] to ensure that erased
+///   cells carry the active background color and attributes, fully complying with
+///   Background Color Erase ([`BCE`]) rules.
+///
+/// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
+/// [`BCE`]: https://invisible-island.net/xterm/xterm.faq.html#what_is_bce
+/// [`create_empty_pixel_char()`]: crate::OfsBufVT100::create_empty_pixel_char
+/// [`hidden_buffer`]: HiddenScreenState::hidden_buffer
+/// [`SGR`]: crate::SgrCode
+/// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
+/// [`xterm`]: https://en.wikipedia.org/wiki/Xterm
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HiddenScreenState {
+    /// The secondary buffer grid representing the alternate screen. Always allocated at
+    /// buffer creation time to avoid having to use [`Option`] which adds needless
+    /// complexity for a very small cost in terms of memory.
+    pub hidden_buffer: PixelCharLines,
+
+    /// Saved cursor position for the hidden buffer.
+    pub hidden_cursor_pos: Pos,
+
+    /// Cached memory size of this struct to provide O(1) retrieval.
+    pub cached_memory_size: MemorySize,
+}
+
+mod hidden_screen_state_impl {
+    #[allow(clippy::wildcard_imports)]
+    use super::*;
+
+    impl HiddenScreenState {
+        #[must_use]
+        pub fn new_empty(arg_window_size: impl Into<Size>) -> Self {
+            let window_size = arg_window_size.into();
+            let hidden_buffer = PixelCharLines::new_empty(window_size);
+
+            let cached_memory_size = {
+                let primary_buffer_mem = hidden_buffer.get_mem_size();
+
+                MemorySize::new(
+                    primary_buffer_mem +
+                // hidden_cursor_pos
+                size_of::<Pos>(),
+                )
+            };
+
+            Self {
+                hidden_buffer,
+                hidden_cursor_pos: Pos::default(),
+                cached_memory_size,
+            }
+        }
+    }
+
+    impl GetMemSize for HiddenScreenState {
+        /// Acts as a fast O(1) getter for the cached memory size to avoid O(N) traversal
+        /// of the entire alternate screen buffer grid.
+        fn get_mem_size(&self) -> usize { self.cached_memory_size.size().unwrap_or(0) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vt100_terminal_state_struct_size() {
+        // TRIPWIRE: If you add or remove a field from `OfsBufVT100`, this test
+        // will fail. This is intentional! It reminds you to:
+        // 1. Update the `GetMemSize` implementation for this struct to include your new
+        //    field.
+        // 2. Update this exact byte-size assertion.
+        #[cfg(target_pointer_width = "64")]
+        {
+            // First we assert against a dummy value to see the real sizes in the test
+            // output, then we will update it.
+            assert_eq!(size_of::<OfsBufVT100>(), 928);
+        }
+    }
+
+    #[test]
+    fn test_hidden_screen_state_struct_size() {
+        // TRIPWIRE: If you add or remove a field from `HiddenScreenState`, this test will
+        // fail. This is intentional! It reminds you to:
+        // 1. Update the `GetMemSize` implementation for this struct to include your new
+        //    field.
+        // 2. Update this exact byte-size assertion.
+        #[cfg(target_pointer_width = "64")]
+        {
+            assert_eq!(size_of::<HiddenScreenState>(), 416);
+        }
+    }
+
+    #[test]
+    fn test_vt100_terminal_state_get_mem_size() {
+        // TRIPWIRE: This test verifies that `GetMemSize` actually sums up all the fields.
+        // If you added a field, you MUST add its memory size calculation to
+        // `expected_size` below, and ensure the actual `GetMemSize`
+        // implementation matches it.
+        use crate::{height, width};
+        let size = height(10) + width(20);
+        let state = OfsBufVT100::new_empty(size);
+
+        let calculated_size = state.get_mem_size();
+        let expected_size = state.ofs_buf.get_mem_size()
+            + state.hidden_screen_state.get_mem_size()
+            + size_of::<ParserGlobalState>()
+            + size_of::<TerminalModeState>()
+            + size_of::<OfsBufVT100>();
+
+        assert_eq!(calculated_size, expected_size);
+        // Ensure consistency across calls
+        assert_eq!(calculated_size, state.get_mem_size());
+    }
+
+    #[test]
+    fn test_hidden_screen_state_get_mem_size() {
+        // TRIPWIRE: This test verifies that `GetMemSize` actually sums up all the fields.
+        // If you added a field, you MUST add its memory size calculation to
+        // `expected_size` below, and ensure the actual `GetMemSize`
+        // implementation matches it.
+        use crate::{height, width};
+        let size = height(10) + width(20);
+        let support = HiddenScreenState::new_empty(size);
+
+        let calculated_size = support.get_mem_size();
+        let expected_size = support.hidden_buffer.get_mem_size() + size_of::<Pos>();
+
+        assert_eq!(calculated_size, expected_size);
+        // Ensure consistency across calls
+        assert_eq!(calculated_size, support.get_mem_size());
+    }
+}

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops/mod.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops/mod.rs
@@ -66,14 +66,14 @@
 //!
 //! ```text
 //! ┌───────────────────────────────────────────────────────────┐
-//! │ Shim Layer (operations/*)                                 │
+//! │ Shim Layer (ops/*)                                        │
 //! │ • NO DIRECT TESTS (by design)                             │
 //! │ • Pure delegation, no business logic                      │
 //! └────────────────────┬──────────────────────────────────────┘
 //!                      │ delegates to
 //!                      │
 //! ┌────────────────────▼──────────────────────────────────────┐
-//! │ Implementation Layer (vt_100_ansi_impl/impl_*)            │
+//! │ Implementation Layer (ops_impl_ofs_buf/vt_100_impl_*)     │
 //! │ • UNIT TESTS: #[test] functions                           │
 //! │ • Contains all business logic                             │
 //! └───────────────────────────────────────────────────────────┘
@@ -92,7 +92,7 @@
 //!
 //! When working with any operation module, you can navigate to its related testing
 //! layers:
-//! - **Implementation with Unit Tests**: [`vt_100_ansi_impl`] module
+//! - **Implementation with Unit Tests**: [`ops_impl_ofs_buf`] module
 //! - **Integration Tests**: See the conformance test modules
 //!
 //! # Naming Convention
@@ -108,35 +108,35 @@
 //!
 //! This same pattern applies to all operation types:
 //!
-//! | Shim                            | Ops                            | Tests                            |
-//! | ------------------------------- | ------------------------------ | -------------------------------- |
-//! | [`vt_100_shim_char_ops`]        | [`vt_100_impl_char_ops`]       | [`vt_100_test_char_ops`]         |
-//! | [`vt_100_shim_control_ops`]     | [`vt_100_impl_control_ops`]    | [`vt_100_test_control_ops`]      |
-//! | [`vt_100_shim_cursor_ops`]      | [`vt_100_impl_cursor_ops`]     | [`vt_100_test_cursor_ops`]       |
-//! | [`vt_100_shim_dsr_ops`]         | [`vt_100_impl_dsr_ops`]        | [`vt_100_test_dsr_ops`]          |
-//! | [`vt_100_shim_line_ops`]        | [`vt_100_impl_line_ops`]       | [`vt_100_test_line_ops`]         |
-//! | [`vt_100_shim_margin_ops`]      | [`vt_100_impl_margin_ops`]     | [`vt_100_test_margin_ops`]       |
-//! | [`vt_100_shim_mode_ops`]        | [`vt_100_impl_mode_ops`]       | [`vt_100_test_mode_ops`]         |
-//! | [`vt_100_shim_osc_ops`]         | [`vt_100_impl_osc_ops`]        | [`vt_100_test_osc_ops`]          |
-//! | [`vt_100_shim_scroll_ops`]      | [`vt_100_impl_scroll_ops`]     | [`vt_100_test_scroll_ops`]       |
-//! | [`vt_100_shim_sgr_ops`]         | [`vt_100_impl_sgr_ops`]        | [`vt_100_test_sgr_ops`]          |
-//! | [`vt_100_shim_terminal_ops`]    | [`vt_100_impl_terminal_ops`]   | [`vt_100_test_terminal_ops`]     |
+//! | Shim                         | Impl                         | Tests                        |
+//! | ---------------------------- | ---------------------------- | ---------------------------- |
+//! | [`vt_100_shim_char_ops`]     | [`vt_100_impl_char_ops`]     | [`vt_100_test_char_ops`]     |
+//! | [`vt_100_shim_control_ops`]  | [`vt_100_impl_control_ops`]  | [`vt_100_test_control_ops`]  |
+//! | [`vt_100_shim_cursor_ops`]   | [`vt_100_impl_cursor_ops`]   | [`vt_100_test_cursor_ops`]   |
+//! | [`vt_100_shim_dsr_ops`]      | [`vt_100_impl_dsr_ops`]      | [`vt_100_test_dsr_ops`]      |
+//! | [`vt_100_shim_line_ops`]     | [`vt_100_impl_line_ops`]     | [`vt_100_test_line_ops`]     |
+//! | [`vt_100_shim_margin_ops`]   | [`vt_100_impl_margin_ops`]   | [`vt_100_test_margin_ops`]   |
+//! | [`vt_100_shim_mode_ops`]     | [`vt_100_impl_mode_ops`]     | [`vt_100_test_mode_ops`]     |
+//! | [`vt_100_shim_osc_ops`]      | [`vt_100_impl_osc_ops`]      | [`vt_100_test_osc_ops`]      |
+//! | [`vt_100_shim_scroll_ops`]   | [`vt_100_impl_scroll_ops`]   | [`vt_100_test_scroll_ops`]   |
+//! | [`vt_100_shim_sgr_ops`]      | [`vt_100_impl_sgr_ops`]      | [`vt_100_test_sgr_ops`]      |
+//! | [`vt_100_shim_terminal_ops`] | [`vt_100_impl_terminal_ops`] | [`vt_100_test_terminal_ops`] |
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 //! [`OffscreenBuffer`]: crate::OffscreenBuffer
+//! [`ops_impl_ofs_buf`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf
 //! [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
-//! [`vt_100_ansi_impl`]: crate::vt_100_ansi_impl
-//! [`vt_100_impl_char_ops`]: crate::vt_100_ansi_impl::vt_100_impl_char_ops
-//! [`vt_100_impl_control_ops`]: crate::vt_100_ansi_impl::vt_100_impl_control_ops
-//! [`vt_100_impl_cursor_ops`]: crate::vt_100_ansi_impl::vt_100_impl_cursor_ops
-//! [`vt_100_impl_dsr_ops`]: crate::vt_100_ansi_impl::vt_100_impl_dsr_ops
-//! [`vt_100_impl_line_ops`]: crate::vt_100_ansi_impl::vt_100_impl_line_ops
-//! [`vt_100_impl_margin_ops`]: crate::vt_100_ansi_impl::vt_100_impl_margin_ops
-//! [`vt_100_impl_mode_ops`]: crate::vt_100_ansi_impl::vt_100_impl_mode_ops
-//! [`vt_100_impl_osc_ops`]: crate::vt_100_ansi_impl::vt_100_impl_osc_ops
-//! [`vt_100_impl_scroll_ops`]: crate::vt_100_ansi_impl::vt_100_impl_scroll_ops
-//! [`vt_100_impl_sgr_ops`]: crate::vt_100_ansi_impl::vt_100_impl_sgr_ops
-//! [`vt_100_impl_terminal_ops`]: crate::vt_100_ansi_impl::vt_100_impl_terminal_ops
+//! [`vt_100_impl_char_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_char_ops
+//! [`vt_100_impl_control_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_control_ops
+//! [`vt_100_impl_cursor_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_cursor_ops
+//! [`vt_100_impl_dsr_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_dsr_ops
+//! [`vt_100_impl_line_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_line_ops
+//! [`vt_100_impl_margin_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_margin_ops
+//! [`vt_100_impl_mode_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_mode_ops
+//! [`vt_100_impl_osc_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_osc_ops
+//! [`vt_100_impl_scroll_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_scroll_ops
+//! [`vt_100_impl_sgr_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_sgr_ops
+//! [`vt_100_impl_terminal_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_terminal_ops
 //! [`vt_100_shim_char_ops`]: vt_100_shim_char_ops
 //! [`vt_100_shim_control_ops`]: vt_100_shim_control_ops
 //! [`vt_100_shim_cursor_ops`]: vt_100_shim_cursor_ops

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_char_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_char_ops.rs
@@ -3,11 +3,11 @@
 //! Character insertion, deletion, and erasure operations.
 //!
 //! This module acts as a thin shim layer that delegates to the actual implementation.
-//! Refer to the module-level documentation in the operations module for details on the
+//! Refer to the module-level documentation in the ops module for details on the
 //! "shim → impl → test" architecture and naming conventions.
 //!
 //! **Related Files:**
-//! - **Implementation**: [`impl_char_ops`] - Business logic with unit tests
+//! - **Implementation**: [`vt_100_impl_char_ops`] - Business logic with unit tests
 //! - **Integration Tests**: [`test_char_ops`] - Full pipeline testing via public API
 //!
 //! # Testing Strategy
@@ -20,7 +20,7 @@
 //! - **Integration tests** in the conformance tests validating the full pipeline
 //!
 //! For the complete testing philosophy and rationale behind this approach,
-//! see the [operations module].
+//! see the [ops module].
 //!
 //! # Architecture Overview
 //!
@@ -39,13 +39,13 @@
 //!         ↓
 //!     csi_dispatch() [routes to modules below]
 //!         ↓
-//!     Route to operations module:
+//!     Route to ops module:
 //!       - cursor_ops:: for movement (A,B,C,D,H)
 //!       - scroll_ops:: for scrolling (S,T)
 //!       - sgr_ops:: for styling (m)
-//!       - line_ops:: for lines (L,M)      ╭───────────╮
-//!       - char_ops:: for chars (@,P,X) <- │THIS MODULE│
-//!         ↓                               ╰───────────╯
+//!       - line_ops:: for lines (L,M)                           ╭───────────╮
+//!       - char_ops:: for chars (@,P,X)                      <- │THIS MODULE│
+//!         ↓                                                    ╰───────────╯
 //!     Update OffscreenBuffer state
 //! ```
 //!
@@ -65,13 +65,13 @@
 //!
 //! [`CSI`]: crate::CsiSequence
 //! [`extract_nth_single_non_zero()`]: crate::ParamsExt::extract_nth_single_non_zero
-//! [`impl_char_ops`]: crate::vt_100_ansi_impl::vt_100_impl_char_ops
 //! [`NonZeroU16`]: std::num::NonZeroU16
 //! [`test_char_ops`]: crate::vt_100_pty_output_conformance_tests::tests::vt_100_test_char_ops
 //! [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
+//! [`vt_100_impl_char_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_char_ops
 //! [module-level Architecture Overview]: super#architecture-overview
 //! [module-level documentation]: self
-//! [operations module]: crate::core::ansi::vt_100_pty_output_parser::operations
+//! [ops module]: crate::core::ansi::vt_100_pty_output_parser::ops
 
 use super::super::ansi_parser_public_api::AnsiToOfsBufPerformer;
 use crate::ParamsExt;
@@ -83,19 +83,20 @@ use crate::ParamsExt;
 /// **Behavior**: Characters to the right of cursor shift right, characters beyond margin
 /// are lost.
 ///
-/// See [`OffscreenBuffer::insert_chars_at_cursor`] for the implementation of this shim.
+/// See [`OfsBufVT100::insert_chars_at_cursor`] for the implementation of this
+/// shim.
 ///
-/// [`OffscreenBuffer::insert_chars_at_cursor`]: crate::OffscreenBuffer::insert_chars_at_cursor
+/// [`OfsBufVT100::insert_chars_at_cursor`]: crate::OfsBufVT100::insert_chars_at_cursor
 /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
 /// [module-level documentation]: self
 pub fn insert_chars(performer: &mut AnsiToOfsBufPerformer, params: &vte::Params) {
     let how_many = params.extract_nth_single_non_zero(0).get().into();
-    let result = performer.ofs_buf.insert_chars_at_cursor(how_many);
+    let result = performer.ofs_buf_vt_100.insert_chars_at_cursor(how_many);
     debug_assert!(
         result.is_ok(),
         "Failed to insert {:?} chars at cursor position {:?}",
         how_many,
-        performer.ofs_buf.cursor_pos
+        performer.ofs_buf_vt_100.cursor_pos
     );
 }
 
@@ -106,19 +107,20 @@ pub fn insert_chars(performer: &mut AnsiToOfsBufPerformer, params: &vte::Params)
 /// **Behavior**: Characters to the right of cursor shift left, blanks are inserted at
 /// line end.
 ///
-/// See [`OffscreenBuffer::delete_chars_at_cursor`] for the implementation of this shim.
+/// See [`OfsBufVT100::delete_chars_at_cursor`] for the implementation of this
+/// shim.
 ///
-/// [`OffscreenBuffer::delete_chars_at_cursor`]: crate::OffscreenBuffer::delete_chars_at_cursor
+/// [`OfsBufVT100::delete_chars_at_cursor`]: crate::OfsBufVT100::delete_chars_at_cursor
 /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
 /// [module-level documentation]: self
 pub fn delete_chars(performer: &mut AnsiToOfsBufPerformer, params: &vte::Params) {
     let how_many = params.extract_nth_single_non_zero(0).get().into();
-    let result = performer.ofs_buf.delete_chars_at_cursor(how_many);
+    let result = performer.ofs_buf_vt_100.delete_chars_at_cursor(how_many);
     debug_assert!(
         result.is_ok(),
         "Failed to delete {:?} chars at cursor position {:?}",
         how_many,
-        performer.ofs_buf.cursor_pos
+        performer.ofs_buf_vt_100.cursor_pos
     );
 }
 
@@ -128,19 +130,19 @@ pub fn delete_chars(performer: &mut AnsiToOfsBufPerformer, params: &vte::Params)
 ///
 /// **Behavior**: Characters are replaced with blanks, no shifting occurs (unlike DCH).
 ///
-/// See [`OffscreenBuffer::erase_chars_at_cursor`] for the implementation of this shim.
+/// See [`OfsBufVT100::erase_chars_at_cursor`] for the implementation of this shim.
 ///
-/// [`OffscreenBuffer::erase_chars_at_cursor`]: crate::OffscreenBuffer::erase_chars_at_cursor
+/// [`OfsBufVT100::erase_chars_at_cursor`]: crate::OfsBufVT100::erase_chars_at_cursor
 /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
 /// [module-level documentation]: self
 pub fn erase_chars(performer: &mut AnsiToOfsBufPerformer, params: &vte::Params) {
     let how_many = params.extract_nth_single_non_zero(0).get().into();
-    let result = performer.ofs_buf.erase_chars_at_cursor(how_many);
+    let result = performer.ofs_buf_vt_100.erase_chars_at_cursor(how_many);
     debug_assert!(
         result.is_ok(),
         "Failed to erase {:?} chars at cursor position {:?}",
         how_many,
-        performer.ofs_buf.cursor_pos
+        performer.ofs_buf_vt_100.cursor_pos
     );
 }
 
@@ -149,17 +151,17 @@ pub fn erase_chars(performer: &mut AnsiToOfsBufPerformer, params: &vte::Params) 
 /// **[`VT-100`] Behavior**: Character set translation applied if [`DEC`] graphics mode is
 /// active.
 ///
-/// See [`OffscreenBuffer::print_char`] for the implementation of this shim.
+/// See [`OfsBufVT100::print_char`] for the implementation of this shim.
 ///
 /// [`DEC`]: https://en.wikipedia.org/wiki/Digital_Equipment_Corporation
-/// [`OffscreenBuffer::print_char`]: crate::OffscreenBuffer::print_char
+/// [`OfsBufVT100::print_char`]: crate::OfsBufVT100::print_char
 /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
 pub fn print_char(performer: &mut AnsiToOfsBufPerformer, ch: char) {
-    let result = performer.ofs_buf.print_char(ch);
+    let result = performer.ofs_buf_vt_100.print_char(ch);
     debug_assert!(
         result.is_ok(),
         "Failed to print char {:?} at cursor position {:?}",
         ch,
-        performer.ofs_buf.cursor_pos
+        performer.ofs_buf_vt_100.cursor_pos
     );
 }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_clear_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_clear_ops.rs
@@ -17,7 +17,7 @@
 //! - **Integration tests** in the conformance tests validating the full pipeline
 //!
 //! For the complete testing philosophy and rationale behind this approach, see the
-//! [operations module].
+//! [ops module].
 //!
 //! # Architecture Overview
 //!
@@ -57,13 +57,11 @@
 //! [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
 //! [`vte`]: https://docs.rs/vte
 //! [module-level Architecture Overview]: super#architecture-overview
-//! [operations module]: crate::core::ansi::vt_100_pty_output_parser::operations
+//! [ops module]: crate::core::ansi::vt_100_pty_output_parser::ops
 
 use super::super::ansi_parser_public_api::AnsiToOfsBufPerformer;
-use crate::{
-    DEBUG_TUI_VT100_PARSER, ED_ERASE_ALL, ED_ERASE_FROM_START, ED_ERASE_TO_END,
-    EL_ERASE_ALL, EL_ERASE_FROM_START, EL_ERASE_TO_END, ParamsExt, ok,
-};
+use crate::{DEBUG_TUI_VT100_PARSER, ED_ERASE_ALL, ED_ERASE_FROM_START, ED_ERASE_TO_END,
+            EL_ERASE_ALL, EL_ERASE_FROM_START, EL_ERASE_TO_END, ParamsExt, ok};
 
 /// Handle ED (Erase in Display) - clear screen relative to cursor.
 ///
@@ -74,24 +72,26 @@ use crate::{
 /// - `1`: Beginning of screen to cursor.
 /// - `2`: Entire screen.
 ///
-/// See [`OffscreenBuffer::erase_display_from_cursor_to_end`],
-/// [`OffscreenBuffer::erase_display_from_start_to_cursor`], and
-/// [`OffscreenBuffer::erase_display_entire`] for the implementations of this shim.
+/// See [`OfsBufVT100::erase_display_from_cursor_to_end`],
+/// [`OfsBufVT100::erase_display_from_start_to_cursor`], and
+/// [`OfsBufVT100::erase_display_entire`] for the implementations of this shim.
 ///
-/// [`OffscreenBuffer::erase_display_entire`]:
-///     crate::OffscreenBuffer::erase_display_entire
-/// [`OffscreenBuffer::erase_display_from_cursor_to_end`]:
-///     crate::OffscreenBuffer::erase_display_from_cursor_to_end
-/// [`OffscreenBuffer::erase_display_from_start_to_cursor`]:
-///     crate::OffscreenBuffer::erase_display_from_start_to_cursor
+/// [`OfsBufVT100::erase_display_entire`]:
+///     crate::OfsBufVT100::erase_display_entire
+/// [`OfsBufVT100::erase_display_from_cursor_to_end`]:
+///     crate::OfsBufVT100::erase_display_from_cursor_to_end
+/// [`OfsBufVT100::erase_display_from_start_to_cursor`]:
+///     crate::OfsBufVT100::erase_display_from_start_to_cursor
 /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
 /// [module-level documentation]: self
 pub fn erase_in_display(performer: &mut AnsiToOfsBufPerformer, params: &vte::Params) {
     let mode = params.extract_nth_single_opt_raw(0).unwrap_or(0);
     let result = match mode {
-        ED_ERASE_TO_END => performer.ofs_buf.erase_display_from_cursor_to_end(),
-        ED_ERASE_FROM_START => performer.ofs_buf.erase_display_from_start_to_cursor(),
-        ED_ERASE_ALL => performer.ofs_buf.erase_display_entire(),
+        ED_ERASE_TO_END => performer.ofs_buf_vt_100.erase_display_from_cursor_to_end(),
+        ED_ERASE_FROM_START => performer
+            .ofs_buf_vt_100
+            .erase_display_from_start_to_cursor(),
+        ED_ERASE_ALL => performer.ofs_buf_vt_100.erase_display_entire(),
         _ => {
             DEBUG_TUI_VT100_PARSER.then(|| {
                 tracing::warn!("CSI {} J: Unsupported Erase Display mode", mode);
@@ -115,15 +115,15 @@ pub fn erase_in_display(performer: &mut AnsiToOfsBufPerformer, params: &vte::Par
 /// - `1`: Beginning of line to cursor.
 /// - `2`: Entire line.
 ///
-/// See [`OffscreenBuffer::erase_line_from_cursor_to_end`],
-/// [`OffscreenBuffer::erase_line_from_start_to_cursor`], and
-/// [`OffscreenBuffer::erase_line_entire`] for the implementations of this shim.
+/// See [`OfsBufVT100::erase_line_from_cursor_to_end`],
+/// [`OfsBufVT100::erase_line_from_start_to_cursor`], and
+/// [`OfsBufVT100::erase_line_entire`] for the implementations of this shim.
 ///
-/// [`OffscreenBuffer::erase_line_entire`]: crate::OffscreenBuffer::erase_line_entire
-/// [`OffscreenBuffer::erase_line_from_cursor_to_end`]:
-///     crate::OffscreenBuffer::erase_line_from_cursor_to_end
-/// [`OffscreenBuffer::erase_line_from_start_to_cursor`]:
-///     crate::OffscreenBuffer::erase_line_from_start_to_cursor
+/// [`OfsBufVT100::erase_line_entire`]: crate::OfsBufVT100::erase_line_entire
+/// [`OfsBufVT100::erase_line_from_cursor_to_end`]:
+///     crate::OfsBufVT100::erase_line_from_cursor_to_end
+/// [`OfsBufVT100::erase_line_from_start_to_cursor`]:
+///     crate::OfsBufVT100::erase_line_from_start_to_cursor
 /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
 /// [module-level documentation]: self
 pub fn erase_in_line(performer: &mut AnsiToOfsBufPerformer, params: &vte::Params) {
@@ -131,9 +131,9 @@ pub fn erase_in_line(performer: &mut AnsiToOfsBufPerformer, params: &vte::Params
         .extract_nth_single_opt_raw(0)
         .unwrap_or(EL_ERASE_TO_END);
     let result = match mode {
-        EL_ERASE_TO_END => performer.ofs_buf.erase_line_from_cursor_to_end(),
-        EL_ERASE_FROM_START => performer.ofs_buf.erase_line_from_start_to_cursor(),
-        EL_ERASE_ALL => performer.ofs_buf.erase_line_entire(),
+        EL_ERASE_TO_END => performer.ofs_buf_vt_100.erase_line_from_cursor_to_end(),
+        EL_ERASE_FROM_START => performer.ofs_buf_vt_100.erase_line_from_start_to_cursor(),
+        EL_ERASE_ALL => performer.ofs_buf_vt_100.erase_line_entire(),
         _ => {
             DEBUG_TUI_VT100_PARSER.then(|| {
                 tracing::warn!("CSI {} K: Unsupported Erase Line mode", mode);

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_control_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_control_ops.rs
@@ -3,11 +3,11 @@
 //! Control character operations.
 //!
 //! This module acts as a thin shim layer that delegates to the actual implementation.
-//! Refer to the module-level documentation in the operations module for details on the
+//! Refer to the module-level documentation in the ops module for details on the
 //! "shim → impl → test" architecture and naming conventions.
 //!
 //! **Related Files:**
-//! - **Implementation**: [`impl_control_ops`] - Business logic with unit tests
+//! - **Implementation**: [`vt_100_impl_control_ops`] - Business logic with unit tests
 //! - **Integration Tests**: [`test_control_ops`] - Full pipeline testing via public API
 //!
 //! # Testing Strategy
@@ -20,7 +20,7 @@
 //! - **Integration tests** in the conformance tests validating the full pipeline
 //!
 //! For the complete testing philosophy and rationale behind this approach,
-//! see the [operations module].
+//! see the [ops module].
 //!
 //! # Architecture Overview
 //!
@@ -39,9 +39,9 @@
 //!         ↓
 //!     execute() [routes to functions below]
 //!         ↓
-//!     Route to control operations:                          ╭───────────╮
-//!       - control_ops:: for control chars (BS,TAB,LF,CR) <- │THIS MODULE│
-//!         ↓                                                 ╰───────────╯
+//!     Route to control operations:                             ╭───────────╮
+//!       - control_ops:: for control chars (BS,TAB,LF,CR)    <- │THIS MODULE│
+//!         ↓                                                    ╰───────────╯
 //!     Update OffscreenBuffer state
 //! ```
 //!
@@ -59,46 +59,46 @@
 //! parameters, unlike their [`CSI`] sequence counterparts.
 //!
 //! [`CSI`]: crate::CsiSequence
-//! [`impl_control_ops`]: crate::vt_100_ansi_impl::vt_100_impl_control_ops
 //! [`test_control_ops`]: crate::vt_100_pty_output_conformance_tests::tests::vt_100_test_control_ops
+//! [`vt_100_impl_control_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_control_ops
 //! [module-level Architecture Overview]: super#architecture-overview
 //! [module-level documentation]: self
-//! [operations module]: crate::core::ansi::vt_100_pty_output_parser::operations
+//! [ops module]: crate::core::ansi::vt_100_pty_output_parser::ops
 
 use super::super::ansi_parser_public_api::AnsiToOfsBufPerformer;
 
 /// Handle BS (Backspace) - move cursor left one position.
 /// If cursor is at start of line, behavior depends on terminal settings.
-/// See [`OffscreenBuffer::handle_backspace`] for detailed behavior.
+/// See [`OfsBufVT100::handle_backspace`] for detailed behavior.
 ///
-/// [`OffscreenBuffer::handle_backspace`]: crate::OffscreenBuffer::handle_backspace
+/// [`OfsBufVT100::handle_backspace`]: crate::OfsBufVT100::handle_backspace
 pub fn handle_backspace(performer: &mut AnsiToOfsBufPerformer) {
-    performer.ofs_buf.handle_backspace();
+    performer.ofs_buf_vt_100.handle_backspace();
 }
 
 /// Handle TAB (Horizontal Tab) - move cursor to next tab stop.
 /// Tab stops are typically at columns 0, 8, 16, 24, 32, etc.
-/// See [`OffscreenBuffer::handle_tab`] for detailed behavior and examples.
+/// See [`OfsBufVT100::handle_tab`] for detailed behavior and examples.
 ///
-/// [`OffscreenBuffer::handle_tab`]: crate::OffscreenBuffer::handle_tab
+/// [`OfsBufVT100::handle_tab`]: crate::OfsBufVT100::handle_tab
 pub fn handle_tab(performer: &mut AnsiToOfsBufPerformer) {
-    performer.ofs_buf.handle_tab();
+    performer.ofs_buf_vt_100.handle_tab();
 }
 
 /// Handle LF (Line Feed) - move cursor down one line.
 /// Cursor column position remains unchanged.
-/// See [`OffscreenBuffer::handle_line_feed`] for detailed behavior.
+/// See [`OfsBufVT100::handle_line_feed`] for detailed behavior.
 ///
-/// [`OffscreenBuffer::handle_line_feed`]: crate::OffscreenBuffer::handle_line_feed
+/// [`OfsBufVT100::handle_line_feed`]: crate::OfsBufVT100::handle_line_feed
 pub fn handle_line_feed(performer: &mut AnsiToOfsBufPerformer) {
-    performer.ofs_buf.handle_line_feed();
+    performer.ofs_buf_vt_100.handle_line_feed();
 }
 
 /// Handle CR (Carriage Return) - move cursor to start of current line.
 /// Cursor row position remains unchanged.
-/// See [`OffscreenBuffer::handle_carriage_return`] for detailed behavior.
+/// See [`OfsBufVT100::handle_carriage_return`] for detailed behavior.
 ///
-/// [`OffscreenBuffer::handle_carriage_return`]: crate::OffscreenBuffer::handle_carriage_return
+/// [`OfsBufVT100::handle_carriage_return`]: crate::OfsBufVT100::handle_carriage_return
 pub fn handle_carriage_return(performer: &mut AnsiToOfsBufPerformer) {
-    performer.ofs_buf.handle_carriage_return();
+    performer.ofs_buf_vt_100.handle_carriage_return();
 }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_cursor_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_cursor_ops.rs
@@ -3,11 +3,11 @@
 //! Cursor movement operations.
 //!
 //! This module acts as a thin shim layer that delegates to the actual implementation.
-//! Refer to the module-level documentation in the operations module for details on the
+//! Refer to the module-level documentation in the ops module for details on the
 //! "shim → impl → test" architecture and naming conventions.
 //!
 //! **Related Files:**
-//! - **Implementation**: [`impl_cursor_ops`] - Business logic with unit tests
+//! - **Implementation**: [`vt_100_impl_cursor_ops`] - Business logic with unit tests
 //! - **Integration Tests**: [`test_cursor_ops`] - Full pipeline testing via public API
 //!
 //! # Testing Strategy
@@ -20,7 +20,7 @@
 //! - **Integration tests** in the conformance tests validating the full pipeline
 //!
 //! For the complete testing philosophy and rationale behind this approach,
-//! see the [operations module].
+//! see the [ops module].
 //!
 //! # Architecture Overview
 //!
@@ -39,9 +39,9 @@
 //!         ↓
 //!     csi_dispatch() [routes to modules below]
 //!         ↓
-//!     Route to operations module:                  ╭───────────╮
-//!       - cursor_ops:: for movement (A,B,C,D,H) <- │THIS MODULE│
-//!       - scroll_ops:: for scrolling (S,T)         ╰───────────╯
+//!     Route to ops module:                                     ╭───────────╮
+//!       - cursor_ops:: for movement (A,B,C,D,H)             <- │THIS MODULE│
+//!       - scroll_ops:: for scrolling (S,T)                     ╰───────────╯
 //!       - sgr_ops:: for styling (m)
 //!       - line_ops:: for lines (L,M)
 //!       - char_ops:: for chars (@,P,X)
@@ -70,9 +70,9 @@
 //!
 //! ```text
 //! [`VT-100`] Wire Format    →    1-based Types    →    0-based Indices
-//! ─────────────────         ──────────────         ───────────────
-//! ESC [5;10H                TermRow(5)             RowIndex(4)
-//!                           TermCol(10)            ColIndex(9)
+//! ──────────────────────         ──────────────        ───────────────
+//! ESC [5;10H                     TermRow(5)            RowIndex(4)
+//!                                TermCol(10)           ColIndex(9)
 //! ```
 //!
 //! Conversion flow:
@@ -84,16 +84,16 @@
 //! [`ColIndex`]: crate::ColIndex
 //! [`CSI`]: crate::CsiSequence
 //! [`extract_nth_single_non_zero()`]: crate::ParamsExt::extract_nth_single_non_zero
-//! [`impl_cursor_ops`]: crate::vt_100_ansi_impl::vt_100_impl_cursor_ops
 //! [`NonZeroU16`]: std::num::NonZeroU16
 //! [`RowIndex`]: crate::RowIndex
 //! [`TermCol::from_raw_non_zero_value()`]: crate::TermCol::from_raw_non_zero_value
 //! [`TermRow::from_raw_non_zero_value()`]: crate::TermRow::from_raw_non_zero_value
 //! [`test_cursor_ops`]: crate::vt_100_pty_output_conformance_tests::tests::vt_100_test_cursor_ops
 //! [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
+//! [`vt_100_impl_cursor_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_cursor_ops
 //! [module-level Architecture Overview]: super#architecture-overview
 //! [module-level documentation]: self
-//! [operations module]: crate::core::ansi::vt_100_pty_output_parser::operations
+//! [ops module]: crate::core::ansi::vt_100_pty_output_parser::ops
 
 use super::super::{ansi_parser_public_api::AnsiToOfsBufPerformer,
                    protocols::parse_cursor_position};
@@ -107,15 +107,15 @@ use vte::Params;
 ///
 /// **Behavior**: Respects [`DECSTBM`] scroll region margins.
 ///
-/// **Implementation**: See [`OffscreenBuffer::cursor_up`] for detailed behavior.
+/// **Implementation**: See [`OfsBufVT100::cursor_up`] for detailed behavior.
 ///
 /// [`DECSTBM`]: https://vt100.net/docs/vt510-rm/DECSTBM.html
-/// [`OffscreenBuffer::cursor_up`]: crate::OffscreenBuffer::cursor_up
+/// [`OfsBufVT100::cursor_up`]: crate::OfsBufVT100::cursor_up
 /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
 /// [module-level documentation]: self
 pub fn cursor_up(performer: &mut AnsiToOfsBufPerformer, params: &Params) {
     let how_many = params.extract_nth_single_non_zero(0).get().into();
-    performer.ofs_buf.cursor_up(how_many);
+    performer.ofs_buf_vt_100.cursor_up(how_many);
 }
 
 /// Move cursor down by n lines.
@@ -125,15 +125,15 @@ pub fn cursor_up(performer: &mut AnsiToOfsBufPerformer, params: &Params) {
 ///
 /// **Behavior**: Respects [`DECSTBM`] scroll region margins.
 ///
-/// **Implementation**: See [`OffscreenBuffer::cursor_down`] for detailed behavior.
+/// **Implementation**: See [`OfsBufVT100::cursor_down`] for detailed behavior.
 ///
 /// [`DECSTBM`]: https://vt100.net/docs/vt510-rm/DECSTBM.html
-/// [`OffscreenBuffer::cursor_down`]: crate::OffscreenBuffer::cursor_down
+/// [`OfsBufVT100::cursor_down`]: crate::OfsBufVT100::cursor_down
 /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
 /// [module-level documentation]: self
 pub fn cursor_down(performer: &mut AnsiToOfsBufPerformer, params: &Params) {
     let how_many = params.extract_nth_single_non_zero(0).get().into();
-    performer.ofs_buf.cursor_down(how_many);
+    performer.ofs_buf_vt_100.cursor_down(how_many);
 }
 
 /// Move cursor forward by n columns.
@@ -141,14 +141,14 @@ pub fn cursor_down(performer: &mut AnsiToOfsBufPerformer, params: &Params) {
 /// **[`VT-100`] Protocol**: See [module-level documentation] for parameter handling
 /// (missing/zero parameters default to 1).
 ///
-/// **Implementation**: See [`OffscreenBuffer::cursor_forward`] for detailed behavior.
+/// **Implementation**: See [`OfsBufVT100::cursor_forward`] for detailed behavior.
 ///
-/// [`OffscreenBuffer::cursor_forward`]: crate::OffscreenBuffer::cursor_forward
+/// [`OfsBufVT100::cursor_forward`]: crate::OfsBufVT100::cursor_forward
 /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
 /// [module-level documentation]: self
 pub fn cursor_forward(performer: &mut AnsiToOfsBufPerformer, params: &Params) {
     let how_many = params.extract_nth_single_non_zero(0).get().into();
-    performer.ofs_buf.cursor_forward(how_many);
+    performer.ofs_buf_vt_100.cursor_forward(how_many);
 }
 
 /// Move cursor backward by n columns.
@@ -156,14 +156,14 @@ pub fn cursor_forward(performer: &mut AnsiToOfsBufPerformer, params: &Params) {
 /// **[`VT-100`] Protocol**: See [module-level documentation] for parameter handling
 /// (missing/zero parameters default to 1).
 ///
-/// **Implementation**: See [`OffscreenBuffer::cursor_backward`] for detailed behavior.
+/// **Implementation**: See [`OfsBufVT100::cursor_backward`] for detailed behavior.
 ///
-/// [`OffscreenBuffer::cursor_backward`]: crate::OffscreenBuffer::cursor_backward
+/// [`OfsBufVT100::cursor_backward`]: crate::OfsBufVT100::cursor_backward
 /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
 /// [module-level documentation]: self
 pub fn cursor_backward(performer: &mut AnsiToOfsBufPerformer, params: &Params) {
     let how_many = params.extract_nth_single_non_zero(0).get().into();
-    performer.ofs_buf.cursor_backward(how_many);
+    performer.ofs_buf_vt_100.cursor_backward(how_many);
 }
 
 /// Sets cursor position to (row, column).
@@ -180,7 +180,7 @@ pub fn cursor_backward(performer: &mut AnsiToOfsBufPerformer, params: &Params) {
 /// [module-level documentation]: self
 pub fn cursor_position(performer: &mut AnsiToOfsBufPerformer, params: &Params) {
     let (row, col) = parse_cursor_position(params);
-    performer.ofs_buf.cursor_to_position(row, col);
+    performer.ofs_buf_vt_100.cursor_to_position(row, col);
 }
 
 /// Handle CNL (Cursor Next Line) - move cursor to beginning of line n lines down.
@@ -192,8 +192,8 @@ pub fn cursor_position(performer: &mut AnsiToOfsBufPerformer, params: &Params) {
 /// [module-level documentation]: self
 pub fn cursor_next_line(performer: &mut AnsiToOfsBufPerformer, params: &Params) {
     let how_many = params.extract_nth_single_non_zero(0).get().into();
-    performer.ofs_buf.cursor_down(how_many);
-    performer.ofs_buf.cursor_to_line_start();
+    performer.ofs_buf_vt_100.cursor_down(how_many);
+    performer.ofs_buf_vt_100.cursor_to_line_start();
 }
 
 /// Handle CPL (Cursor Previous Line) - move cursor to beginning of line n lines up.
@@ -205,8 +205,8 @@ pub fn cursor_next_line(performer: &mut AnsiToOfsBufPerformer, params: &Params) 
 /// [module-level documentation]: self
 pub fn cursor_prev_line(performer: &mut AnsiToOfsBufPerformer, params: &Params) {
     let how_many = params.extract_nth_single_non_zero(0).get().into();
-    performer.ofs_buf.cursor_up(how_many);
-    performer.ofs_buf.cursor_to_line_start();
+    performer.ofs_buf_vt_100.cursor_up(how_many);
+    performer.ofs_buf_vt_100.cursor_to_line_start();
 }
 
 /// Handle CHA (Cursor Horizontal Absolute) - move cursor to column n.
@@ -221,17 +221,17 @@ pub fn cursor_column(performer: &mut AnsiToOfsBufPerformer, params: &Params) {
     let target_col =
         TermCol::from_raw_non_zero_value(params.extract_nth_single_non_zero(0))
             .to_zero_based();
-    performer.ofs_buf.cursor_to_column(target_col);
+    performer.ofs_buf_vt_100.cursor_to_column(target_col);
 }
 
 /// Handle SCP (Save Cursor Position) - save current cursor position.
 pub fn save_cursor_position(performer: &mut AnsiToOfsBufPerformer) {
-    performer.ofs_buf.save_cursor_position();
+    performer.ofs_buf_vt_100.save_cursor_position();
 }
 
 /// Handle RCP (Restore Cursor Position) - restore saved cursor position.
 pub fn restore_cursor_position(performer: &mut AnsiToOfsBufPerformer) {
-    performer.ofs_buf.restore_cursor_position();
+    performer.ofs_buf_vt_100.restore_cursor_position();
 }
 
 /// Handle VPA (Vertical Position Absolute) - move cursor to specified row.
@@ -251,5 +251,5 @@ pub fn vertical_position_absolute(
     let target_row =
         TermRow::from_raw_non_zero_value(params.extract_nth_single_non_zero(0))
             .to_zero_based();
-    performer.ofs_buf.cursor_to_row(target_row);
+    performer.ofs_buf_vt_100.cursor_to_row(target_row);
 }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_dsr_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_dsr_ops.rs
@@ -3,11 +3,11 @@
 //! Device Status Report ([`DSR`]) operations.
 //!
 //! This module acts as a thin shim layer that delegates to the actual implementation.
-//! Refer to the module-level documentation in the operations module for details on the
+//! Refer to the module-level documentation in the ops module for details on the
 //! "shim → impl → test" architecture and naming conventions.
 //!
 //! **Related Files:**
-//! - **Implementation**: [`impl_dsr_ops`] - Business logic with unit tests
+//! - **Implementation**: [`vt_100_impl_dsr_ops`] - Business logic with unit tests
 //! - **Integration Tests**: [`test_dsr_ops`] - Full pipeline testing via public API
 //!
 //! # Testing Strategy
@@ -20,7 +20,7 @@
 //! - **Integration tests** in the conformance tests validating the full pipeline
 //!
 //! For the complete testing philosophy and rationale behind this approach,
-//! see the [operations module].
+//! see the [ops module].
 //!
 //! # Architecture Overview
 //!
@@ -39,32 +39,28 @@
 //!         ↓
 //!     csi_dispatch() [routes to modules below]
 //!         ↓
-//!     Route to operations module:
+//!     Route to ops module:
 //!       - cursor_ops:: for movement (A,B,C,D,H)
 //!       - scroll_ops:: for scrolling (S,T)
 //!       - sgr_ops:: for styling (m)
 //!       - line_ops:: for lines (L,M)
-//!       - char_ops:: for chars (@,P,X)       ╭───────────╮
-//!       - dsr_ops:: for device status (n) <- │THIS MODULE│
-//!         ↓                                  ╰───────────╯
+//!       - char_ops:: for chars (@,P,X)                         ╭───────────╮
+//!       - dsr_ops:: for device status (n)                   <- │THIS MODULE│
+//!         ↓                                                    ╰───────────╯
 //!     Update OffscreenBuffer state
 //! ```
 //!
 //! [`CSI`]: crate::CsiSequence
 //! [`DSR`]: crate::DsrSequence
-//! [`impl_dsr_ops`]: crate::vt_100_ansi_impl::vt_100_impl_dsr_ops
 //! [`test_dsr_ops`]: crate::vt_100_pty_output_conformance_tests::tests::vt_100_test_dsr_ops
+//! [`vt_100_impl_dsr_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_dsr_ops
 //! [module-level Architecture Overview]: super#architecture-overview
 //! [module-level documentation]: self
-//! [operations module]: crate::core::ansi::vt_100_pty_output_parser::operations
+//! [ops module]: crate::core::ansi::vt_100_pty_output_parser::ops
 
-use crate::{
-    core::ansi::{
-        generator::DsrRequestType,
-        vt_100_pty_output_parser::ansi_parser_public_api::AnsiToOfsBufPerformer,
-    },
-    DEBUG_TUI_VT100_PARSER,
-};
+use crate::{DEBUG_TUI_VT100_PARSER,
+            core::ansi::{generator::DsrRequestType,
+                         vt_100_pty_output_parser::ansi_parser_public_api::AnsiToOfsBufPerformer}};
 
 /// Handle Device Status Report (`CSI n`) command.
 ///
@@ -77,14 +73,17 @@ use crate::{
 pub fn status_report(performer: &mut AnsiToOfsBufPerformer, params: &vte::Params) {
     match DsrRequestType::from(params) {
         DsrRequestType::RequestStatus => {
-            performer.ofs_buf.handle_status_report_request();
+            performer.ofs_buf_vt_100.handle_status_report_request();
         }
         DsrRequestType::RequestCursorPosition => {
-            performer.ofs_buf.handle_cursor_position_request();
+            performer.ofs_buf_vt_100.handle_cursor_position_request();
         }
         DsrRequestType::Other(n) => {
             DEBUG_TUI_VT100_PARSER.then(|| {
-                tracing::warn!("CSI {}n (DSR): Unsupported device status report request", n);
+                tracing::warn!(
+                    "CSI {}n (DSR): Unsupported device status report request",
+                    n
+                );
             });
         }
     }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_line_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_line_ops.rs
@@ -3,11 +3,11 @@
 //! Line insertion and deletion operations.
 //!
 //! This module acts as a thin shim layer that delegates to the actual implementation.
-//! Refer to the module-level documentation in the operations module for details on the
+//! Refer to the module-level documentation in the ops module for details on the
 //! "shim → impl → test" architecture and naming conventions.
 //!
 //! **Related Files:**
-//! - **Implementation**: [`impl_line_ops`] - Business logic with unit tests
+//! - **Implementation**: [`vt_100_impl_line_ops`] - Business logic with unit tests
 //! - **Integration Tests**: [`test_line_ops`] - Full pipeline testing via public API
 //!
 //! # Testing Strategy
@@ -20,7 +20,7 @@
 //! - **Integration tests** in the conformance tests validating the full pipeline
 //!
 //! For the complete testing philosophy and rationale behind this approach,
-//! see the [operations module].
+//! see the [ops module].
 //!
 //! # Architecture Overview
 //!
@@ -39,12 +39,12 @@
 //!         ↓
 //!     csi_dispatch() [routes to modules below]
 //!         ↓
-//!     Route to operations module:
+//!     Route to ops module:
 //!       - cursor_ops:: for movement (A,B,C,D,H)
 //!       - scroll_ops:: for scrolling (S,T)
-//!       - sgr_ops:: for styling (m)     ╭───────────╮
-//!       - line_ops:: for lines (L,M) <- │THIS MODULE│
-//!       - char_ops:: for chars (@,P,X)  ╰───────────╯
+//!       - sgr_ops:: for styling (m)                            ╭───────────╮
+//!       - line_ops:: for lines (L,M)                        <- │THIS MODULE│
+//!       - char_ops:: for chars (@,P,X)                         ╰───────────╯
 //!         ↓
 //!     Update OffscreenBuffer state
 //! ```
@@ -72,13 +72,13 @@
 //! [`CSI`]: crate::CsiSequence
 //! [`DECSTBM`]: https://vt100.net/docs/vt510-rm/DECSTBM.html
 //! [`extract_nth_single_non_zero()`]: crate::ParamsExt::extract_nth_single_non_zero
-//! [`impl_line_ops`]: crate::vt_100_ansi_impl::vt_100_impl_line_ops
 //! [`NonZeroU16`]: std::num::NonZeroU16
 //! [`test_line_ops`]: crate::vt_100_pty_output_conformance_tests::tests::vt_100_test_line_ops
 //! [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
+//! [`vt_100_impl_line_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_line_ops
 //! [module-level Architecture Overview]: super#architecture-overview
 //! [module-level documentation]: self
-//! [operations module]: crate::core::ansi::vt_100_pty_output_parser::operations
+//! [ops module]: crate::core::ansi::vt_100_pty_output_parser::ops
 
 use super::super::ansi_parser_public_api::AnsiToOfsBufPerformer;
 use crate::ParamsExt;
@@ -90,16 +90,16 @@ use crate::ParamsExt;
 /// (missing/zero parameters default to 1) and scroll region interaction.
 ///
 /// This operation respects [`VT-100`] scroll region boundaries.
-/// See [`OffscreenBuffer::insert_lines_at`] for detailed behavior and scroll region
+/// See [`OfsBufVT100::insert_lines_at`] for detailed behavior and scroll region
 /// handling.
 ///
-/// [`OffscreenBuffer::insert_lines_at`]: crate::OffscreenBuffer::insert_lines_at
+/// [`OfsBufVT100::insert_lines_at`]: crate::OfsBufVT100::insert_lines_at
 /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
 /// [module-level documentation]: self
 pub fn insert_lines(performer: &mut AnsiToOfsBufPerformer, params: &vte::Params) {
     let how_many = params.extract_nth_single_non_zero(0).get().into();
-    let at = performer.ofs_buf.cursor_pos.row_index;
-    let result = performer.ofs_buf.insert_lines_at(at, how_many);
+    let at = performer.ofs_buf_vt_100.cursor_pos.row_index;
+    let result = performer.ofs_buf_vt_100.insert_lines_at(at, how_many);
     debug_assert!(
         result.is_ok(),
         "Failed to insert {how_many:?} lines at row {at:?}",
@@ -114,16 +114,16 @@ pub fn insert_lines(performer: &mut AnsiToOfsBufPerformer, params: &vte::Params)
 /// (missing/zero parameters default to 1) and scroll region interaction.
 ///
 /// This operation respects [`VT-100`] scroll region boundaries.
-/// See [`OffscreenBuffer::delete_lines_at`] for detailed behavior and scroll region
+/// See [`OfsBufVT100::delete_lines_at`] for detailed behavior and scroll region
 /// handling.
 ///
-/// [`OffscreenBuffer::delete_lines_at`]: crate::OffscreenBuffer::delete_lines_at
+/// [`OfsBufVT100::delete_lines_at`]: crate::OfsBufVT100::delete_lines_at
 /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
 /// [module-level documentation]: self
 pub fn delete_lines(performer: &mut AnsiToOfsBufPerformer, params: &vte::Params) {
     let how_many = params.extract_nth_single_non_zero(0).get().into();
-    let at = performer.ofs_buf.cursor_pos.row_index;
-    let result = performer.ofs_buf.delete_lines_at(at, how_many);
+    let at = performer.ofs_buf_vt_100.cursor_pos.row_index;
+    let result = performer.ofs_buf_vt_100.delete_lines_at(at, how_many);
     debug_assert!(
         result.is_ok(),
         "Failed to delete {how_many:?} lines at row {at:?}",

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_margin_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_margin_ops.rs
@@ -3,11 +3,11 @@
 //! Margin setting operations ([`DECSTBM`]).
 //!
 //! This module acts as a thin shim layer that delegates to the actual implementation.
-//! Refer to the module-level documentation in the operations module for details on the
+//! Refer to the module-level documentation in the ops module for details on the
 //! "shim → impl → test" architecture and naming conventions.
 //!
 //! **Related Files:**
-//! - **Implementation**: [`impl_margin_ops`] - Business logic with unit tests
+//! - **Implementation**: [`vt_100_impl_margin_ops`] - Business logic with unit tests
 //! - **Integration Tests**: [`test_margin_ops`] - Full pipeline testing via public API
 //!
 //! # Testing Strategy
@@ -20,7 +20,7 @@
 //! - **Integration tests** in the conformance tests validating the full pipeline
 //!
 //! For the complete testing philosophy and rationale behind this approach,
-//! see the [operations module].
+//! see the [ops module].
 //!
 //! # Architecture Overview
 //!
@@ -39,24 +39,24 @@
 //!         ↓
 //!     csi_dispatch() [routes to modules below]
 //!         ↓
-//!     Route to operations module:
+//!     Route to ops module:
 //!       - cursor_ops:: for movement (A,B,C,D,H)
 //!       - scroll_ops:: for scrolling (S,T)
 //!       - sgr_ops:: for styling (m)
 //!       - line_ops:: for lines (L,M)
-//!       - char_ops:: for chars (@,P,X)    ╭───────────╮
-//!       - margin_ops:: for margins (r) <- │THIS MODULE│
-//!         ↓                               ╰───────────╯
+//!       - char_ops:: for chars (@,P,X)                         ╭───────────╮
+//!       - margin_ops:: for margins (r)                      <- │THIS MODULE│
+//!         ↓                                                    ╰───────────╯
 //!     Update OffscreenBuffer state
 //! ```
 //!
 //! [`CSI`]: crate::CsiSequence
 //! [`DECSTBM`]: https://vt100.net/docs/vt510-rm/DECSTBM.html
-//! [`impl_margin_ops`]: crate::vt_100_ansi_impl::vt_100_impl_margin_ops
 //! [`test_margin_ops`]: crate::vt_100_pty_output_conformance_tests::tests::vt_100_test_margin_ops
+//! [`vt_100_impl_margin_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_margin_ops
 //! [module-level Architecture Overview]: super#architecture-overview
 //! [module-level documentation]: self
-//! [operations module]: crate::core::ansi::vt_100_pty_output_parser::operations
+//! [ops module]: crate::core::ansi::vt_100_pty_output_parser::ops
 
 use super::super::{MarginRequest, ansi_parser_public_api::AnsiToOfsBufPerformer};
 use vte::Params;
@@ -73,10 +73,10 @@ pub fn set_margins(performer: &mut AnsiToOfsBufPerformer, params: &Params) {
 
     match request {
         MarginRequest::Reset => {
-            performer.ofs_buf.reset_scroll_margins();
+            performer.ofs_buf_vt_100.reset_scroll_margins();
         }
         MarginRequest::SetRegion { top, bottom } => {
-            performer.ofs_buf.set_scroll_margins(top, bottom);
+            performer.ofs_buf_vt_100.set_scroll_margins(top, bottom);
         }
     }
 }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_mode_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_mode_ops.rs
@@ -3,11 +3,11 @@
 //! Mode setting operations (SM/RM).
 //!
 //! This module acts as a thin shim layer that delegates to the actual implementation.
-//! Refer to the module-level documentation in the operations module for details on the
+//! Refer to the module-level documentation in the ops module for details on the
 //! "shim → impl → test" architecture and naming conventions.
 //!
 //! **Related Files:**
-//! - **Implementation**: [`impl_mode_ops`] - Business logic with unit tests
+//! - **Implementation**: [`vt_100_impl_mode_ops`] - Business logic with unit tests
 //! - **Integration Tests**: [`test_mode_ops`] - Full pipeline testing via public API
 //!
 //! # Testing Strategy
@@ -20,7 +20,7 @@
 //! - **Integration tests** in the conformance tests validating the full pipeline
 //!
 //! For the complete testing philosophy and rationale behind this approach,
-//! see the [operations module].
+//! see the [ops module].
 //!
 //! # Architecture Overview
 //!
@@ -39,32 +39,30 @@
 //!         ↓
 //!     csi_dispatch() [routes to modules below]
 //!         ↓
-//!     Route to operations module:
+//!     Route to ops module:
 //!       - cursor_ops:: for movement (A,B,C,D,H)
 //!       - scroll_ops:: for scrolling (S,T)
 //!       - sgr_ops:: for styling (m)
 //!       - line_ops:: for lines (L,M)
-//!       - char_ops:: for chars (@,P,X)  ╭───────────╮
-//!       - mode_ops:: for modes (h,l) <- │THIS MODULE│
-//!         ↓                             ╰───────────╯
+//!       - char_ops:: for chars (@,P,X)                         ╭───────────╮
+//!       - mode_ops:: for modes (h,l)                        <- │THIS MODULE│
+//!         ↓                                                    ╰───────────╯
 //!     Update OffscreenBuffer state
 //! ```
 //!
 //! [`CSI`]: crate::CsiSequence
-//! [`impl_mode_ops`]: crate::vt_100_ansi_impl::vt_100_impl_mode_ops
 //! [`test_mode_ops`]: crate::vt_100_pty_output_conformance_tests::tests::vt_100_test_mode_ops
+//! [`vt_100_impl_mode_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_mode_ops
 //! [module-level Architecture Overview]: super#architecture-overview
 //! [module-level documentation]: self
-//! [operations module]: crate::core::ansi::vt_100_pty_output_parser::operations
+//! [ops module]: crate::core::ansi::vt_100_pty_output_parser::ops
 
-use crate::{
-    APPLICATION_MOUSE_TRACKING, BRACKETED_PASTE_MODE, CELL_MOTION_MOUSE_TRACKING,
-    DEBUG_TUI_VT100_PARSER, SGR_MOUSE_MODE, URXVT_MOUSE_EXTENSION, UTF8_MOUSE_EXTENSION,
-    X11_MOUSE_TRACKING,
-};
-
-use super::super::{ansi_parser_public_api::AnsiToOfsBufPerformer, PrivateModeType};
-use crate::{AutoWrapState, CursorVisibilityState, RequestedScreenMode, core::ansi::constants::CSI_PRIVATE_MODE_PREFIX};
+use super::super::{PrivateModeType, ansi_parser_public_api::AnsiToOfsBufPerformer};
+use crate::{APPLICATION_MOUSE_TRACKING, AutoWrapState, BRACKETED_PASTE_MODE,
+            CELL_MOTION_MOUSE_TRACKING, CursorVisibilityState, DEBUG_TUI_VT100_PARSER,
+            RequestedScreenMode, SGR_MOUSE_MODE, URXVT_MOUSE_EXTENSION,
+            UTF8_MOUSE_EXTENSION, X11_MOUSE_TRACKING,
+            core::ansi::constants::CSI_PRIVATE_MODE_PREFIX};
 use vte::Params;
 
 /// Handle Set Mode (`CSI h`) command.
@@ -79,17 +77,24 @@ pub fn set_mode(
         let mode = PrivateModeType::from(params);
         match mode {
             PrivateModeType::AutoWrap => {
-                performer.ofs_buf.set_requested_auto_wrap_mode(AutoWrapState::Enabled);
+                performer
+                    .ofs_buf_vt_100
+                    .set_requested_auto_wrap_mode(AutoWrapState::Enabled);
             }
             PrivateModeType::AlternateScreenBuffer => {
-                performer.ofs_buf.set_alt_screen_mode(RequestedScreenMode::Alternate);
+                performer
+                    .ofs_buf_vt_100
+                    .set_alt_screen_mode(RequestedScreenMode::Alternate);
             }
             PrivateModeType::ShowCursor => {
-                performer.ofs_buf.set_requested_cursor_visibility_mode(CursorVisibilityState::Visible);
+                performer
+                    .ofs_buf_vt_100
+                    .set_requested_cursor_visibility_mode(CursorVisibilityState::Visible);
             }
-            // Safely suppress/ignore modern TUI extensions (like mouse tracking and bracketed paste).
-            // Currently, the multiplexer does not support routing rich input events back into the PTY.
-            // Downgrading to debug prevents heavy log spam from interactive TUIs (like hx/gitui).
+            // Safely suppress/ignore modern TUI extensions (like mouse tracking and
+            // bracketed paste). Currently, the multiplexer does not support
+            // routing rich input events back into the PTY. Downgrading to
+            // debug prevents heavy log spam from interactive TUIs (like hx/gitui).
             PrivateModeType::Other(
                 X11_MOUSE_TRACKING
                 | CELL_MOTION_MOUSE_TRACKING
@@ -100,7 +105,10 @@ pub fn set_mode(
                 | BRACKETED_PASTE_MODE,
             ) => {
                 DEBUG_TUI_VT100_PARSER.then(|| {
-                    tracing::debug!("CSI ?{}h: Suppressed/shimmed private mode", mode.as_u16());
+                    tracing::debug!(
+                        "CSI ?{}h: Suppressed/shimmed private mode",
+                        mode.as_u16()
+                    );
                 });
             }
             _ => {
@@ -128,17 +136,24 @@ pub fn reset_mode(
         let mode = PrivateModeType::from(params);
         match mode {
             PrivateModeType::AutoWrap => {
-                performer.ofs_buf.set_requested_auto_wrap_mode(AutoWrapState::Disabled);
+                performer
+                    .ofs_buf_vt_100
+                    .set_requested_auto_wrap_mode(AutoWrapState::Disabled);
             }
             PrivateModeType::AlternateScreenBuffer => {
-                performer.ofs_buf.set_alt_screen_mode(RequestedScreenMode::Primary);
+                performer
+                    .ofs_buf_vt_100
+                    .set_alt_screen_mode(RequestedScreenMode::Primary);
             }
             PrivateModeType::ShowCursor => {
-                performer.ofs_buf.set_requested_cursor_visibility_mode(CursorVisibilityState::Hidden);
+                performer
+                    .ofs_buf_vt_100
+                    .set_requested_cursor_visibility_mode(CursorVisibilityState::Hidden);
             }
-            // Safely suppress/ignore modern TUI extensions (like mouse tracking and bracketed paste).
-            // Currently, the multiplexer does not support routing rich input events back into the PTY.
-            // Downgrading to debug prevents heavy log spam from interactive TUIs (like hx/gitui).
+            // Safely suppress/ignore modern TUI extensions (like mouse tracking and
+            // bracketed paste). Currently, the multiplexer does not support
+            // routing rich input events back into the PTY. Downgrading to
+            // debug prevents heavy log spam from interactive TUIs (like hx/gitui).
             PrivateModeType::Other(
                 X11_MOUSE_TRACKING
                 | CELL_MOTION_MOUSE_TRACKING
@@ -149,7 +164,10 @@ pub fn reset_mode(
                 | BRACKETED_PASTE_MODE,
             ) => {
                 DEBUG_TUI_VT100_PARSER.then(|| {
-                    tracing::debug!("CSI ?{}l: Suppressed/shimmed private mode", mode.as_u16());
+                    tracing::debug!(
+                        "CSI ?{}l: Suppressed/shimmed private mode",
+                        mode.as_u16()
+                    );
                 });
             }
             _ => {

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_osc_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_osc_ops.rs
@@ -3,11 +3,11 @@
 //! [`OSC`] (Operating System Command) sequence operations.
 //!
 //! This module acts as a thin shim layer that delegates to the actual implementation.
-//! Refer to the module-level documentation in the operations module for details on the
+//! Refer to the module-level documentation in the ops module for details on the
 //! "shim → impl → test" architecture and naming conventions.
 //!
 //! **Related Files:**
-//! - **Implementation**: [`impl_osc_ops`] - Business logic with unit tests
+//! - **Implementation**: [`vt_100_impl_osc_ops`] - Business logic with unit tests
 //! - **Integration Tests**: [`test_osc_ops`] - Full pipeline testing via public API
 //!
 //! # Testing Strategy
@@ -20,7 +20,7 @@
 //! - **Integration tests** in the conformance tests validating the full pipeline
 //!
 //! For the complete testing philosophy and rationale behind this approach,
-//! see the [operations module].
+//! see the [ops module].
 //!
 //! # Architecture Overview
 //!
@@ -39,9 +39,9 @@
 //!         ↓
 //!     osc_dispatch() [routes to functions below]
 //!         ↓
-//!     Route to `OSC` operations:                          ╭───────────╮
-//!       - osc_ops:: for OS commands (title, hyperlink) <- │THIS MODULE│
-//!         ↓                                               ╰───────────╯
+//!     Route to `OSC` operations:                               ╭───────────╮
+//!       - osc_ops:: for OS commands (title, hyperlink)      <- │THIS MODULE│
+//!         ↓                                                    ╰───────────╯
 //!     Queue OscEvent for later rendering
 //! ```
 //!
@@ -57,12 +57,12 @@
 //!
 //! [`OSC`] sequences are queued as events for later processing by the output renderer.
 //!
-//! [`impl_osc_ops`]: crate::vt_100_ansi_impl::vt_100_impl_osc_ops
 //! [`OSC`]: crate::osc_codes::OscSequence
 //! [`test_osc_ops`]: crate::vt_100_pty_output_conformance_tests::tests::vt_100_test_osc_ops
+//! [`vt_100_impl_osc_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_osc_ops
 //! [module-level Architecture Overview]: super#architecture-overview
 //! [module-level documentation]: self
-//! [operations module]: crate::core::ansi::vt_100_pty_output_parser::operations
+//! [ops module]: crate::core::ansi::vt_100_pty_output_parser::ops
 
 use super::super::ansi_parser_public_api::AnsiToOfsBufPerformer;
 use crate::core::osc::osc_codes;
@@ -118,7 +118,7 @@ pub fn dispatch_osc(
 /// [`OSC`]: crate::osc_codes::OscSequence
 /// [`SetTitleAndTab`]: crate::OscEvent::SetTitleAndTab
 pub fn handle_title_and_icon(performer: &mut AnsiToOfsBufPerformer, title: &str) {
-    performer.ofs_buf.handle_title_and_icon(title);
+    performer.ofs_buf_vt_100.handle_title_and_icon(title);
 }
 
 /// Handle `OSC 8` hyperlink sequences.
@@ -126,5 +126,5 @@ pub fn handle_title_and_icon(performer: &mut AnsiToOfsBufPerformer, title: &str)
 /// The display text is handled separately via `print()` calls.
 /// Queues Hyperlink event for later processing by output renderer.
 pub fn handle_hyperlink(performer: &mut AnsiToOfsBufPerformer, uri: &str) {
-    performer.ofs_buf.handle_hyperlink(uri);
+    performer.ofs_buf_vt_100.handle_hyperlink(uri);
 }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_scroll_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_scroll_ops.rs
@@ -3,11 +3,11 @@
 //! Scrolling operations.
 //!
 //! This module acts as a thin shim layer that delegates to the actual implementation.
-//! Refer to the module-level documentation in the operations module for details on the
+//! Refer to the module-level documentation in the ops module for details on the
 //! "shim → impl → test" architecture and naming conventions.
 //!
 //! **Related Files:**
-//! - **Implementation**: [`impl_scroll_ops`] - Business logic with unit tests
+//! - **Implementation**: [`vt_100_impl_scroll_ops`] - Business logic with unit tests
 //! - **Integration Tests**: [`test_scroll_ops`] - Full pipeline testing via public API
 //!
 //! # Testing Strategy
@@ -20,7 +20,7 @@
 //! - **Integration tests** in the conformance tests validating the full pipeline
 //!
 //! For the complete testing philosophy and rationale behind this approach,
-//! see the [operations module].
+//! see the [ops module].
 //!
 //! # Architecture Overview
 //!
@@ -39,10 +39,10 @@
 //!         ↓
 //!     csi_dispatch() [routes to modules below]
 //!         ↓
-//!     Route to operations module:
-//!       - cursor_ops:: for movement (A,B,C,D,H) ╭───────────╮
-//!       - scroll_ops:: for scrolling (S,T) <--- │THIS MODULE│
-//!       - sgr_ops:: for styling (m)             ╰───────────╯
+//!     Route to ops module:
+//!       - cursor_ops:: for movement (A,B,C,D,H)                ╭───────────╮
+//!       - scroll_ops:: for scrolling (S,T)                  <- │THIS MODULE│
+//!       - sgr_ops:: for styling (m)                            ╰───────────╯
 //!       - line_ops:: for lines (L,M)
 //!       - char_ops:: for chars (@,P,X)
 //!         ↓
@@ -73,14 +73,14 @@
 //! [`CSI`]: crate::CsiSequence
 //! [`DECSTBM`]: https://vt100.net/docs/vt510-rm/DECSTBM.html
 //! [`extract_nth_single_non_zero()`]: crate::ParamsExt::extract_nth_single_non_zero
-//! [`impl_scroll_ops`]: crate::vt_100_ansi_impl::vt_100_impl_scroll_ops
 //! [`NonZeroU16`]: std::num::NonZeroU16
 //! [`OffscreenBuffer`]: crate::OffscreenBuffer
 //! [`test_scroll_ops`]: crate::vt_100_pty_output_conformance_tests::tests::vt_100_test_scroll_ops
 //! [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
+//! [`vt_100_impl_scroll_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_scroll_ops
 //! [module-level Architecture Overview]: super#architecture-overview
 //! [module-level documentation]: self
-//! [operations module]: crate::core::ansi::vt_100_pty_output_parser::operations
+//! [ops module]: crate::core::ansi::vt_100_pty_output_parser::ops
 
 use super::super::ansi_parser_public_api::AnsiToOfsBufPerformer;
 use crate::ParamsExt;
@@ -97,11 +97,11 @@ use crate::ParamsExt;
 /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
 /// [module-level documentation]: self
 pub fn index_down(performer: &mut AnsiToOfsBufPerformer) {
-    let result = performer.ofs_buf.index_down();
+    let result = performer.ofs_buf_vt_100.index_down();
     debug_assert!(
         result.is_ok(),
         "Failed to index down at cursor position {:?}",
-        performer.ofs_buf.cursor_pos
+        performer.ofs_buf_vt_100.cursor_pos
     );
 }
 
@@ -117,11 +117,11 @@ pub fn index_down(performer: &mut AnsiToOfsBufPerformer) {
 /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
 /// [module-level documentation]: self
 pub fn reverse_index_up(performer: &mut AnsiToOfsBufPerformer) {
-    let result = performer.ofs_buf.reverse_index_up();
+    let result = performer.ofs_buf_vt_100.reverse_index_up();
     debug_assert!(
         result.is_ok(),
         "Failed to reverse index up at cursor position {:?}",
-        performer.ofs_buf.cursor_pos
+        performer.ofs_buf_vt_100.cursor_pos
     );
 }
 
@@ -136,11 +136,11 @@ pub fn reverse_index_up(performer: &mut AnsiToOfsBufPerformer) {
 /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
 /// [module-level documentation]: self
 pub fn scroll_buffer_up(performer: &mut AnsiToOfsBufPerformer) {
-    let result = performer.ofs_buf.scroll_buffer_up();
+    let result = performer.ofs_buf_vt_100.scroll_buffer_up();
     debug_assert!(
         result.is_ok(),
         "Failed to scroll buffer up at cursor position {:?}",
-        performer.ofs_buf.cursor_pos
+        performer.ofs_buf_vt_100.cursor_pos
     );
 }
 
@@ -155,11 +155,11 @@ pub fn scroll_buffer_up(performer: &mut AnsiToOfsBufPerformer) {
 /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
 /// [module-level documentation]: self
 pub fn scroll_buffer_down(performer: &mut AnsiToOfsBufPerformer) {
-    let result = performer.ofs_buf.scroll_buffer_down();
+    let result = performer.ofs_buf_vt_100.scroll_buffer_down();
     debug_assert!(
         result.is_ok(),
         "Failed to scroll buffer down at cursor position {:?}",
-        performer.ofs_buf.cursor_pos
+        performer.ofs_buf_vt_100.cursor_pos
     );
 }
 
@@ -172,12 +172,12 @@ pub fn scroll_buffer_down(performer: &mut AnsiToOfsBufPerformer) {
 /// [module-level documentation]: self
 pub fn scroll_up(performer: &mut AnsiToOfsBufPerformer, params: &vte::Params) {
     let how_many = params.extract_nth_single_non_zero(0).get().into();
-    let result = performer.ofs_buf.scroll_up(how_many);
+    let result = performer.ofs_buf_vt_100.scroll_up(how_many);
     debug_assert!(
         result.is_ok(),
         "Failed to scroll up {:?} lines at cursor position {:?}",
         how_many,
-        performer.ofs_buf.cursor_pos
+        performer.ofs_buf_vt_100.cursor_pos
     );
 }
 
@@ -190,11 +190,11 @@ pub fn scroll_up(performer: &mut AnsiToOfsBufPerformer, params: &vte::Params) {
 /// [module-level documentation]: self
 pub fn scroll_down(performer: &mut AnsiToOfsBufPerformer, params: &vte::Params) {
     let how_many = params.extract_nth_single_non_zero(0).get().into();
-    let result = performer.ofs_buf.scroll_down(how_many);
+    let result = performer.ofs_buf_vt_100.scroll_down(how_many);
     debug_assert!(
         result.is_ok(),
         "Failed to scroll down {:?} lines at cursor position {:?}",
         how_many,
-        performer.ofs_buf.cursor_pos
+        performer.ofs_buf_vt_100.cursor_pos
     );
 }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_sgr_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_sgr_ops.rs
@@ -3,11 +3,11 @@
 //! Style/Graphics Rendition operations.
 //!
 //! This module acts as a thin shim layer that delegates to the actual implementation.
-//! Refer to the module-level documentation in the operations module for details on the
+//! Refer to the module-level documentation in the ops module for details on the
 //! "shim → impl → test" architecture and naming conventions.
 //!
 //! **Related Files:**
-//! - **Implementation**: [`impl_sgr_ops`] - Business logic with unit tests
+//! - **Implementation**: [`vt_100_impl_sgr_ops`] - Business logic with unit tests
 //! - **Integration Tests**: [`test_sgr_ops`] - Full pipeline testing via public API
 //!
 //! # Testing Strategy
@@ -20,7 +20,7 @@
 //! - **Integration tests** in the conformance tests validating the full pipeline
 //!
 //! For the complete testing philosophy and rationale behind this approach,
-//! see the [operations module].
+//! see the [ops module].
 //!
 //! # Architecture Overview
 //!
@@ -39,22 +39,22 @@
 //!         ↓
 //!     csi_dispatch() [routes to modules below]
 //!         ↓
-//!     Route to operations module:
+//!     Route to ops module:
 //!       - cursor_ops:: for movement (A,B,C,D,H)
-//!       - scroll_ops:: for scrolling (S,T) ╭───────────╮
-//!       - sgr_ops:: for styling (m) <----- │THIS MODULE│
-//!       - line_ops:: for lines (L,M)       ╰───────────╯
+//!       - scroll_ops:: for scrolling (S,T)                     ╭───────────╮
+//!       - sgr_ops:: for styling (m)                         <- │THIS MODULE│
+//!       - line_ops:: for lines (L,M)                           ╰───────────╯
 //!       - char_ops:: for chars (@,P,X)
 //!         ↓
 //!     Update OffscreenBuffer state
 //! ```
 //!
 //! [`CSI`]: crate::CsiSequence
-//! [`impl_sgr_ops`]: crate::vt_100_ansi_impl::vt_100_impl_sgr_ops
 //! [`test_sgr_ops`]: crate::vt_100_pty_output_conformance_tests::tests::vt_100_test_sgr_ops
+//! [`vt_100_impl_sgr_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_sgr_ops
 //! [module-level Architecture Overview]: super#architecture-overview
 //! [module-level documentation]: self
-//! [operations module]: crate::core::ansi::vt_100_pty_output_parser::operations
+//! [ops module]: crate::core::ansi::vt_100_pty_output_parser::ops
 
 use super::super::{AnsiToOfsBufPerformer, ParamsExt};
 use crate::{SgrColorSequence,
@@ -81,105 +81,105 @@ use vte::Params;
 fn apply_sgr_param(performer: &mut AnsiToOfsBufPerformer, param: u16) {
     match param {
         SGR_RESET => {
-            performer.ofs_buf.reset_all_style_attributes();
+            performer.ofs_buf_vt_100.reset_all_style_attributes();
         }
         SGR_BOLD => {
             performer
-                .ofs_buf
+                .ofs_buf_vt_100
                 .apply_style_attribute(tui_style_attrib::Bold.into());
         }
         SGR_DIM => {
             performer
-                .ofs_buf
+                .ofs_buf_vt_100
                 .apply_style_attribute(tui_style_attrib::Dim.into());
         }
         SGR_ITALIC => {
             performer
-                .ofs_buf
+                .ofs_buf_vt_100
                 .apply_style_attribute(tui_style_attrib::Italic.into());
         }
         SGR_UNDERLINE => {
             performer
-                .ofs_buf
+                .ofs_buf_vt_100
                 .apply_style_attribute(tui_style_attrib::Underline.into());
         }
         SGR_BLINK => {
             performer
-                .ofs_buf
+                .ofs_buf_vt_100
                 .apply_style_attribute(tui_style_attrib::BlinkMode::Slow.into());
         }
         SGR_RAPID_BLINK => {
             performer
-                .ofs_buf
+                .ofs_buf_vt_100
                 .apply_style_attribute(tui_style_attrib::BlinkMode::Rapid.into());
         }
         SGR_REVERSE => {
             performer
-                .ofs_buf
+                .ofs_buf_vt_100
                 .apply_style_attribute(tui_style_attrib::Reverse.into());
         }
         SGR_HIDDEN => {
             performer
-                .ofs_buf
+                .ofs_buf_vt_100
                 .apply_style_attribute(tui_style_attrib::Hidden.into());
         }
         SGR_STRIKETHROUGH => {
             performer
-                .ofs_buf
+                .ofs_buf_vt_100
                 .apply_style_attribute(tui_style_attrib::Strikethrough.into());
         }
         SGR_RESET_BOLD_DIM => {
             performer
-                .ofs_buf
+                .ofs_buf_vt_100
                 .reset_style_attribute(tui_style_attrib::Bold.into());
         }
         SGR_RESET_ITALIC => {
             performer
-                .ofs_buf
+                .ofs_buf_vt_100
                 .reset_style_attribute(tui_style_attrib::Italic.into());
         }
         SGR_RESET_UNDERLINE => {
             performer
-                .ofs_buf
+                .ofs_buf_vt_100
                 .reset_style_attribute(tui_style_attrib::Underline.into());
         }
         SGR_RESET_BLINK => {
             performer
-                .ofs_buf
+                .ofs_buf_vt_100
                 .reset_style_attribute(tui_style_attrib::BlinkMode::Slow.into());
         }
         SGR_RESET_REVERSE => {
             performer
-                .ofs_buf
+                .ofs_buf_vt_100
                 .reset_style_attribute(tui_style_attrib::Reverse.into());
         }
         SGR_RESET_HIDDEN => {
             performer
-                .ofs_buf
+                .ofs_buf_vt_100
                 .reset_style_attribute(tui_style_attrib::Hidden.into());
         }
         SGR_RESET_STRIKETHROUGH => {
             performer
-                .ofs_buf
+                .ofs_buf_vt_100
                 .reset_style_attribute(tui_style_attrib::Strikethrough.into());
         }
         SGR_FG_BLACK..=SGR_FG_WHITE => {
-            performer.ofs_buf.set_foreground_color(param);
+            performer.ofs_buf_vt_100.set_foreground_color(param);
         }
         SGR_FG_DEFAULT => {
-            performer.ofs_buf.reset_foreground_color();
+            performer.ofs_buf_vt_100.reset_foreground_color();
         }
         SGR_BG_BLACK..=SGR_BG_WHITE => {
-            performer.ofs_buf.set_background_color(param);
+            performer.ofs_buf_vt_100.set_background_color(param);
         }
         SGR_BG_DEFAULT => {
-            performer.ofs_buf.reset_background_color();
+            performer.ofs_buf_vt_100.reset_background_color();
         }
         SGR_FG_BRIGHT_BLACK..=SGR_FG_BRIGHT_WHITE => {
-            performer.ofs_buf.set_foreground_color(param);
+            performer.ofs_buf_vt_100.set_foreground_color(param);
         }
         SGR_BG_BRIGHT_BLACK..=SGR_BG_BRIGHT_WHITE => {
-            performer.ofs_buf.set_background_color(param);
+            performer.ofs_buf_vt_100.set_background_color(param);
         }
         _ => {
             // Ignore other unsupported SGR parameters:
@@ -221,7 +221,9 @@ pub fn set_graphics_rendition(performer: &mut AnsiToOfsBufPerformer, params: &Pa
     while let Some(param_slice) = params.extract_nth_many_raw(idx) {
         // Case 1: Colon-separated format (already grouped by VTE as a single slice).
         if let Some(color_seq) = SgrColorSequence::parse_from_raw_slice(param_slice) {
-            performer.ofs_buf.apply_extended_color_sequence(color_seq);
+            performer
+                .ofs_buf_vt_100
+                .apply_extended_color_sequence(color_seq);
             idx += 1;
             continue;
         }
@@ -284,7 +286,9 @@ fn try_parse_semicolon_extended_color(
             } else {
                 SgrColorSequence::SetBackgroundAnsi256(index as u8)
             };
-            performer.ofs_buf.apply_extended_color_sequence(color_seq);
+            performer
+                .ofs_buf_vt_100
+                .apply_extended_color_sequence(color_seq);
             Some(3) // Consumed: [38/48], [5], [index]
         }
         SGR_COLOR_MODE_RGB => {
@@ -301,7 +305,9 @@ fn try_parse_semicolon_extended_color(
             } else {
                 SgrColorSequence::SetBackgroundRgb(r as u8, g as u8, b as u8)
             };
-            performer.ofs_buf.apply_extended_color_sequence(color_seq);
+            performer
+                .ofs_buf_vt_100
+                .apply_extended_color_sequence(color_seq);
             Some(5) // Consumed: [38/48], [2], [r], [g], [b]
         }
         _ => None, // Unknown mode, not an extended color.

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_terminal_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_terminal_ops.rs
@@ -3,11 +3,11 @@
 //! Terminal state operations for [`ESC`] sequences.
 //!
 //! This module acts as a thin shim layer that delegates to the actual implementation.
-//! Refer to the module-level documentation in the operations module for details on the
+//! Refer to the module-level documentation in the ops module for details on the
 //! "shim → impl → test" architecture and naming conventions.
 //!
 //! **Related Files:**
-//! - **Implementation**: [`impl_terminal_ops`] - Business logic with unit tests
+//! - **Implementation**: [`vt_100_impl_terminal_ops`] - Business logic with unit tests
 //! - **Integration Tests**: [`test_terminal_ops`] - Full pipeline testing via public API
 //!
 //! # Testing Strategy
@@ -20,7 +20,7 @@
 //! - **Integration tests** in the conformance tests validating the full pipeline
 //!
 //! For the complete testing philosophy and rationale behind this approach,
-//! see the [operations module].
+//! see the [ops module].
 //!
 //! # Architecture Overview
 //!
@@ -51,25 +51,27 @@
 //! [`cursor_ops`] functions to maintain consistency with `CSI` equivalents (`CSI s`/`CSI
 //! u`).
 //!
-//! [`cursor_ops`]: crate::vt_100_pty_output_parser::operations::vt_100_shim_cursor_ops
+//! [`cursor_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops::vt_100_shim_cursor_ops
 //! [`ESC`]: crate::EscSequence
-//! [`impl_terminal_ops`]: crate::vt_100_ansi_impl::vt_100_impl_terminal_ops
 //! [`test_terminal_ops`]: crate::vt_100_pty_output_conformance_tests::tests::vt_100_test_terminal_ops
+//! [`vt_100_impl_terminal_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_terminal_ops
 //! [module-level Architecture Overview]: super#architecture-overview
 //! [module-level documentation]: self
-//! [operations module]: crate::core::ansi::vt_100_pty_output_parser::operations
+//! [ops module]: crate::core::ansi::vt_100_pty_output_parser::ops
 
 use super::super::ansi_parser_public_api::AnsiToOfsBufPerformer;
 use crate::{Pos, TuiStyle};
 
 /// Clears all buffer content.
-fn clear_buffer(performer: &mut AnsiToOfsBufPerformer) { performer.ofs_buf.clear(); }
+fn clear_buffer(performer: &mut AnsiToOfsBufPerformer) {
+    performer.ofs_buf_vt_100.clear();
+}
 
 /// Reset all [`SGR`] attributes to default state.
 ///
 /// [`SGR`]: crate::SgrCode
 fn reset_sgr_attributes(performer: &mut AnsiToOfsBufPerformer) {
-    performer.ofs_buf.ansi_parser_support.current_style = TuiStyle::default();
+    performer.ofs_buf_vt_100.parser_global_state.current_style = TuiStyle::default();
 }
 
 /// Reset terminal to initial state (`ESC c`).
@@ -81,20 +83,26 @@ pub fn reset_terminal(performer: &mut AnsiToOfsBufPerformer) {
     clear_buffer(performer);
 
     // Reset cursor to home position.
-    performer.ofs_buf.cursor_pos = Pos::default();
+    performer.ofs_buf_vt_100.cursor_pos = Pos::default();
 
     // Clear saved cursor state.
     performer
-        .ofs_buf
-        .ansi_parser_support
+        .ofs_buf_vt_100
+        .parser_global_state
         .cursor_pos_for_esc_save_and_restore = None;
 
     // Reset to ASCII character set.
     select_ascii_character_set(performer);
 
     // Clear DECSTBM scroll region margins.
-    performer.ofs_buf.ansi_parser_support.scroll_region_top = None;
-    performer.ofs_buf.ansi_parser_support.scroll_region_bottom = None;
+    performer
+        .ofs_buf_vt_100
+        .parser_global_state
+        .scroll_region_top = None;
+    performer
+        .ofs_buf_vt_100
+        .parser_global_state
+        .scroll_region_bottom = None;
 
     // Clear any `SGR` attributes.
     reset_sgr_attributes(performer);
@@ -105,7 +113,7 @@ pub fn reset_terminal(performer: &mut AnsiToOfsBufPerformer) {
 ///
 /// [`ASCII`]: https://en.wikipedia.org/wiki/ASCII
 pub fn select_ascii_character_set(performer: &mut AnsiToOfsBufPerformer) {
-    performer.ofs_buf.select_ascii_character_set();
+    performer.ofs_buf_vt_100.select_ascii_character_set();
 }
 
 /// Select [`DEC`] Special Graphics character set (`ESC ( 0`).
@@ -113,5 +121,5 @@ pub fn select_ascii_character_set(performer: &mut AnsiToOfsBufPerformer) {
 ///
 /// [`DEC`]: https://en.wikipedia.org/wiki/Digital_Equipment_Corporation
 pub fn select_dec_graphics_character_set(performer: &mut AnsiToOfsBufPerformer) {
-    performer.ofs_buf.select_dec_graphics_character_set();
+    performer.ofs_buf_vt_100.select_dec_graphics_character_set();
 }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/mod.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/mod.rs
@@ -1,28 +1,28 @@
 // Copyright (c) 2025 R3BL LLC. Licensed under Apache License, Version 2.0.
 
-//! VT100/[`ANSI`] terminal operation implementations for `OffscreenBuffer`.
+//! VT100/[`ANSI`] terminal operation implementations for [`OfsBufVT100`].
 //!
 //! This module contains the actual implementations of VT100 and [`ANSI`] escape sequence
-//! operations that are delegated from the `vt_100_pty_output_parser::operations` module.
-//! The structure mirrors `vt_100_pty_output_parser/operations/` to provide a clear 1:1
-//! mapping between the parser shim layer and the implementation layer.
+//! operations that are delegated from the [`vt_100_pty_output_parser::ops`]
+//! module. The structure mirrors [`vt_100_pty_output_parser/ops/`] to provide a
+//! clear 1:1 mapping between the parser shim layer and the implementation layer.
 //!
 //! # Architecture
 //!
 //! ```text
-//! vt_100_pty_output_parser/operations/vt_100_shim_char_ops <- (shim - minimal logic)
+//! vt_100_pty_output_parser/ops/vt_100_shim_char_ops <- (shim - minimal logic)
 //!           ↓ delegates to
-//! vt_100_ansi_impl/vt_100_impl_char_ops                  <- (implementation - full logic)
+//! ops_impl_ofs_buf/vt_100_impl_char_ops             <- (implementation - full logic)
 //! ```
 //!
-//! ## The `impl_` Prefix Convention
+//! ## The `vt_100_impl_` Prefix Convention
 //!
-//! All implementation files in this module use the `impl_` prefix. This deliberate
+//! All implementation files in this module use the `vt_100_impl_` prefix. This deliberate
 //! naming convention creates a searchable namespace that distinguishes implementations
 //! from their corresponding shim layers and tests. When searching for any operation
 //! (e.g., "`char_ops`"), developers can easily identify:
 //! - The shim (no prefix): Protocol translation
-//! - The implementation (`impl_` prefix): Business logic
+//! - The implementation (`vt_100_impl_` prefix): Business logic
 //! - The tests (`test_` prefix): Validation
 //!
 //! This naming pattern solves the IDE search problem by creating a predictable hierarchy
@@ -32,7 +32,7 @@
 //!
 //! # Module Organization
 //!
-//! Each file corresponds directly to a file in `vt_100_pty_output_parser/operations/`:
+//! Each file corresponds directly to a file in `vt_100_pty_output_parser/ops/`:
 //!
 //! - [`vt_100_impl_char_ops`] - Character operations (`print_char`, ICH, DCH, ECH)
 //! - [`vt_100_impl_control_ops`] - Control character handling (BS, TAB, LF, CR)
@@ -54,7 +54,8 @@
 //!
 //! ## Unit Tests in Implementation Files
 //!
-//! Each `impl_*.rs` file contains comprehensive unit tests using `#[test]` functions:
+//! Each `vt_100_impl_*.rs` file contains comprehensive unit tests using `#[test]`
+//! functions:
 //!
 //! ```text
 //! vt_100_impl_char_ops ──── Contains unit tests for:
@@ -109,6 +110,7 @@
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 //! [`DECSTBM`]: https://vt100.net/docs/vt510-rm/DECSTBM.html
+//! [`OfsBufVT100`]: crate::core::ansi::vt_100_pty_output_parser::OfsBufVT100
 //! [`vt_100_impl_ansi_scroll_helper`]: vt_100_impl_ansi_scroll_helper
 //! [`vt_100_impl_char_ops`]: vt_100_impl_char_ops
 //! [`vt_100_impl_control_ops`]: vt_100_impl_control_ops
@@ -121,14 +123,19 @@
 //! [`vt_100_impl_scroll_ops`]: vt_100_impl_scroll_ops
 //! [`vt_100_impl_sgr_ops`]: vt_100_impl_sgr_ops
 //! [`vt_100_impl_terminal_ops`]: vt_100_impl_terminal_ops
+//! [`vt_100_pty_output_parser/ops/`]: crate::core::ansi::vt_100_pty_output_parser::ops
+//! [`vt_100_pty_output_parser::ops`]: crate::core::ansi::vt_100_pty_output_parser::ops
 
 /// Standard terminal tab stop width (8 columns).
 /// Used for calculating tab positions in VT100 terminal emulation.
 /// This is a widely-adopted standard across most terminal emulators.
 pub const TAB_STOP_WIDTH: usize = 8;
 
+// Barrel Export: core struct and state.
+// (Lifted to vt_100_pty_output_parser/ofs_buf_vt_100.rs)
+
 // Attach modules - conditionally public for documentation and testing.
-// These modules contain impl blocks for OffscreenBuffer and are accessed by
+// These modules contain impl blocks for OfsBufVT100 and are accessed by
 // the parser shim layer. Making them conditionally public allows rustdoc links
 // to work while keeping them private in release builds.
 #[cfg(any(test, doc))]
@@ -198,4 +205,4 @@ pub(super) mod vt_100_impl_terminal_ops;
 
 // Note: Individual modules are accessed by the parser shim layer
 // (vt_100_pty_output_parser). No re-exports needed here since the impl blocks extend
-// OffscreenBuffer directly.
+// OfsBufVT100 directly.

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_ansi_scroll_helper.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_ansi_scroll_helper.rs
@@ -1,5 +1,5 @@
 // Copyright (c) 2025 R3BL LLC. Licensed under Apache License, Version 2.0.
-//! [`ANSI`] terminal scroll helper operations for `OffscreenBuffer`.
+//! [`ANSI`] terminal scroll helper operations for `OfsBufVT100`.
 //!
 //! This module provides helper methods for [`ANSI`] escape sequence scrolling operations,
 //! including scroll region boundary detection and row clamping within defined scroll
@@ -7,11 +7,10 @@
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 
-#[allow(clippy::wildcard_imports)]
-use super::super::*;
-use crate::{LengthOps, RowIndex, core::coordinates::bounds_check::IndexOps, row};
+use crate::{LengthOps, OfsBufVT100, RowIndex, core::coordinates::bounds_check::IndexOps,
+            row};
 
-impl OffscreenBuffer {
+impl OfsBufVT100 {
     /// Gets the scroll region as an inclusive range.
     ///
     /// Returns `RangeInclusive<RowIndex>` representing the [`VT-100`] scroll region
@@ -48,12 +47,12 @@ impl OffscreenBuffer {
     /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
     #[must_use]
     pub fn get_scroll_range_inclusive(&self) -> std::ops::RangeInclusive<RowIndex> {
-        let scroll_top = self.ansi_parser_support.scroll_region_top.map_or(
+        let scroll_top = self.parser_global_state.scroll_region_top.map_or(
             /* None */ row(0),
             /* Some */ |term_row| term_row.to_zero_based(),
         );
 
-        let scroll_bottom = self.ansi_parser_support.scroll_region_bottom.map_or(
+        let scroll_bottom = self.parser_global_state.scroll_region_bottom.map_or(
             /* None */ self.window_size.row_height.convert_to_index(),
             /* Some */ |term_row| term_row.to_zero_based(),
         );
@@ -101,12 +100,12 @@ impl OffscreenBuffer {
 #[cfg(test)]
 mod tests_bounds_check_ops {
     use super::*;
-    use crate::{height, term_row, width,
+    use crate::{OfsBufVT100, height, term_row, width,
                 core::ansi::vt_100_pty_output_conformance_tests::test_fixtures_vt_100_ansi_conformance::nz};
 
-    fn create_test_buffer() -> OffscreenBuffer {
+    fn create_test_buffer() -> OfsBufVT100 {
         let size = width(10) + height(6);
-        OffscreenBuffer::new_empty(size)
+        OfsBufVT100::new_empty(size)
     }
 
     #[test]
@@ -124,7 +123,7 @@ mod tests_bounds_check_ops {
         let mut buffer = create_test_buffer();
 
         // Set scroll region top to row 3 (1-based) = row 2 (0-based)
-        buffer.ansi_parser_support.scroll_region_top = Some(term_row(nz(3)));
+        buffer.parser_global_state.scroll_region_top = Some(term_row(nz(3)));
 
         // Should return [2, 5] (top boundary to end of buffer)
         let range = buffer.get_scroll_range_inclusive();
@@ -137,7 +136,7 @@ mod tests_bounds_check_ops {
         let mut buffer = create_test_buffer();
 
         // Set scroll region bottom to row 4 (1-based) = row 3 (0-based)
-        buffer.ansi_parser_support.scroll_region_bottom = Some(term_row(nz(4)));
+        buffer.parser_global_state.scroll_region_bottom = Some(term_row(nz(4)));
 
         // Should return [0, 3] (start of buffer to bottom boundary)
         let range = buffer.get_scroll_range_inclusive();
@@ -150,8 +149,8 @@ mod tests_bounds_check_ops {
         let mut buffer = create_test_buffer();
 
         // Set scroll region from row 2 to row 4 (1-based: 3 to 5)
-        buffer.ansi_parser_support.scroll_region_top = Some(term_row(nz(3)));
-        buffer.ansi_parser_support.scroll_region_bottom = Some(term_row(nz(5)));
+        buffer.parser_global_state.scroll_region_top = Some(term_row(nz(3)));
+        buffer.parser_global_state.scroll_region_bottom = Some(term_row(nz(5)));
 
         // Should return [2, 4] (0-based)
         let range = buffer.get_scroll_range_inclusive();
@@ -164,8 +163,8 @@ mod tests_bounds_check_ops {
         let mut buffer = create_test_buffer();
 
         // Set scroll region from row 2 to row 4 (1-based: 3 to 5)
-        buffer.ansi_parser_support.scroll_region_top = Some(term_row(nz(3)));
-        buffer.ansi_parser_support.scroll_region_bottom = Some(term_row(nz(5)));
+        buffer.parser_global_state.scroll_region_top = Some(term_row(nz(3)));
+        buffer.parser_global_state.scroll_region_bottom = Some(term_row(nz(5)));
 
         let range = buffer.get_scroll_range_inclusive();
 
@@ -190,8 +189,8 @@ mod tests_bounds_check_ops {
         let mut buffer = create_test_buffer();
 
         // Set scroll region from row 2 to row 4 (1-based: 3 to 5)
-        buffer.ansi_parser_support.scroll_region_top = Some(term_row(nz(3)));
-        buffer.ansi_parser_support.scroll_region_bottom = Some(term_row(nz(5)));
+        buffer.parser_global_state.scroll_region_top = Some(term_row(nz(3)));
+        buffer.parser_global_state.scroll_region_bottom = Some(term_row(nz(5)));
 
         // Row 3 (0-based) is within the scroll region
         assert_eq!(buffer.clamp_row_to_scroll_region(row(3)), row(3));
@@ -202,8 +201,8 @@ mod tests_bounds_check_ops {
         let mut buffer = create_test_buffer();
 
         // Set scroll region from row 2 to row 4 (1-based: 3 to 5)
-        buffer.ansi_parser_support.scroll_region_top = Some(term_row(nz(3)));
-        buffer.ansi_parser_support.scroll_region_bottom = Some(term_row(nz(5)));
+        buffer.parser_global_state.scroll_region_top = Some(term_row(nz(3)));
+        buffer.parser_global_state.scroll_region_bottom = Some(term_row(nz(5)));
 
         // Row 0 is above scroll region - should be clamped to top (row 2)
         assert_eq!(buffer.clamp_row_to_scroll_region(row(0)), row(2));
@@ -214,8 +213,8 @@ mod tests_bounds_check_ops {
         let mut buffer = create_test_buffer();
 
         // Set scroll region from row 2 to row 4 (1-based: 3 to 5)
-        buffer.ansi_parser_support.scroll_region_top = Some(term_row(nz(3)));
-        buffer.ansi_parser_support.scroll_region_bottom = Some(term_row(nz(5)));
+        buffer.parser_global_state.scroll_region_top = Some(term_row(nz(3)));
+        buffer.parser_global_state.scroll_region_bottom = Some(term_row(nz(5)));
 
         // Row 5 is below scroll region - should be clamped to bottom (row 4)
         assert_eq!(buffer.clamp_row_to_scroll_region(row(5)), row(4));

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_char_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_char_ops.rs
@@ -5,7 +5,7 @@
 //! Character operations for VT100/[`ANSI`] terminal emulation.
 //!
 //! This module implements character-level operations that correspond to [`ANSI`] escape
-//! sequences handled by the `vt_100_pty_output_parser/operations/vt_100_shim_char_ops`
+//! sequences handled by the `vt_100_pty_output_parser/ops/vt_100_shim_char_ops`
 //! shim. These include:
 //!
 //! - **ICH** (Insert Character) - [`insert_chars_at_cursor`]
@@ -25,20 +25,20 @@
 //! **Related Files:**
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
-//! [`delete_chars_at_cursor`]: crate::OffscreenBuffer::delete_chars_at_cursor
-//! [`erase_chars_at_cursor`]: crate::OffscreenBuffer::erase_chars_at_cursor
-//! [`insert_chars_at_cursor`]: crate::OffscreenBuffer::insert_chars_at_cursor
-//! [`print_char`]: crate::OffscreenBuffer::print_char
+//! [`delete_chars_at_cursor`]: crate::OfsBufVT100::delete_chars_at_cursor
+//! [`erase_chars_at_cursor`]: crate::OfsBufVT100::erase_chars_at_cursor
+//! [`insert_chars_at_cursor`]: crate::OfsBufVT100::insert_chars_at_cursor
+//! [`print_char`]: crate::OfsBufVT100::print_char
 
 #[allow(clippy::wildcard_imports)]
 use super::super::*;
-use crate::{ArrayBoundsCheck, ArrayOverflowResult, AutoWrapState, ColIndex, Length, NumericValue,
-            RowIndex, col,
+use crate::{ArrayBoundsCheck, ArrayOverflowResult, AutoWrapState, ColIndex, Length,
+            NumericValue, OfsBufVT100, PixelChar, RowIndex, col,
             core::coordinates::bounds_check::{CursorBoundsCheck, LengthOps,
                                               RangeBoundsExt, RangeConvertExt},
             height, ok, width};
 
-impl OffscreenBuffer {
+impl OfsBufVT100 {
     /// Insert blank characters at cursor position (for ICH - Insert Character).
     /// Characters at and after the cursor shift right by `how_many`.
     /// Characters that would shift beyond the line width are lost.
@@ -311,7 +311,7 @@ impl OffscreenBuffer {
     /// [`DEC`]: https://en.wikipedia.org/wiki/Digital_Equipment_Corporation
     pub fn print_char(&mut self, ch: char) -> miette::Result<()> {
         // Apply character set translation if in graphics mode.
-        let display_char = match self.ansi_parser_support.character_set {
+        let display_char = match self.parser_global_state.character_set {
             CharacterSet::DECGraphics => Self::translate_dec_graphics(ch),
             CharacterSet::Ascii => ch,
         };
@@ -325,11 +325,12 @@ impl OffscreenBuffer {
         if current_row.overflows(row_max) == ArrayOverflowResult::Within
             && current_col.overflows(col_max) == ArrayOverflowResult::Within
         {
+            let current_style = self.parser_global_state.current_style;
             let result = self.set_char(
                 current_row + current_col,
                 PixelChar::PlainText {
                     display_char, // Use the translated character
-                    style: self.ansi_parser_support.current_style,
+                    style: current_style,
                 },
             );
             if result.is_err() {
@@ -341,7 +342,7 @@ impl OffscreenBuffer {
 
             // Handle line wrap based on DECAWM (Auto Wrap Mode).
             if new_col.overflows(col_max) == ArrayOverflowResult::Overflowed {
-                if self.ansi_parser_support.auto_wrap_mode == AutoWrapState::Enabled {
+                if self.parser_global_state.auto_wrap_mode == AutoWrapState::Enabled {
                     // DECAWM enabled: wrap to next line (default behavior).
                     self.cursor_pos.col_index = col(0);
                     let next_row: RowIndex = current_row + 1;
@@ -364,18 +365,18 @@ impl OffscreenBuffer {
 #[cfg(test)]
 mod tests_shifting_ops {
     use super::*;
-    use crate::{TuiStyle, len, row,
+    use crate::{OfsBufVT100, TuiStyle, len, row,
                 test_fixtures_ofs_buf::{create_plain_test_char,
-                                        create_test_buffer_with_size}};
+                                        create_vt100_test_buffer_with_size}};
 
-    fn create_test_buffer() -> OffscreenBuffer {
-        create_test_buffer_with_size(width(6), height(3))
+    fn create_test_buffer() -> OfsBufVT100 {
+        create_vt100_test_buffer_with_size(width(6), height(3))
     }
 
     fn create_test_char(ch: char) -> PixelChar { create_plain_test_char(ch) }
 
     fn setup_line_with_chars(
-        buffer: &mut OffscreenBuffer,
+        buffer: &mut OfsBufVT100,
         test_row: RowIndex,
         chars: &[char],
     ) {
@@ -733,7 +734,7 @@ mod tests_shifting_ops {
         }
 
         let size = width(10) + height(3);
-        let mut buffer = OffscreenBuffer::new_empty(size);
+        let mut buffer = OfsBufVT100::new_empty(size);
         let test_row = row(0);
 
         // Set up initial line with characters: "ABCDEFGHIJ".
@@ -841,7 +842,7 @@ mod tests_shifting_ops {
         }
 
         let size = width(5) + height(2);
-        let mut buffer = OffscreenBuffer::new_empty(size);
+        let mut buffer = OfsBufVT100::new_empty(size);
         let test_row = row(0);
 
         // Set up initial line with characters: "ABCDE".
@@ -1018,11 +1019,11 @@ mod tests_shifting_ops {
 #[cfg(test)]
 mod tests_print_char {
     use super::*;
-    use crate::{row, test_fixtures_ofs_buf::create_test_buffer_with_size};
+    use crate::{row, test_fixtures_ofs_buf::create_vt100_test_buffer_with_size};
 
     #[test]
     fn test_print_char_basic() {
-        let mut buffer = create_test_buffer_with_size(width(10), height(5));
+        let mut buffer = create_vt100_test_buffer_with_size(width(10), height(5));
 
         // Set cursor position.
         buffer.cursor_pos = row(1) + col(2);
@@ -1043,10 +1044,10 @@ mod tests_print_char {
 
     #[test]
     fn test_print_char_dec_graphics_mode() {
-        let mut buffer = create_test_buffer_with_size(width(10), height(5));
+        let mut buffer = create_vt100_test_buffer_with_size(width(10), height(5));
 
         // Set DEC graphics character set.
-        buffer.ansi_parser_support.character_set = CharacterSet::DECGraphics;
+        buffer.parser_global_state.character_set = CharacterSet::DECGraphics;
 
         buffer.cursor_pos = row(0) + col(0);
 
@@ -1063,10 +1064,10 @@ mod tests_print_char {
 
     #[test]
     fn test_print_char_line_wrap() {
-        let mut buffer = create_test_buffer_with_size(width(5), height(3));
+        let mut buffer = create_vt100_test_buffer_with_size(width(5), height(3));
 
         // Ensure DECAWM is enabled (default).
-        buffer.ansi_parser_support.auto_wrap_mode = AutoWrapState::Enabled;
+        buffer.parser_global_state.auto_wrap_mode = AutoWrapState::Enabled;
 
         // Position cursor at end of line (column 4 in 5-width buffer).
         buffer.cursor_pos = row(1) + col(4);

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_clear_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_clear_ops.rs
@@ -1,11 +1,11 @@
 // Copyright (c) 2025 R3BL LLC. Licensed under Apache License, Version 2.0.
 
 use crate::{ArrayBoundsCheck as _, ArrayOverflowResult, CursorBoundsCheck as _,
-            OffscreenBuffer, PixelChar, RangeBoundsExt as _, RangeExt as _,
+            OfsBufVT100, PixelChar, RangeBoundsExt as _, RangeExt as _,
             glyphs::SPACER_GLYPH_CHAR, height, ok, row, width};
 use std::cmp::min;
 
-impl OffscreenBuffer {
+impl OfsBufVT100 {
     /// Creates a pixel character configured for erasing, using the current active
     /// background style according to [`VT-100`] specifications.
     ///
@@ -14,7 +14,7 @@ impl OffscreenBuffer {
     pub fn create_empty_pixel_char(&self) -> PixelChar {
         PixelChar::PlainText {
             display_char: SPACER_GLYPH_CHAR,
-            style: self.ansi_parser_support.current_style,
+            style: self.parser_global_state.current_style,
         }
     }
 
@@ -308,15 +308,15 @@ impl OffscreenBuffer {
 
 #[cfg(test)]
 mod tests {
-    use crate::{OffscreenBuffer, PixelChar, TuiStyle, col, height, row, width};
+    use crate::{OfsBufVT100, PixelChar, TuiStyle, col, height, row, width};
 
-    fn create_test_buffer() -> OffscreenBuffer {
-        let mut buf = OffscreenBuffer::new_empty(height(3) + width(4));
+    fn create_test_buffer() -> OfsBufVT100 {
+        let mut buf = OfsBufVT100::new_empty(height(3) + width(4));
         let style = TuiStyle {
             id: None,
             ..Default::default()
         };
-        buf.ansi_parser_support.current_style = style;
+        buf.parser_global_state.current_style = style;
 
         let char_x = PixelChar::PlainText {
             display_char: 'x',

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_control_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_control_ops.rs
@@ -3,7 +3,7 @@
 //! Control character operations for VT100/[`ANSI`] terminal emulation.
 //!
 //! This module implements control character handling that corresponds to [`ANSI`] control
-//! sequences handled by the `vt_100_pty_output_parser::operations::control_ops` module.
+//! sequences handled by the `vt_100_pty_output_parser::ops::control_ops` module.
 //! These include:
 //!
 //! - **BS** (Backspace) - [`handle_backspace`]
@@ -22,17 +22,16 @@
 //! **Related Files:**
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
-//! [`handle_backspace`]: crate::OffscreenBuffer::handle_backspace
-//! [`handle_carriage_return`]: crate::OffscreenBuffer::handle_carriage_return
-//! [`handle_line_feed`]: crate::OffscreenBuffer::handle_line_feed
-//! [`handle_tab`]: crate::OffscreenBuffer::handle_tab
+//! [`handle_backspace`]: crate::OfsBufVT100::handle_backspace
+//! [`handle_carriage_return`]: crate::OfsBufVT100::handle_carriage_return
+//! [`handle_line_feed`]: crate::OfsBufVT100::handle_line_feed
+//! [`handle_tab`]: crate::OfsBufVT100::handle_tab
 
-#[allow(clippy::wildcard_imports)]
-use super::super::*;
 use super::TAB_STOP_WIDTH;
-use crate::{ArrayBoundsCheck, ArrayOverflowResult, LengthOps, NumericValue, col};
+use crate::{ArrayBoundsCheck, ArrayOverflowResult, LengthOps, NumericValue, OfsBufVT100,
+            col};
 
-impl OffscreenBuffer {
+impl OfsBufVT100 {
     /// Handles backspace control character (0x08).
     /// Moves cursor left one position if not at leftmost column.
     pub fn handle_backspace(&mut self) {
@@ -79,11 +78,11 @@ impl OffscreenBuffer {
 #[cfg(test)]
 mod tests_control_ops {
     use super::*;
-    use crate::{height, row, width};
+    use crate::{OfsBufVT100, height, row, width};
 
-    fn create_test_buffer() -> OffscreenBuffer {
+    fn create_test_buffer() -> OfsBufVT100 {
         let size = width(10) + height(6);
-        OffscreenBuffer::new_empty(size)
+        OfsBufVT100::new_empty(size)
     }
 
     #[test]

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_cursor_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_cursor_ops.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2025 R3BL LLC. Licensed under Apache License, Version 2.0.
 
-//! [`ANSI`] cursor movement operations for `OffscreenBuffer`.
+//! [`ANSI`] cursor movement operations for `OfsBufVT100`.
 //!
 //! This module provides methods for moving the cursor position within the buffer,
 //! handling boundary conditions, scroll regions, and cursor state management
@@ -15,12 +15,10 @@
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 
-#[allow(clippy::wildcard_imports)]
-use super::super::*;
-use crate::{ColIndex, ColWidth, Pos, RowHeight, RowIndex, col,
+use crate::{ColIndex, ColWidth, OfsBufVT100, Pos, RowHeight, RowIndex, col,
             core::coordinates::bounds_check::IndexOps};
 
-impl OffscreenBuffer {
+impl OfsBufVT100 {
     /// Move cursor up by n lines.
     /// Respects [`DECSTBM`] scroll region margins.
     ///
@@ -148,14 +146,14 @@ impl OffscreenBuffer {
 
     /// Save current cursor position for later restoration.
     pub fn save_cursor_position(&mut self) {
-        self.ansi_parser_support.cursor_pos_for_esc_save_and_restore =
+        self.parser_global_state.cursor_pos_for_esc_save_and_restore =
             Some(self.cursor_pos);
     }
 
     /// Restore previously saved cursor position.
     pub fn restore_cursor_position(&mut self) {
         if let Some(saved_pos) =
-            self.ansi_parser_support.cursor_pos_for_esc_save_and_restore
+            self.parser_global_state.cursor_pos_for_esc_save_and_restore
         {
             self.cursor_pos = saved_pos;
         }
@@ -173,11 +171,11 @@ impl OffscreenBuffer {
 #[cfg(test)]
 mod tests_cursor_ops {
     use super::*;
-    use crate::{height, row, width};
+    use crate::{OfsBufVT100, height, row, width};
 
-    fn create_test_buffer() -> OffscreenBuffer {
+    fn create_test_buffer() -> OfsBufVT100 {
         let size = width(10) + height(6);
-        OffscreenBuffer::new_empty(size)
+        OfsBufVT100::new_empty(size)
     }
 
     #[test]

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_dsr_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_dsr_ops.rs
@@ -3,7 +3,7 @@
 //! Device Status Report ([`DSR`]) operations for VT100/[`ANSI`] terminal emulation.
 //!
 //! This module implements [`DSR`] operations that correspond to [`ANSI`] [`DSR`]
-//! sequences handled by the `vt_100_pty_output_parser::operations::dsr_ops` module. These
+//! sequences handled by the `vt_100_pty_output_parser::ops::dsr_ops` module. These
 //! include:
 //!
 //! - **[`DSR`] 5** (Device Status Report) - [`handle_status_report_request`]
@@ -21,21 +21,19 @@
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 //! [`DSR`]: crate::DsrSequence
-//! [`handle_cursor_position_request`]: crate::OffscreenBuffer::handle_cursor_position_request
-//! [`handle_status_report_request`]: crate::OffscreenBuffer::handle_status_report_request
+//! [`handle_cursor_position_request`]: crate::OfsBufVT100::handle_cursor_position_request
+//! [`handle_status_report_request`]: crate::OfsBufVT100::handle_status_report_request
 //! [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
 
-#[allow(clippy::wildcard_imports)]
-use super::super::*;
-use crate::{DsrRequestFromPtyEvent, TermCol, TermRow};
+use crate::{DsrRequestFromPtyEvent, OfsBufVT100, TermCol, TermRow};
 
-impl OffscreenBuffer {
+impl OfsBufVT100 {
     /// Handles device status report request.
     /// Queues a response indicating terminal is OK ([`ESC`][0n).
     ///
     /// [`ESC`]: crate::EscSequence
     pub fn handle_status_report_request(&mut self) {
-        self.ansi_parser_support
+        self.parser_global_state
             .pending_dsr_responses
             .push(DsrRequestFromPtyEvent::TerminalStatus);
     }
@@ -50,7 +48,7 @@ impl OffscreenBuffer {
         // Uses type-safe From<RowIndex>/From<ColIndex> conversions.
         let row = TermRow::from(self.cursor_pos.row_index);
         let col = TermCol::from(self.cursor_pos.col_index);
-        self.ansi_parser_support
+        self.parser_global_state
             .pending_dsr_responses
             .push(DsrRequestFromPtyEvent::CursorPosition { row, col });
     }
@@ -59,11 +57,11 @@ impl OffscreenBuffer {
 #[cfg(test)]
 mod tests_dsr_ops {
     use super::*;
-    use crate::{col, height, row, width};
+    use crate::{OfsBufVT100, col, height, row, width};
 
-    fn create_test_buffer() -> OffscreenBuffer {
+    fn create_test_buffer() -> OfsBufVT100 {
         let size = width(10) + height(6);
-        OffscreenBuffer::new_empty(size)
+        OfsBufVT100::new_empty(size)
     }
 
     #[test]
@@ -71,14 +69,14 @@ mod tests_dsr_ops {
         let mut buffer = create_test_buffer();
 
         // Initially no pending responses.
-        assert!(buffer.ansi_parser_support.pending_dsr_responses.is_empty());
+        assert!(buffer.parser_global_state.pending_dsr_responses.is_empty());
 
         buffer.handle_status_report_request();
 
         // Should have one terminal status response.
-        assert_eq!(buffer.ansi_parser_support.pending_dsr_responses.len(), 1);
+        assert_eq!(buffer.parser_global_state.pending_dsr_responses.len(), 1);
         assert!(matches!(
-            buffer.ansi_parser_support.pending_dsr_responses[0],
+            buffer.parser_global_state.pending_dsr_responses[0],
             DsrRequestFromPtyEvent::TerminalStatus
         ));
     }
@@ -91,9 +89,9 @@ mod tests_dsr_ops {
         buffer.handle_cursor_position_request();
 
         // Should have one cursor position response.
-        assert_eq!(buffer.ansi_parser_support.pending_dsr_responses.len(), 1);
+        assert_eq!(buffer.parser_global_state.pending_dsr_responses.len(), 1);
         if let DsrRequestFromPtyEvent::CursorPosition { row, col } =
-            &buffer.ansi_parser_support.pending_dsr_responses[0]
+            &buffer.parser_global_state.pending_dsr_responses[0]
         {
             // 0-based internal (2,5) becomes 1-based terminal (3,6)
             assert_eq!(row.as_u16(), 3);
@@ -111,13 +109,13 @@ mod tests_dsr_ops {
         buffer.handle_cursor_position_request();
 
         // Should have both responses queued.
-        assert_eq!(buffer.ansi_parser_support.pending_dsr_responses.len(), 2);
+        assert_eq!(buffer.parser_global_state.pending_dsr_responses.len(), 2);
         assert!(matches!(
-            buffer.ansi_parser_support.pending_dsr_responses[0],
+            buffer.parser_global_state.pending_dsr_responses[0],
             DsrRequestFromPtyEvent::TerminalStatus
         ));
         assert!(matches!(
-            buffer.ansi_parser_support.pending_dsr_responses[1],
+            buffer.parser_global_state.pending_dsr_responses[1],
             DsrRequestFromPtyEvent::CursorPosition { .. }
         ));
     }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_line_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_line_ops.rs
@@ -53,18 +53,19 @@
 //! the scroll region, the operation is skipped entirely.
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
-//! [`clear_line()`]: crate::OffscreenBuffer::clear_line
-//! [`shift_lines_down()`]: crate::OffscreenBuffer::shift_lines_down
-//! [`shift_lines_up()`]: crate::OffscreenBuffer::shift_lines_up
+//! [`clear_line()`]: crate::OfsBufVT100::clear_line
+//! [`shift_lines_down()`]: crate::OfsBufVT100::shift_lines_down
+//! [`shift_lines_up()`]: crate::OfsBufVT100::shift_lines_up
 //! [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
 //! [Interval Notation]: crate::bounds_check#interval-notation
 
-use crate::{Length, OffscreenBuffer, PixelChar, RowHeight, RowIndex,
+use crate::{Length, OfsBufVT100, PixelChar, RowHeight, RowIndex,
             core::coordinates::bounds_check::{RangeBoundsExt, RangeBoundsResult,
-                                              RangeConvertExt}, ok};
+                                              RangeConvertExt},
+            ok};
 use std::ops::Range;
 
-impl OffscreenBuffer {
+impl OfsBufVT100 {
     /// Clear an entire line by filling it with blank characters.
     /// Returns true if the operation was successful.
     ///
@@ -282,14 +283,14 @@ impl OffscreenBuffer {
 #[cfg(test)]
 mod tests_line_ops {
     use super::*;
-    use crate::{PixelCharLine, TermRow, col, height, len, row,
+    use crate::{OfsBufVT100, PixelCharLine, TermRow, col, height, len, row,
                 test_fixtures_ofs_buf::{create_plain_test_char,
-                                        create_test_buffer_with_size,
-                                        create_test_line_with_chars},
+                                        create_test_line_with_chars,
+                                        create_vt100_test_buffer_with_size},
                 width};
 
-    fn create_test_buffer() -> OffscreenBuffer {
-        create_test_buffer_with_size(width(4), height(5))
+    fn create_test_buffer() -> OfsBufVT100 {
+        create_vt100_test_buffer_with_size(width(4), height(5))
     }
 
     fn create_test_char(ch: char) -> PixelChar { create_plain_test_char(ch) }
@@ -422,8 +423,8 @@ mod tests_line_ops {
         let mut buffer = create_test_buffer();
 
         // Set scroll region to rows 1-3 (inclusive).
-        buffer.ansi_parser_support.scroll_region_top = Some(TermRow::from(row(1)));
-        buffer.ansi_parser_support.scroll_region_bottom = Some(TermRow::from(row(3)));
+        buffer.parser_global_state.scroll_region_top = Some(TermRow::from(row(1)));
+        buffer.parser_global_state.scroll_region_bottom = Some(TermRow::from(row(3)));
 
         // Set up initial lines.
         let _unused = buffer.set_line(row(1), create_test_line(&['A', 'A', 'A', 'A']));
@@ -451,8 +452,8 @@ mod tests_line_ops {
         let mut buffer = create_test_buffer();
 
         // Set scroll region to rows 1-3 (inclusive).
-        buffer.ansi_parser_support.scroll_region_top = Some(TermRow::from(row(1)));
-        buffer.ansi_parser_support.scroll_region_bottom = Some(TermRow::from(row(3)));
+        buffer.parser_global_state.scroll_region_top = Some(TermRow::from(row(1)));
+        buffer.parser_global_state.scroll_region_bottom = Some(TermRow::from(row(3)));
 
         // Set up initial lines.
         let _unused = buffer.set_line(row(0), create_test_line(&['X', 'X', 'X', 'X']));
@@ -484,8 +485,8 @@ mod tests_line_ops {
         let mut buffer = create_test_buffer();
 
         // Set scroll region to rows 1-3 (inclusive).
-        buffer.ansi_parser_support.scroll_region_top = Some(TermRow::from(row(1)));
-        buffer.ansi_parser_support.scroll_region_bottom = Some(TermRow::from(row(3)));
+        buffer.parser_global_state.scroll_region_top = Some(TermRow::from(row(1)));
+        buffer.parser_global_state.scroll_region_bottom = Some(TermRow::from(row(3)));
 
         // Set up initial lines.
         let _unused = buffer.set_line(row(1), create_test_line(&['A', 'A', 'A', 'A']));
@@ -513,8 +514,8 @@ mod tests_line_ops {
         let mut buffer = create_test_buffer();
 
         // Set scroll region to rows 1-3 (inclusive).
-        buffer.ansi_parser_support.scroll_region_top = Some(TermRow::from(row(1)));
-        buffer.ansi_parser_support.scroll_region_bottom = Some(TermRow::from(row(3)));
+        buffer.parser_global_state.scroll_region_top = Some(TermRow::from(row(1)));
+        buffer.parser_global_state.scroll_region_bottom = Some(TermRow::from(row(3)));
 
         // Set up initial lines.
         let _unused = buffer.set_line(row(0), create_test_line(&['X', 'X', 'X', 'X']));
@@ -546,8 +547,8 @@ mod tests_line_ops {
         let mut buffer = create_test_buffer();
 
         // Set scroll region to rows 0-4 (entire buffer).
-        buffer.ansi_parser_support.scroll_region_top = Some(TermRow::from(row(0)));
-        buffer.ansi_parser_support.scroll_region_bottom = Some(TermRow::from(row(4)));
+        buffer.parser_global_state.scroll_region_top = Some(TermRow::from(row(0)));
+        buffer.parser_global_state.scroll_region_bottom = Some(TermRow::from(row(4)));
 
         // Set up initial lines.
         let _unused = buffer.set_line(row(0), create_test_line(&['A', 'A', 'A', 'A']));
@@ -582,8 +583,8 @@ mod tests_line_ops {
         let mut buffer = create_test_buffer();
 
         // Set scroll region to rows 0-4 (entire buffer).
-        buffer.ansi_parser_support.scroll_region_top = Some(TermRow::from(row(0)));
-        buffer.ansi_parser_support.scroll_region_bottom = Some(TermRow::from(row(4)));
+        buffer.parser_global_state.scroll_region_top = Some(TermRow::from(row(0)));
+        buffer.parser_global_state.scroll_region_bottom = Some(TermRow::from(row(4)));
 
         // Set up initial lines.
         let _unused = buffer.set_line(row(0), create_test_line(&['A', 'A', 'A', 'A']));

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_margin_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_margin_ops.rs
@@ -3,7 +3,7 @@
 //! Scroll margin operations for VT100/[`ANSI`] terminal emulation.
 //!
 //! This module implements scroll margin operations that correspond to [`ANSI`]
-//! sequences handled by the `vt_100_pty_output_parser::operations::margin_ops` module.
+//! sequences handled by the `vt_100_pty_output_parser::ops::margin_ops` module.
 //! These include:
 //!
 //! - **[`DECSTBM`]** (Set Top and Bottom Margins) - [`set_scroll_margins`]
@@ -21,21 +21,21 @@
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 //! [`DECSTBM`]: https://vt100.net/docs/vt510-rm/DECSTBM.html
-//! [`reset_scroll_margins`]: crate::OffscreenBuffer::reset_scroll_margins
-//! [`set_scroll_margins`]: crate::OffscreenBuffer::set_scroll_margins
+//! [`reset_scroll_margins`]: crate::OfsBufVT100::reset_scroll_margins
+//! [`set_scroll_margins`]: crate::OfsBufVT100::set_scroll_margins
 
 #[allow(clippy::wildcard_imports)]
 use super::super::*;
 use crate::core::coordinates::{TermRow, bounds_check::LengthOps};
 use std::num::NonZeroU16;
 
-impl OffscreenBuffer {
+impl OfsBufVT100 {
     /// Reset scroll margins to full screen (no restrictions).
     /// This disables any active scroll region and allows operations
     /// to affect the entire buffer.
     pub fn reset_scroll_margins(&mut self) {
-        self.ansi_parser_support.scroll_region_top = None;
-        self.ansi_parser_support.scroll_region_bottom = None;
+        self.parser_global_state.scroll_region_top = None;
+        self.parser_global_state.scroll_region_bottom = None;
     }
 
     /// Set top and bottom scroll margins for the buffer.
@@ -70,22 +70,22 @@ impl OffscreenBuffer {
         debug_assert!(clamped_bottom_raw >= 1);
         let clamped_bottom_nz = unsafe { NonZeroU16::new_unchecked(clamped_bottom_raw) };
 
-        self.ansi_parser_support.scroll_region_top = Some(top);
-        self.ansi_parser_support.scroll_region_bottom =
+        self.parser_global_state.scroll_region_top = Some(top);
+        self.parser_global_state.scroll_region_bottom =
             Some(TermRow::from_raw_non_zero_value(clamped_bottom_nz));
     }
 }
 
 #[cfg(test)]
 mod tests_margin_ops {
-    use super::*;
-    use crate::{core::{ansi::vt_100_pty_output_conformance_tests::test_fixtures_vt_100_ansi_conformance::nz,
+
+    use crate::{OfsBufVT100, core::{ansi::vt_100_pty_output_conformance_tests::test_fixtures_vt_100_ansi_conformance::nz,
                        coordinates::term_row},
                 height, width};
 
-    fn create_test_buffer() -> OffscreenBuffer {
+    fn create_test_buffer() -> OfsBufVT100 {
         let size = width(10) + height(6);
-        OffscreenBuffer::new_empty(size)
+        OfsBufVT100::new_empty(size)
     }
 
     #[test]
@@ -93,14 +93,14 @@ mod tests_margin_ops {
         let mut buffer = create_test_buffer();
 
         // Set some margins first.
-        buffer.ansi_parser_support.scroll_region_top = Some(term_row(nz(2)));
-        buffer.ansi_parser_support.scroll_region_bottom = Some(term_row(nz(4)));
+        buffer.parser_global_state.scroll_region_top = Some(term_row(nz(2)));
+        buffer.parser_global_state.scroll_region_bottom = Some(term_row(nz(4)));
 
         buffer.reset_scroll_margins();
 
         // Should be reset to None.
-        assert!(buffer.ansi_parser_support.scroll_region_top.is_none());
-        assert!(buffer.ansi_parser_support.scroll_region_bottom.is_none());
+        assert!(buffer.parser_global_state.scroll_region_top.is_none());
+        assert!(buffer.parser_global_state.scroll_region_bottom.is_none());
     }
 
     #[test]
@@ -111,11 +111,11 @@ mod tests_margin_ops {
 
         // Check that margins were set.
         assert_eq!(
-            buffer.ansi_parser_support.scroll_region_top,
+            buffer.parser_global_state.scroll_region_top,
             Some(term_row(nz(2)))
         );
         assert_eq!(
-            buffer.ansi_parser_support.scroll_region_bottom,
+            buffer.parser_global_state.scroll_region_bottom,
             Some(term_row(nz(4)))
         );
     }
@@ -127,8 +127,8 @@ mod tests_margin_ops {
         buffer.set_scroll_margins(term_row(nz(4)), term_row(nz(2)));
 
         // Margins should remain unchanged. (None).
-        assert!(buffer.ansi_parser_support.scroll_region_top.is_none());
-        assert!(buffer.ansi_parser_support.scroll_region_bottom.is_none());
+        assert!(buffer.parser_global_state.scroll_region_top.is_none());
+        assert!(buffer.parser_global_state.scroll_region_bottom.is_none());
     }
 
     #[test]
@@ -140,11 +140,11 @@ mod tests_margin_ops {
 
         // Bottom should be clamped to buffer height.
         assert_eq!(
-            buffer.ansi_parser_support.scroll_region_top,
+            buffer.parser_global_state.scroll_region_top,
             Some(term_row(nz(2)))
         );
         assert_eq!(
-            buffer.ansi_parser_support.scroll_region_bottom,
+            buffer.parser_global_state.scroll_region_bottom,
             Some(term_row(nz(6)))
         );
     }
@@ -156,7 +156,7 @@ mod tests_margin_ops {
         buffer.set_scroll_margins(term_row(nz(3)), term_row(nz(3)));
 
         // Margins should remain unchanged.
-        assert!(buffer.ansi_parser_support.scroll_region_top.is_none());
-        assert!(buffer.ansi_parser_support.scroll_region_bottom.is_none());
+        assert!(buffer.parser_global_state.scroll_region_top.is_none());
+        assert!(buffer.parser_global_state.scroll_region_bottom.is_none());
     }
 }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_mode_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_mode_ops.rs
@@ -20,19 +20,19 @@
 //! **Related Files:**
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
-//! [`mode_ops`]: crate::vt_100_pty_output_parser::operations::vt_100_shim_mode_ops
-//! [`set_requested_auto_wrap_mode`]: crate::OffscreenBuffer::set_requested_auto_wrap_mode
+//! [`mode_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops::vt_100_shim_mode_ops
+//! [`set_requested_auto_wrap_mode`]: crate::OfsBufVT100::set_requested_auto_wrap_mode
 
 #[allow(clippy::wildcard_imports)]
 use super::super::*;
 use std::mem::swap;
 
-impl OffscreenBuffer {
+impl OfsBufVT100 {
     /// Set auto wrap mode on.
     /// When enabled, text automatically wraps to the next line when it
     /// reaches the right margin.
     pub fn set_requested_auto_wrap_mode(&mut self, requested_state: AutoWrapState) {
-        self.ansi_parser_support.auto_wrap_mode = requested_state;
+        self.parser_global_state.auto_wrap_mode = requested_state;
     }
 
     /// Set the cursor visibility mode.
@@ -44,7 +44,7 @@ impl OffscreenBuffer {
         &mut self,
         requested_state: CursorVisibilityState,
     ) {
-        self.ansi_parser_support.cursor_visibility = requested_state;
+        self.parser_global_state.cursor_visibility = requested_state;
     }
 
     /// Toggle between the primary and alternate screen buffers.
@@ -52,7 +52,7 @@ impl OffscreenBuffer {
     /// When switching to the alternate screen buffer:
     /// - Saves the primary cursor position.
     /// - Swaps the 2D grid buffers ([`self.buffer`] and
-    ///   [`self.alt_screen_support.alt_buffer`]).
+    ///   [`self.hidden_screen_state.hidden_buffer`]).
     /// - Sets the active cursor position to the saved alternate cursor position.
     /// - Clears the alternate screen buffer with cells carrying the active style to be
     ///   [`BCE`] (Background Color Erase) compliant.
@@ -67,20 +67,21 @@ impl OffscreenBuffer {
     /// [`AlternateScreenState::Active`]: crate::AlternateScreenState::Active
     /// [`AlternateScreenState::Inactive`]: crate::AlternateScreenState::Inactive
     /// [`BCE`]: https://invisible-island.net/xterm/xterm.faq.html#what_is_bce
-    /// [`self.alt_screen_support.alt_buffer`]: field@crate::AltScreenSupport::alt_buffer
-    /// [`self.buffer`]: field@crate::OffscreenBuffer::buffer
+    /// [`self.buffer`]: field@crate::OfsBufVT100::ofs_buf
+    /// [`self.hidden_screen_state.hidden_buffer`]: field@crate::HiddenScreenState::hidden_buffer
     pub fn set_alt_screen_mode(&mut self, requested_screen_mode: RequestedScreenMode) {
         match (self.terminal_mode.alternate_screen, requested_screen_mode) {
             // Transition: Primary -> Alternate Screen
             (AlternateScreenState::Inactive, RequestedScreenMode::Alternate) => {
-                // Save primary cursor.
-                self.alt_screen_support.cursor_pos_primary = self.cursor_pos;
-
-                // Swap the screen buffer grids.
-                swap(&mut self.buffer, &mut self.alt_screen_support.alt_buffer);
-
-                // Restore alternate cursor.
-                self.cursor_pos = self.alt_screen_support.cursor_pos_alt;
+                // Swap the screen buffer grids and their respective cursor positions.
+                swap(
+                    &mut self.ofs_buf.buffer,
+                    &mut self.hidden_screen_state.hidden_buffer,
+                );
+                swap(
+                    &mut self.ofs_buf.cursor_pos,
+                    &mut self.hidden_screen_state.hidden_cursor_pos,
+                );
 
                 // Update mode status.
                 self.terminal_mode.alternate_screen = AlternateScreenState::Active;
@@ -96,14 +97,15 @@ impl OffscreenBuffer {
 
             // Transition: Alternate -> Primary Screen
             (AlternateScreenState::Active, RequestedScreenMode::Primary) => {
-                // Save alternate cursor.
-                self.alt_screen_support.cursor_pos_alt = self.cursor_pos;
-
-                // Swap back to primary buffer.
-                swap(&mut self.buffer, &mut self.alt_screen_support.alt_buffer);
-
-                // Restore primary cursor.
-                self.cursor_pos = self.alt_screen_support.cursor_pos_primary;
+                // Swap the screen buffer grids and their respective cursor positions.
+                swap(
+                    &mut self.ofs_buf.buffer,
+                    &mut self.hidden_screen_state.hidden_buffer,
+                );
+                swap(
+                    &mut self.ofs_buf.cursor_pos,
+                    &mut self.hidden_screen_state.hidden_cursor_pos,
+                );
 
                 // Update mode status.
                 self.terminal_mode.alternate_screen = AlternateScreenState::Inactive;
@@ -118,11 +120,12 @@ impl OffscreenBuffer {
 #[cfg(test)]
 mod tests_mode_ops {
     use super::*;
-    use crate::{Pos, RequestedScreenMode, col, height, new_style, row, width};
+    use crate::{OfsBufVT100, Pos, RequestedScreenMode, col, height, new_style, row,
+                width};
 
-    fn create_test_buffer() -> OffscreenBuffer {
+    fn create_test_buffer() -> OfsBufVT100 {
         let size = width(10) + height(6);
-        OffscreenBuffer::new_empty(size)
+        OfsBufVT100::new_empty(size)
     }
 
     #[test]
@@ -130,10 +133,16 @@ mod tests_mode_ops {
         let mut buffer = create_test_buffer();
 
         // Initially should be enabled by default.
-        assert_eq!(buffer.ansi_parser_support.auto_wrap_mode, AutoWrapState::Enabled);
+        assert_eq!(
+            buffer.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Enabled
+        );
 
         buffer.set_requested_auto_wrap_mode(AutoWrapState::Enabled);
-        assert_eq!(buffer.ansi_parser_support.auto_wrap_mode, AutoWrapState::Enabled);
+        assert_eq!(
+            buffer.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Enabled
+        );
     }
 
     #[test]
@@ -141,7 +150,10 @@ mod tests_mode_ops {
         let mut buffer = create_test_buffer();
 
         buffer.set_requested_auto_wrap_mode(AutoWrapState::Disabled);
-        assert_eq!(buffer.ansi_parser_support.auto_wrap_mode, AutoWrapState::Disabled);
+        assert_eq!(
+            buffer.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Disabled
+        );
     }
 
     #[test]
@@ -150,15 +162,24 @@ mod tests_mode_ops {
 
         // Start enabled.
         buffer.set_requested_auto_wrap_mode(AutoWrapState::Enabled);
-        assert_eq!(buffer.ansi_parser_support.auto_wrap_mode, AutoWrapState::Enabled);
+        assert_eq!(
+            buffer.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Enabled
+        );
 
         // Disable.
         buffer.set_requested_auto_wrap_mode(AutoWrapState::Disabled);
-        assert_eq!(buffer.ansi_parser_support.auto_wrap_mode, AutoWrapState::Disabled);
+        assert_eq!(
+            buffer.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Disabled
+        );
 
         // Enable again.
         buffer.set_requested_auto_wrap_mode(AutoWrapState::Enabled);
-        assert_eq!(buffer.ansi_parser_support.auto_wrap_mode, AutoWrapState::Enabled);
+        assert_eq!(
+            buffer.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Enabled
+        );
     }
 
     #[test]
@@ -174,7 +195,7 @@ mod tests_mode_ops {
 
         // Set a styled current_style to verify BCE clearing.
         let custom_style = new_style!(bold);
-        buffer.ansi_parser_support.current_style = custom_style;
+        buffer.parser_global_state.current_style = custom_style;
 
         // Move primary cursor.
         buffer.cursor_pos = col(2) + row(3);
@@ -188,9 +209,9 @@ mod tests_mode_ops {
 
         // Cursor pos should be reset to default/alt state (0, 0).
         assert_eq!(buffer.cursor_pos, Pos::default());
-        // Saved primary cursor should be (2, 3).
+        // Saved hidden (primary) cursor should be (2, 3).
         assert_eq!(
-            buffer.alt_screen_support.cursor_pos_primary,
+            buffer.hidden_screen_state.hidden_cursor_pos,
             col(2) + row(3)
         );
 
@@ -223,8 +244,11 @@ mod tests_mode_ops {
 
         // Cursor pos should restore to (2, 3).
         assert_eq!(buffer.cursor_pos, col(2) + row(3));
-        // Saved alternate cursor should be (4, 5).
-        assert_eq!(buffer.alt_screen_support.cursor_pos_alt, col(4) + row(5));
+        // Saved hidden (alternate) cursor should be (4, 5).
+        assert_eq!(
+            buffer.hidden_screen_state.hidden_cursor_pos,
+            col(4) + row(5)
+        );
     }
 
     #[test]
@@ -244,7 +268,7 @@ mod tests_mode_ops {
 
         // Change the active style to verify the second BCE clear.
         let new_style = new_style!(italic);
-        buffer.ansi_parser_support.current_style = new_style;
+        buffer.parser_global_state.current_style = new_style;
 
         // Toggle to Alternate Screen again.
         buffer.set_alt_screen_mode(RequestedScreenMode::Alternate);
@@ -253,9 +277,9 @@ mod tests_mode_ops {
             AlternateScreenState::Active
         );
 
-        // Saved primary cursor should now be the new location (7, 8).
+        // Saved hidden (primary) cursor should now be the new location (7, 8).
         assert_eq!(
-            buffer.alt_screen_support.cursor_pos_primary,
+            buffer.hidden_screen_state.hidden_cursor_pos,
             col(7) + row(8)
         );
 

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_osc_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_osc_ops.rs
@@ -3,7 +3,7 @@
 //! [`OSC`] (Operating System Command) operations for VT100/[`ANSI`] terminal emulation.
 //!
 //! This module implements [`OSC`] operations that correspond to [`ANSI`] [`OSC`]
-//! sequences handled by the `vt_100_pty_output_parser::operations::osc_ops` module. These
+//! sequences handled by the `vt_100_pty_output_parser::ops::osc_ops` module. These
 //! include:
 //!
 //! - **[`OSC`] 0/1/2** (Set Title/Icon) - [`handle_title_and_icon`]
@@ -20,21 +20,21 @@
 //! **Related Files:**
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
-//! [`handle_hyperlink`]: crate::OffscreenBuffer::handle_hyperlink
-//! [`handle_title_and_icon`]: crate::OffscreenBuffer::handle_title_and_icon
+//! [`handle_hyperlink`]: crate::OfsBufVT100::handle_hyperlink
+//! [`handle_title_and_icon`]: crate::OfsBufVT100::handle_title_and_icon
 //! [`OSC`]: crate::osc_codes::OscSequence
 
 #[allow(clippy::wildcard_imports)]
 use super::super::*;
 use crate::core::osc::OscEvent;
 
-impl OffscreenBuffer {
+impl OfsBufVT100 {
     /// Handle [`OSC`] title and icon sequences ([`OSC`] 0, 1, 2).
     /// Sets window title and/or icon name by queuing an [`OSC`] event.
     ///
     /// [`OSC`]: crate::osc_codes::OscSequence
     pub fn handle_title_and_icon(&mut self, title: &str) {
-        self.ansi_parser_support
+        self.parser_global_state
             .pending_osc_events
             .push(OscEvent::SetTitleAndTab(title.to_string()));
     }
@@ -45,7 +45,7 @@ impl OffscreenBuffer {
     ///
     /// [`OSC`]: crate::osc_codes::OscSequence
     pub fn handle_hyperlink(&mut self, uri: &str) {
-        self.ansi_parser_support
+        self.parser_global_state
             .pending_osc_events
             .push(OscEvent::Hyperlink {
                 uri: uri.to_string(),
@@ -57,11 +57,11 @@ impl OffscreenBuffer {
 #[cfg(test)]
 mod tests_osc_ops {
     use super::*;
-    use crate::{height, width};
+    use crate::{OfsBufVT100, height, width};
 
-    fn create_test_buffer() -> OffscreenBuffer {
+    fn create_test_buffer() -> OfsBufVT100 {
         let size = width(10) + height(6);
-        OffscreenBuffer::new_empty(size)
+        OfsBufVT100::new_empty(size)
     }
 
     #[test]
@@ -69,14 +69,14 @@ mod tests_osc_ops {
         let mut buffer = create_test_buffer();
 
         // Initially no pending OSC events.
-        assert!(buffer.ansi_parser_support.pending_osc_events.is_empty());
+        assert!(buffer.parser_global_state.pending_osc_events.is_empty());
 
         buffer.handle_title_and_icon("My Window Title");
 
         // Should have one SetTitleAndTab event.
-        assert_eq!(buffer.ansi_parser_support.pending_osc_events.len(), 1);
+        assert_eq!(buffer.parser_global_state.pending_osc_events.len(), 1);
         if let OscEvent::SetTitleAndTab(title) =
-            &buffer.ansi_parser_support.pending_osc_events[0]
+            &buffer.parser_global_state.pending_osc_events[0]
         {
             assert_eq!(title, "My Window Title");
         } else {
@@ -91,9 +91,9 @@ mod tests_osc_ops {
         buffer.handle_hyperlink("https://example.com");
 
         // Should have one Hyperlink event.
-        assert_eq!(buffer.ansi_parser_support.pending_osc_events.len(), 1);
+        assert_eq!(buffer.parser_global_state.pending_osc_events.len(), 1);
         if let OscEvent::Hyperlink { uri, text } =
-            &buffer.ansi_parser_support.pending_osc_events[0]
+            &buffer.parser_global_state.pending_osc_events[0]
         {
             assert_eq!(uri, "https://example.com");
             assert_eq!(text, ""); // Text is handled separately
@@ -111,19 +111,19 @@ mod tests_osc_ops {
         buffer.handle_title_and_icon("Title 2");
 
         // Should have three events queued.
-        assert_eq!(buffer.ansi_parser_support.pending_osc_events.len(), 3);
+        assert_eq!(buffer.parser_global_state.pending_osc_events.len(), 3);
 
         // Check order is preserved.
         assert!(matches!(
-            buffer.ansi_parser_support.pending_osc_events[0],
+            buffer.parser_global_state.pending_osc_events[0],
             OscEvent::SetTitleAndTab(_)
         ));
         assert!(matches!(
-            buffer.ansi_parser_support.pending_osc_events[1],
+            buffer.parser_global_state.pending_osc_events[1],
             OscEvent::Hyperlink { .. }
         ));
         assert!(matches!(
-            buffer.ansi_parser_support.pending_osc_events[2],
+            buffer.parser_global_state.pending_osc_events[2],
             OscEvent::SetTitleAndTab(_)
         ));
     }
@@ -134,9 +134,9 @@ mod tests_osc_ops {
 
         buffer.handle_title_and_icon("");
 
-        assert_eq!(buffer.ansi_parser_support.pending_osc_events.len(), 1);
+        assert_eq!(buffer.parser_global_state.pending_osc_events.len(), 1);
         if let OscEvent::SetTitleAndTab(title) =
-            &buffer.ansi_parser_support.pending_osc_events[0]
+            &buffer.parser_global_state.pending_osc_events[0]
         {
             assert_eq!(title, "");
         } else {
@@ -150,9 +150,9 @@ mod tests_osc_ops {
 
         buffer.handle_hyperlink("");
 
-        assert_eq!(buffer.ansi_parser_support.pending_osc_events.len(), 1);
+        assert_eq!(buffer.parser_global_state.pending_osc_events.len(), 1);
         if let OscEvent::Hyperlink { uri, text } =
-            &buffer.ansi_parser_support.pending_osc_events[0]
+            &buffer.parser_global_state.pending_osc_events[0]
         {
             assert_eq!(uri, "");
             assert_eq!(text, "");

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_scroll_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_scroll_ops.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2025 R3BL LLC. Licensed under Apache License, Version 2.0.
 
-//! [`ANSI`] vertical scrolling operations for `OffscreenBuffer`.
+//! [`ANSI`] vertical scrolling operations for `OfsBufVT100`.
 //!
 //! This module provides methods for vertical line-based scrolling operations,
 //! including index operations (IND/RI) and scroll operations (SU/SD).
@@ -17,12 +17,10 @@
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 //! [`DECSTBM`]: https://vt100.net/docs/vt510-rm/DECSTBM.html
 
-#[allow(clippy::wildcard_imports)]
-use super::super::*;
-use crate::{ArrayBoundsCheck, ArrayUnderflowResult, RowHeight,
+use crate::{ArrayBoundsCheck, ArrayUnderflowResult, OfsBufVT100, RowHeight,
             core::coordinates::bounds_check::RangeConvertExt, ok};
 
-impl OffscreenBuffer {
+impl OfsBufVT100 {
     /// Move cursor down one line, scrolling the buffer if at bottom.
     /// Implements the [`ESC`] D (IND) escape sequence.
     /// Respects [`DECSTBM`] scroll region margins.
@@ -153,7 +151,7 @@ impl OffscreenBuffer {
     ///
     /// [`DECSTBM`]: https://vt100.net/docs/vt510-rm/DECSTBM.html
     /// [`ESC`]: crate::EscSequence
-    /// [`shift_lines_up()`]: crate::OffscreenBuffer::shift_lines_up
+    /// [`shift_lines_up()`]: crate::OfsBufVT100::shift_lines_up
     pub fn scroll_buffer_up(&mut self) -> miette::Result<()> {
         // Get scroll region as an inclusive range and convert to
         // exclusive for iteration.
@@ -176,7 +174,7 @@ impl OffscreenBuffer {
     ///
     /// [`DECSTBM`]: https://vt100.net/docs/vt510-rm/DECSTBM.html
     /// [`ESC`]: crate::EscSequence
-    /// [`shift_lines_down()`]: crate::OffscreenBuffer::shift_lines_down
+    /// [`shift_lines_down()`]: crate::OfsBufVT100::shift_lines_down
     pub fn scroll_buffer_down(&mut self) -> miette::Result<()> {
         // Get scroll region as an inclusive range and convert to
         // exclusive for iteration.
@@ -282,16 +280,16 @@ impl OffscreenBuffer {
 #[cfg(test)]
 mod tests_scroll_vert_ops {
     use super::*;
-    use crate::{col, height, idx, row, term_row, width,
+    use crate::{OfsBufVT100, col, height, idx, row, term_row, width,
                 core::ansi::vt_100_pty_output_conformance_tests::test_fixtures_vt_100_ansi_conformance::nz,
                 test_fixtures_ofs_buf::{assert_plain_char_at,
-                                        create_test_buffer_with_size}};
+                                        create_vt100_test_buffer_with_size}};
 
-    fn create_test_buffer() -> OffscreenBuffer {
-        create_test_buffer_with_size(width(10), height(6))
+    fn create_test_buffer() -> OfsBufVT100 {
+        create_vt100_test_buffer_with_size(width(10), height(6))
     }
 
-    fn fill_buffer_with_test_content(buffer: &mut OffscreenBuffer) {
+    fn fill_buffer_with_test_content(buffer: &mut OfsBufVT100) {
         // Fill buffer with identifiable content:
         // Row 0: "0000000000"
         // Row 1: "1111111111"
@@ -457,8 +455,8 @@ mod tests_scroll_vert_ops {
         fill_buffer_with_test_content(&mut buffer);
 
         // Set up scroll region from row 1 to row 4.
-        buffer.ansi_parser_support.scroll_region_top = Some(term_row(nz(2)));
-        buffer.ansi_parser_support.scroll_region_bottom = Some(term_row(nz(5)));
+        buffer.parser_global_state.scroll_region_top = Some(term_row(nz(2)));
+        buffer.parser_global_state.scroll_region_bottom = Some(term_row(nz(5)));
 
         // Position cursor at scroll region bottom.
         buffer.cursor_pos = row(4) + col(0);

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_sgr_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_sgr_ops.rs
@@ -3,7 +3,7 @@
 //! [`SGR`] (Select Graphic Rendition) operations for VT100/[`ANSI`] terminal emulation.
 //!
 //! This module implements [`SGR`] operations that correspond to [`ANSI`] [`SGR`]
-//! sequences handled by the `vt_100_pty_output_parser::operations::sgr_ops` module. These
+//! sequences handled by the `vt_100_pty_output_parser::ops::sgr_ops` module. These
 //! include:
 //!
 //! - **[`SGR`] 0** (Reset) - [`reset_all_style_attributes()`]
@@ -31,33 +31,33 @@
 //! **Related Files:**
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
-//! [`apply_style_attribute()`]: crate::OffscreenBuffer::apply_style_attribute
-//! [`reset_all_style_attributes()`]: crate::OffscreenBuffer::reset_all_style_attributes
-//! [`set_background_color()`]: crate::OffscreenBuffer::set_background_color
-//! [`set_foreground_color()`]: crate::OffscreenBuffer::set_foreground_color
+//! [`apply_style_attribute()`]: crate::OfsBufVT100::apply_style_attribute
+//! [`reset_all_style_attributes()`]: crate::OfsBufVT100::reset_all_style_attributes
+//! [`set_background_color()`]: crate::OfsBufVT100::set_background_color
+//! [`set_foreground_color()`]: crate::OfsBufVT100::set_foreground_color
 //! [`SGR`]: crate::SgrCode
 
-use crate::{AnsiValue, ColorTarget, OffscreenBuffer, RgbValue, SgrColorSequence,
-            TuiColor, TuiStyle, TuiStyleAttribs};
+use crate::{AnsiValue, ColorTarget, OfsBufVT100, RgbValue, SgrColorSequence, TuiColor,
+            TuiStyle, TuiStyleAttribs};
 
-impl OffscreenBuffer {
+impl OfsBufVT100 {
     /// Reset all [`SGR`] attributes to default state.
     ///
     /// [`SGR`]: crate::SgrCode
     pub fn reset_all_style_attributes(&mut self) {
-        self.ansi_parser_support.current_style = TuiStyle::default();
+        self.parser_global_state.current_style = TuiStyle::default();
     }
 
     /// Apply style attributes to the current style by merging with new attributes.
     pub fn apply_style_attribute(&mut self, attribs: TuiStyleAttribs) {
-        self.ansi_parser_support.current_style.attribs =
-            self.ansi_parser_support.current_style.attribs + attribs;
+        self.parser_global_state.current_style.attribs =
+            self.parser_global_state.current_style.attribs + attribs;
     }
 
     /// Reset specific style attributes. Only fields that are `Some` in the input are
     /// reset.
     pub fn reset_style_attribute(&mut self, attribs: TuiStyleAttribs) {
-        let style = &mut self.ansi_parser_support.current_style;
+        let style = &mut self.parser_global_state.current_style;
 
         if attribs.bold.is_some() || attribs.dim.is_some() {
             style.attribs.bold = None;
@@ -90,7 +90,7 @@ impl OffscreenBuffer {
     ///
     /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
     pub fn set_foreground_color(&mut self, ansi_color: u16) {
-        self.ansi_parser_support.current_style.color_fg =
+        self.parser_global_state.current_style.color_fg =
             Some(TuiColor::from(AnsiValue::from(ansi_color)));
     }
 
@@ -98,18 +98,18 @@ impl OffscreenBuffer {
     ///
     /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
     pub fn set_background_color(&mut self, ansi_color: u16) {
-        self.ansi_parser_support.current_style.color_bg =
+        self.parser_global_state.current_style.color_bg =
             Some(TuiColor::from(AnsiValue::from(ansi_color)));
     }
 
     /// Reset foreground color to default.
     pub fn reset_foreground_color(&mut self) {
-        self.ansi_parser_support.current_style.color_fg = None;
+        self.parser_global_state.current_style.color_fg = None;
     }
 
     /// Reset background color to default.
     pub fn reset_background_color(&mut self) {
-        self.ansi_parser_support.current_style.color_bg = None;
+        self.parser_global_state.current_style.color_bg = None;
     }
 
     /// Set foreground color using 256-color palette index.
@@ -122,7 +122,7 @@ impl OffscreenBuffer {
     ///
     /// Used with: `ESC[38;5;nm` or `ESC[38:5:nm`
     pub fn set_foreground_ansi256(&mut self, index: u8) {
-        self.ansi_parser_support.current_style.color_fg =
+        self.parser_global_state.current_style.color_fg =
             Some(TuiColor::Ansi(AnsiValue::new(index)));
     }
 
@@ -136,7 +136,7 @@ impl OffscreenBuffer {
     ///
     /// Used with: `ESC[48;5;nm` or `ESC[48:5:nm`
     pub fn set_background_ansi256(&mut self, index: u8) {
-        self.ansi_parser_support.current_style.color_bg =
+        self.parser_global_state.current_style.color_bg =
             Some(TuiColor::Ansi(AnsiValue::new(index)));
     }
 
@@ -152,7 +152,7 @@ impl OffscreenBuffer {
     ///
     /// Used with: `ESC[38;2;r;g;bm` or `ESC[38:2:r:g:bm`
     pub fn set_foreground_rgb(&mut self, r: u8, g: u8, b: u8) {
-        self.ansi_parser_support.current_style.color_fg =
+        self.parser_global_state.current_style.color_fg =
             Some(TuiColor::Rgb(RgbValue::from_u8(r, g, b)));
     }
 
@@ -168,7 +168,7 @@ impl OffscreenBuffer {
     ///
     /// Used with: `ESC[48;2;r;g;bm` or `ESC[48:2:r:g:bm`
     pub fn set_background_rgb(&mut self, r: u8, g: u8, b: u8) {
-        self.ansi_parser_support.current_style.color_bg =
+        self.parser_global_state.current_style.color_bg =
             Some(TuiColor::Rgb(RgbValue::from_u8(r, g, b)));
     }
     /// Apply an extended color sequence to the current style.
@@ -184,9 +184,9 @@ impl OffscreenBuffer {
     /// # Example
     ///
     /// ```
-    /// use r3bl_tui::{SgrColorSequence, OffscreenBuffer, height, width};
+    /// use r3bl_tui::{SgrColorSequence, OfsBufVT100, height, width};
     ///
-    /// let mut buffer = OffscreenBuffer::new_empty(height(10) + width(20));
+    /// let mut buffer = OfsBufVT100::new_empty(height(10) + width(20));
     ///
     /// // Parse an extended color sequence (256-color foreground)
     /// let params = &[38, 5, 196];
@@ -201,10 +201,10 @@ impl OffscreenBuffer {
         let tui_color = TuiColor::from(color_seq);
         match color_seq.target() {
             ColorTarget::Foreground => {
-                self.ansi_parser_support.current_style.color_fg = Some(tui_color);
+                self.parser_global_state.current_style.color_fg = Some(tui_color);
             }
             ColorTarget::Background => {
-                self.ansi_parser_support.current_style.color_bg = Some(tui_color);
+                self.parser_global_state.current_style.color_bg = Some(tui_color);
             }
         }
     }
@@ -213,11 +213,11 @@ impl OffscreenBuffer {
 #[cfg(test)]
 mod tests_sgr_ops {
     use super::*;
-    use crate::{height, tui_style_attrib, width};
+    use crate::{OfsBufVT100, height, tui_style_attrib, width};
 
-    fn create_test_buffer() -> OffscreenBuffer {
+    fn create_test_buffer() -> OfsBufVT100 {
         let size = width(10) + height(6);
-        OffscreenBuffer::new_empty(size)
+        OfsBufVT100::new_empty(size)
     }
 
     #[test]
@@ -231,18 +231,18 @@ mod tests_sgr_ops {
         // Verify they're set
         assert!(
             buffer
-                .ansi_parser_support
+                .parser_global_state
                 .current_style
                 .attribs
                 .bold
                 .is_some()
         );
-        assert!(buffer.ansi_parser_support.current_style.color_fg.is_some());
+        assert!(buffer.parser_global_state.current_style.color_fg.is_some());
 
         buffer.reset_all_style_attributes();
 
         // Should be reset to defaults
-        let style = &buffer.ansi_parser_support.current_style;
+        let style = &buffer.parser_global_state.current_style;
         assert!(style.attribs.bold.is_none());
         assert!(style.color_fg.is_none());
         assert!(style.color_bg.is_none());
@@ -256,7 +256,7 @@ mod tests_sgr_ops {
 
         assert!(
             buffer
-                .ansi_parser_support
+                .parser_global_state
                 .current_style
                 .attribs
                 .bold
@@ -272,7 +272,7 @@ mod tests_sgr_ops {
 
         assert!(
             buffer
-                .ansi_parser_support
+                .parser_global_state
                 .current_style
                 .attribs
                 .italic
@@ -292,7 +292,7 @@ mod tests_sgr_ops {
 
         assert!(
             buffer
-                .ansi_parser_support
+                .parser_global_state
                 .current_style
                 .attribs
                 .bold
@@ -300,7 +300,7 @@ mod tests_sgr_ops {
         );
         assert!(
             buffer
-                .ansi_parser_support
+                .parser_global_state
                 .current_style
                 .attribs
                 .dim
@@ -314,8 +314,8 @@ mod tests_sgr_ops {
 
         buffer.set_foreground_color(31); // Red
 
-        assert!(buffer.ansi_parser_support.current_style.color_fg.is_some());
-        if let Some(color) = buffer.ansi_parser_support.current_style.color_fg {
+        assert!(buffer.parser_global_state.current_style.color_fg.is_some());
+        if let Some(color) = buffer.parser_global_state.current_style.color_fg {
             // Should be red color
             // Red is ANSI color 31, which maps to palette index 9 (basic red)
             assert!(matches!(color, TuiColor::Ansi(a) if a.index < 16));
@@ -328,8 +328,8 @@ mod tests_sgr_ops {
 
         buffer.set_background_color(42); // Green background
 
-        assert!(buffer.ansi_parser_support.current_style.color_bg.is_some());
-        if let Some(color) = buffer.ansi_parser_support.current_style.color_bg {
+        assert!(buffer.parser_global_state.current_style.color_bg.is_some());
+        if let Some(color) = buffer.parser_global_state.current_style.color_bg {
             // Should be green color
             // Green is ANSI color 42, which maps to palette index 10 (basic green)
             assert!(matches!(color, TuiColor::Ansi(a) if a.index < 16));
@@ -341,10 +341,10 @@ mod tests_sgr_ops {
         let mut buffer = create_test_buffer();
 
         buffer.set_foreground_color(31);
-        assert!(buffer.ansi_parser_support.current_style.color_fg.is_some());
+        assert!(buffer.parser_global_state.current_style.color_fg.is_some());
 
         buffer.reset_foreground_color();
-        assert!(buffer.ansi_parser_support.current_style.color_fg.is_none());
+        assert!(buffer.parser_global_state.current_style.color_fg.is_none());
     }
 
     #[test]
@@ -352,10 +352,10 @@ mod tests_sgr_ops {
         let mut buffer = create_test_buffer();
 
         buffer.set_background_color(42);
-        assert!(buffer.ansi_parser_support.current_style.color_bg.is_some());
+        assert!(buffer.parser_global_state.current_style.color_bg.is_some());
 
         buffer.reset_background_color();
-        assert!(buffer.ansi_parser_support.current_style.color_bg.is_none());
+        assert!(buffer.parser_global_state.current_style.color_bg.is_none());
     }
 
     #[test]
@@ -366,7 +366,7 @@ mod tests_sgr_ops {
         buffer.apply_style_attribute(TuiStyleAttribs::from(tui_style_attrib::Italic));
         buffer.apply_style_attribute(TuiStyleAttribs::from(tui_style_attrib::Underline));
 
-        let style = &buffer.ansi_parser_support.current_style;
+        let style = &buffer.parser_global_state.current_style;
         assert!(style.attribs.bold.is_some());
         assert!(style.attribs.italic.is_some());
         assert!(style.attribs.underline.is_some());

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_terminal_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_terminal_ops.rs
@@ -1,10 +1,10 @@
 // Copyright (c) 2025 R3BL LLC. Licensed under Apache License, Version 2.0.
 
-//! [`ANSI`] character set selection operations for `OffscreenBuffer`.
+//! [`ANSI`] character set selection operations for `OfsBufVT100`.
 //!
 //! This module provides methods for selecting different character sets
 //! as required by [`ANSI`] terminal emulation standards, particularly for
-//! [`ESC`] ( B ([`ASCII`]) and [`ESC`] ( 0 ([`DEC`] Special Graphics) sequences.
+//! `ESC ( B` ([`ASCII`]) and `ESC ( 0` ([`DEC`] Special Graphics) sequences.
 //!
 //! This module implements the business logic for terminal operations delegated from
 //! the parser shim. The `impl_` prefix follows our naming convention for searchable
@@ -21,10 +21,10 @@
 #[allow(clippy::wildcard_imports)]
 use super::super::*;
 
-impl OffscreenBuffer {
+impl OfsBufVT100 {
     /// Select [`ASCII`] character set for normal text rendering.
     ///
-    /// Used by [`ESC`] ( B sequence to switch to normal [`ASCII`] character set.
+    /// Used by `ESC ( B` sequence to switch to normal [`ASCII`] character set.
     /// This is the default character set for most text operations.
     ///
     /// # Example
@@ -37,12 +37,12 @@ impl OffscreenBuffer {
     /// [`ASCII`]: https://en.wikipedia.org/wiki/ASCII
     /// [`ESC`]: crate::EscSequence
     pub fn select_ascii_character_set(&mut self) {
-        self.ansi_parser_support.character_set = CharacterSet::Ascii;
+        self.parser_global_state.character_set = CharacterSet::Ascii;
     }
 
     /// Select [`DEC`] Special Graphics character set for box-drawing characters.
     ///
-    /// Used by [`ESC`] ( 0 sequence to switch to [`DEC`] Special Graphics character set.
+    /// Used by `ESC ( 0` sequence to switch to [`DEC`] Special Graphics character set.
     /// This enables rendering of box-drawing and line-drawing characters commonly
     /// used for terminal-based user interfaces.
     ///
@@ -56,11 +56,11 @@ impl OffscreenBuffer {
     /// [`DEC`]: https://en.wikipedia.org/wiki/Digital_Equipment_Corporation
     /// [`ESC`]: crate::EscSequence
     pub fn select_dec_graphics_character_set(&mut self) {
-        self.ansi_parser_support.character_set = CharacterSet::DECGraphics;
+        self.parser_global_state.character_set = CharacterSet::DECGraphics;
     }
 
     /// Translate [`DEC`] Special Graphics characters to Unicode box-drawing characters.
-    /// Used when `character_set` is [`DECGraphics`] (after [`ESC`] ( 0).
+    /// Used when `character_set` is [`DECGraphics`] (after `ESC ( 0`).
     ///
     /// [`DEC`]: https://en.wikipedia.org/wiki/Digital_Equipment_Corporation
     /// [`DECGraphics`]: crate::CharacterSet::DECGraphics
@@ -87,11 +87,11 @@ impl OffscreenBuffer {
 #[cfg(test)]
 mod tests_char_set_ops {
     use super::*;
-    use crate::{height, width};
+    use crate::{OfsBufVT100, height, width};
 
-    fn create_test_buffer() -> OffscreenBuffer {
+    fn create_test_buffer() -> OfsBufVT100 {
         let size = width(10) + height(6);
-        OffscreenBuffer::new_empty(size)
+        OfsBufVT100::new_empty(size)
     }
 
     #[test]
@@ -99,12 +99,12 @@ mod tests_char_set_ops {
         let mut buffer = create_test_buffer();
 
         // Start with DEC graphics character set.
-        buffer.ansi_parser_support.character_set = CharacterSet::DECGraphics;
+        buffer.parser_global_state.character_set = CharacterSet::DECGraphics;
 
         buffer.select_ascii_character_set();
 
         assert_eq!(
-            buffer.ansi_parser_support.character_set,
+            buffer.parser_global_state.character_set,
             CharacterSet::Ascii
         );
     }
@@ -114,12 +114,12 @@ mod tests_char_set_ops {
         let mut buffer = create_test_buffer();
 
         // Start with ASCII character set (default).
-        buffer.ansi_parser_support.character_set = CharacterSet::Ascii;
+        buffer.parser_global_state.character_set = CharacterSet::Ascii;
 
         buffer.select_dec_graphics_character_set();
 
         assert_eq!(
-            buffer.ansi_parser_support.character_set,
+            buffer.parser_global_state.character_set,
             CharacterSet::DECGraphics
         );
     }
@@ -127,37 +127,37 @@ mod tests_char_set_ops {
     #[test]
     fn test_translate_dec_graphics_corners() {
         // Test corner characters.
-        assert_eq!(OffscreenBuffer::translate_dec_graphics('j'), '┘'); // Lower right
-        assert_eq!(OffscreenBuffer::translate_dec_graphics('k'), '┐'); // Upper right
-        assert_eq!(OffscreenBuffer::translate_dec_graphics('l'), '┌'); // Upper left
-        assert_eq!(OffscreenBuffer::translate_dec_graphics('m'), '└'); // Lower left
+        assert_eq!(OfsBufVT100::translate_dec_graphics('j'), '┘'); // Lower right
+        assert_eq!(OfsBufVT100::translate_dec_graphics('k'), '┐'); // Upper right
+        assert_eq!(OfsBufVT100::translate_dec_graphics('l'), '┌'); // Upper left
+        assert_eq!(OfsBufVT100::translate_dec_graphics('m'), '└'); // Lower left
     }
 
     #[test]
     fn test_translate_dec_graphics_lines() {
         // Test line characters.
-        assert_eq!(OffscreenBuffer::translate_dec_graphics('q'), '─'); // Horizontal line
-        assert_eq!(OffscreenBuffer::translate_dec_graphics('x'), '│'); // Vertical line
-        assert_eq!(OffscreenBuffer::translate_dec_graphics('n'), '┼'); // Crossing lines
+        assert_eq!(OfsBufVT100::translate_dec_graphics('q'), '─'); // Horizontal line
+        assert_eq!(OfsBufVT100::translate_dec_graphics('x'), '│'); // Vertical line
+        assert_eq!(OfsBufVT100::translate_dec_graphics('n'), '┼'); // Crossing lines
     }
 
     #[test]
     fn test_translate_dec_graphics_tees() {
         // Test T-junction characters.
-        assert_eq!(OffscreenBuffer::translate_dec_graphics('t'), '├'); // Left "T"
-        assert_eq!(OffscreenBuffer::translate_dec_graphics('u'), '┤'); // Right "T"
-        assert_eq!(OffscreenBuffer::translate_dec_graphics('v'), '┴'); // Bottom "T"
-        assert_eq!(OffscreenBuffer::translate_dec_graphics('w'), '┬'); // Top "T"
+        assert_eq!(OfsBufVT100::translate_dec_graphics('t'), '├'); // Left "T"
+        assert_eq!(OfsBufVT100::translate_dec_graphics('u'), '┤'); // Right "T"
+        assert_eq!(OfsBufVT100::translate_dec_graphics('v'), '┴'); // Bottom "T"
+        assert_eq!(OfsBufVT100::translate_dec_graphics('w'), '┬'); // Top "T"
     }
 
     #[test]
     fn test_translate_dec_graphics_unmapped_characters() {
         // Test that unmapped characters pass through unchanged.
-        assert_eq!(OffscreenBuffer::translate_dec_graphics('a'), 'a');
-        assert_eq!(OffscreenBuffer::translate_dec_graphics('Z'), 'Z');
-        assert_eq!(OffscreenBuffer::translate_dec_graphics('1'), '1');
-        assert_eq!(OffscreenBuffer::translate_dec_graphics('@'), '@');
-        assert_eq!(OffscreenBuffer::translate_dec_graphics(' '), ' ');
+        assert_eq!(OfsBufVT100::translate_dec_graphics('a'), 'a');
+        assert_eq!(OfsBufVT100::translate_dec_graphics('Z'), 'Z');
+        assert_eq!(OfsBufVT100::translate_dec_graphics('1'), '1');
+        assert_eq!(OfsBufVT100::translate_dec_graphics('@'), '@');
+        assert_eq!(OfsBufVT100::translate_dec_graphics(' '), ' ');
     }
 
     #[test]
@@ -179,7 +179,7 @@ mod tests_char_set_ops {
 
         for (input, expected) in mappings {
             assert_eq!(
-                OffscreenBuffer::translate_dec_graphics(input),
+                OfsBufVT100::translate_dec_graphics(input),
                 expected,
                 "Translation failed for character '{input}'"
             );
@@ -192,21 +192,21 @@ mod tests_char_set_ops {
 
         // Verify initial state is ASCII (default).
         assert_eq!(
-            buffer.ansi_parser_support.character_set,
+            buffer.parser_global_state.character_set,
             CharacterSet::Ascii
         );
 
         // Switch to DEC graphics and verify persistence.
         buffer.select_dec_graphics_character_set();
         assert_eq!(
-            buffer.ansi_parser_support.character_set,
+            buffer.parser_global_state.character_set,
             CharacterSet::DECGraphics
         );
 
         // Switch back to ASCII and verify persistence.
         buffer.select_ascii_character_set();
         assert_eq!(
-            buffer.ansi_parser_support.character_set,
+            buffer.parser_global_state.character_set,
             CharacterSet::Ascii
         );
     }
@@ -219,13 +219,13 @@ mod tests_char_set_ops {
         for _ in 0..3 {
             buffer.select_dec_graphics_character_set();
             assert_eq!(
-                buffer.ansi_parser_support.character_set,
+                buffer.parser_global_state.character_set,
                 CharacterSet::DECGraphics
             );
 
             buffer.select_ascii_character_set();
             assert_eq!(
-                buffer.ansi_parser_support.character_set,
+                buffer.parser_global_state.character_set,
                 CharacterSet::Ascii
             );
         }
@@ -241,7 +241,7 @@ mod tests_char_set_ops {
             box_chars.iter().zip(expected_unicode.iter())
         {
             assert_eq!(
-                OffscreenBuffer::translate_dec_graphics(*dec_char),
+                OfsBufVT100::translate_dec_graphics(*dec_char),
                 *expected_unicode_char,
                 "Failed to translate box drawing character '{dec_char}'"
             );

--- a/tui/src/core/ansi/vt_100_pty_output_parser/performer.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/performer.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 R3BL LLC. Licensed under Apache License, Version 2.0.
+// Copyright (c) 2025-2026 R3BL LLC. Licensed under Apache License, Version 2.0.
 
 // cspell:words suckless
 
@@ -141,18 +141,18 @@
 //! organization and predictable code navigation:
 //!
 //! ```text
-//! vt_100_pty_output_parser/operations/             offscreen_buffer/vt_100_ansi_impl/
-//! ├── vt_100_shim_char_ops         →         ├── vt_100_impl_char_ops
-//! ├── vt_100_shim_control_ops      →         ├── vt_100_impl_control_ops
-//! ├── vt_100_shim_cursor_ops       →         ├── vt_100_impl_cursor_ops
-//! ├── vt_100_shim_dsr_ops          →         ├── vt_100_impl_dsr_ops
-//! ├── vt_100_shim_line_ops         →         ├── vt_100_impl_line_ops
-//! ├── vt_100_shim_margin_ops       →         ├── vt_100_impl_margin_ops
-//! ├── vt_100_shim_mode_ops         →         ├── vt_100_impl_mode_ops
-//! ├── vt_100_shim_osc_ops          →         ├── vt_100_impl_osc_ops
-//! ├── vt_100_shim_scroll_ops       →         ├── vt_100_impl_scroll_ops
-//! ├── vt_100_shim_sgr_ops          →         ├── vt_100_impl_sgr_ops
-//! └── vt_100_shim_terminal_ops     →         └── vt_100_impl_terminal_ops
+//! vt_100_pty_output_parser/ops/             offscreen_buffer/ofs_buf_vt_100/
+//! ├── vt_100_shim_char_ops         →         ├── impl_char_ops
+//! ├── vt_100_shim_control_ops      →         ├── impl_control_ops
+//! ├── vt_100_shim_cursor_ops       →         ├── impl_cursor_ops
+//! ├── vt_100_shim_dsr_ops          →         ├── impl_dsr_ops
+//! ├── vt_100_shim_line_ops         →         ├── impl_line_ops
+//! ├── vt_100_shim_margin_ops       →         ├── impl_margin_ops
+//! ├── vt_100_shim_mode_ops         →         ├── impl_mode_ops
+//! ├── vt_100_shim_osc_ops          →         ├── impl_osc_ops
+//! ├── vt_100_shim_scroll_ops       →         ├── impl_scroll_ops
+//! ├── vt_100_shim_sgr_ops          →         ├── impl_sgr_ops
+//! └── vt_100_shim_terminal_ops     →         └── impl_terminal_ops
 //! ```
 //!
 //! Each operations file contains **thin shim functions** that:
@@ -213,28 +213,29 @@
 
 // Import the operation modules and public API.
 use super::{ansi_parser_public_api::AnsiToOfsBufPerformer,
-            operations::{vt_100_shim_char_ops, vt_100_shim_clear_ops,
+            ops::{vt_100_shim_char_ops, vt_100_shim_clear_ops,
                          vt_100_shim_control_ops, vt_100_shim_cursor_ops,
                          vt_100_shim_dsr_ops, vt_100_shim_line_ops,
                          vt_100_shim_margin_ops, vt_100_shim_mode_ops,
                          vt_100_shim_osc_ops, vt_100_shim_scroll_ops,
                          vt_100_shim_sgr_ops, vt_100_shim_terminal_ops}};
-use crate::DEBUG_TUI_VT100_PARSER;
-use crate::core::ansi::constants::{BACKSPACE, CARRIAGE_RETURN, CHA_CURSOR_COLUMN,
-                                   CHARSET_ASCII, CHARSET_DEC_GRAPHICS,
-                                   CNL_CURSOR_NEXT_LINE, CPL_CURSOR_PREV_LINE,
-                                   CUB_CURSOR_BACKWARD, CUD_CURSOR_DOWN,
-                                   CUF_CURSOR_FORWARD, CUP_CURSOR_POSITION,
-                                   CUU_CURSOR_UP, DCH_DELETE_CHAR, DECRC_RESTORE_CURSOR,
-                                   DECSC_SAVE_CURSOR, DECSTBM_SET_MARGINS,
-                                   DL_DELETE_LINE, DSR_DEVICE_STATUS, ECH_ERASE_CHAR,
-                                   ED_ERASE_DISPLAY, EL_ERASE_LINE,
-                                   G0_CHARSET_INTERMEDIATE, HVP_CURSOR_POSITION,
-                                   ICH_INSERT_CHAR, IL_INSERT_LINE, IND_INDEX_DOWN,
-                                   LINE_FEED, RCP_RESTORE_CURSOR, RI_REVERSE_INDEX_UP,
-                                   RIS_RESET_TERMINAL, RM_RESET_MODE, SCP_SAVE_CURSOR,
-                                   SD_SCROLL_DOWN, SGR_SET_GRAPHICS, SM_SET_MODE,
-                                   SU_SCROLL_UP, TAB, VPA_VERTICAL_POSITION};
+use crate::{DEBUG_TUI_VT100_PARSER,
+            core::ansi::constants::{BACKSPACE, CARRIAGE_RETURN, CHA_CURSOR_COLUMN,
+                                    CHARSET_ASCII, CHARSET_DEC_GRAPHICS,
+                                    CNL_CURSOR_NEXT_LINE, CPL_CURSOR_PREV_LINE,
+                                    CUB_CURSOR_BACKWARD, CUD_CURSOR_DOWN,
+                                    CUF_CURSOR_FORWARD, CUP_CURSOR_POSITION,
+                                    CUU_CURSOR_UP, DCH_DELETE_CHAR,
+                                    DECRC_RESTORE_CURSOR, DECSC_SAVE_CURSOR,
+                                    DECSTBM_SET_MARGINS, DL_DELETE_LINE,
+                                    DSR_DEVICE_STATUS, ECH_ERASE_CHAR,
+                                    ED_ERASE_DISPLAY, EL_ERASE_LINE,
+                                    G0_CHARSET_INTERMEDIATE, HVP_CURSOR_POSITION,
+                                    ICH_INSERT_CHAR, IL_INSERT_LINE, IND_INDEX_DOWN,
+                                    LINE_FEED, RCP_RESTORE_CURSOR, RI_REVERSE_INDEX_UP,
+                                    RIS_RESET_TERMINAL, RM_RESET_MODE, SCP_SAVE_CURSOR,
+                                    SD_SCROLL_DOWN, SGR_SET_GRAPHICS, SM_SET_MODE,
+                                    SU_SCROLL_UP, TAB, VPA_VERTICAL_POSITION}};
 use vte::{Params, Perform};
 
 /// Internal methods for `AnsiToOfsBufPerformer` to implement [`Perform`] trait.
@@ -265,7 +266,7 @@ impl Perform for AnsiToOfsBufPerformer<'_> {
     ///
     /// ## Character Processing Flow
     /// 1. Receives printable character from the [`vte`] [`Parser`]
-    /// 2. Translates character if [`DECGraphics`] mode active ([`ESC`] ( 0)
+    /// 2. Translates character if [`DECGraphics`] mode active (`ESC ( 0`)
     /// 3. Writes character to buffer at current cursor position
     /// 4. Advances cursor, handling line wrap based on [`DECAWM`] mode
     ///
@@ -443,9 +444,9 @@ impl Perform for AnsiToOfsBufPerformer<'_> {
         if ignore {
             DEBUG_TUI_VT100_PARSER.then(|| {
                 tracing::warn!(
-                "CSI {}: Discarding malformed sequence (VTE parser exceeded limits)",
-                dispatch_char
-            );
+                    "CSI {}: Discarding malformed sequence (VTE parser exceeded limits)",
+                    dispatch_char
+                );
             });
             return;
         }
@@ -541,7 +542,7 @@ impl Perform for AnsiToOfsBufPerformer<'_> {
             'I' => {
                 // CHT (Cursor Horizontal Tab) - Move cursor forward N tab stops
                 // Not needed: Tab handling is done via execute() with TAB character.
-                // See [mod-level docs](crate::vt_100_pty_output_parser) for rationale
+                // See [mod-level docs](crate::core::ansi::vt_100_pty_output_parser) for rationale
                 DEBUG_TUI_VT100_PARSER.then(|| {
                     tracing::warn!("CSI I: Cursor Horizontal Tab not implemented");
                 });
@@ -549,7 +550,7 @@ impl Perform for AnsiToOfsBufPerformer<'_> {
             'Z' => {
                 // CBT (Cursor Backward Tab) - Move cursor backward N tab stops
                 // Not needed: Reverse tab rarely used, complex tab stop tracking required
-                // See [mod-level docs](crate::vt_100_pty_output_parser) for rationale
+                // See [mod-level docs](crate::core::ansi::vt_100_pty_output_parser) for rationale
                 DEBUG_TUI_VT100_PARSER.then(|| {
                     tracing::warn!("CSI Z: Cursor Backward Tab not implemented");
                 });
@@ -557,7 +558,7 @@ impl Perform for AnsiToOfsBufPerformer<'_> {
             'g' => {
                 // TBC (Tab Clear) - Clear tab stops (0=current, 3=all)
                 // Not needed: Tab stops are application-specific, TUI apps manage their
-                // own. See [mod-level docs](crate::vt_100_pty_output_parser) for
+                // own. See [mod-level docs](crate::core::ansi::vt_100_pty_output_parser) for
                 // rationale
                 DEBUG_TUI_VT100_PARSER.then(|| {
                     tracing::warn!("CSI g: Tab Clear not implemented");
@@ -566,7 +567,7 @@ impl Perform for AnsiToOfsBufPerformer<'_> {
             'a' => {
                 // HPR (Horizontal Position Relative) - Same as CUF (Cursor Forward)
                 // Not needed: CUF already implemented, this is redundant
-                // See [mod-level docs](crate::vt_100_pty_output_parser) for rationale
+                // See [mod-level docs](crate::core::ansi::vt_100_pty_output_parser) for rationale
                 DEBUG_TUI_VT100_PARSER.then(|| {
                     tracing::warn!(
                     "CSI a: Horizontal Position Relative not implemented (use CUF instead)"
@@ -576,7 +577,7 @@ impl Perform for AnsiToOfsBufPerformer<'_> {
             'e' => {
                 // VPR (Vertical Position Relative) - Same as CUD (Cursor Down)
                 // Not needed: CUD already implemented, this is redundant
-                // See [mod-level docs](crate::vt_100_pty_output_parser) for rationale
+                // See [mod-level docs](crate::core::ansi::vt_100_pty_output_parser) for rationale
                 DEBUG_TUI_VT100_PARSER.then(|| {
                     tracing::warn!(
                     "CSI e: Vertical Position Relative not implemented (use CUD instead)"
@@ -586,7 +587,7 @@ impl Perform for AnsiToOfsBufPerformer<'_> {
             '`' => {
                 // HPA (Horizontal Position Absolute) - Same as CHA
                 // Not needed: CHA already implemented, this is redundant
-                // See [mod-level docs](crate::vt_100_pty_output_parser) for rationale
+                // See [mod-level docs](crate::core::ansi::vt_100_pty_output_parser) for rationale
                 DEBUG_TUI_VT100_PARSER.then(|| {
                     tracing::warn!(
                     "CSI `: Horizontal Position Absolute not implemented (use CHA instead)"
@@ -596,7 +597,7 @@ impl Perform for AnsiToOfsBufPerformer<'_> {
             'U' => {
                 // NP (Next Page) - Move to next page in page memory
                 // Not needed: Page memory not supported in multiplexer.
-                // See [mod-level docs](crate::vt_100_pty_output_parser) for rationale
+                // See [mod-level docs](crate::core::ansi::vt_100_pty_output_parser) for rationale
                 DEBUG_TUI_VT100_PARSER.then(|| {
                     tracing::warn!("CSI U: Next Page not supported in multiplexer");
                 });
@@ -604,7 +605,7 @@ impl Perform for AnsiToOfsBufPerformer<'_> {
             'V' => {
                 // PP (Preceding Page) - Move to previous page in page memory
                 // Not needed: Page memory not supported in multiplexer.
-                // See [mod-level docs](crate::vt_100_pty_output_parser) for rationale
+                // See [mod-level docs](crate::core::ansi::vt_100_pty_output_parser) for rationale
                 DEBUG_TUI_VT100_PARSER.then(|| {
                     tracing::warn!("CSI V: Preceding Page not supported in multiplexer");
                 });
@@ -612,7 +613,7 @@ impl Perform for AnsiToOfsBufPerformer<'_> {
             '~' => {
                 // DECLL (DEC Load LEDs) - Set keyboard LED indicators
                 // Not needed: Hardware control not applicable in multiplexer.
-                // See [mod-level docs](crate::vt_100_pty_output_parser) for rationale
+                // See [mod-level docs](crate::core::ansi::vt_100_pty_output_parser) for rationale
                 DEBUG_TUI_VT100_PARSER.then(|| {
                     tracing::warn!("CSI ~: DEC Load LEDs not supported in multiplexer");
                 });
@@ -620,7 +621,7 @@ impl Perform for AnsiToOfsBufPerformer<'_> {
             '}' => {
                 // DECIC (DEC Insert Column) - Insert blank columns at cursor
                 // Not needed: Column insertion rarely used, complex for TUI apps
-                // See [mod-level docs](crate::vt_100_pty_output_parser) for rationale
+                // See [mod-level docs](crate::core::ansi::vt_100_pty_output_parser) for rationale
                 DEBUG_TUI_VT100_PARSER.then(|| {
                     tracing::warn!("CSI }}: DEC Insert Column not implemented");
                 });
@@ -628,7 +629,7 @@ impl Perform for AnsiToOfsBufPerformer<'_> {
             '|' => {
                 // DECDC (DEC Delete Column) - Delete columns at cursor
                 // Not needed: Column deletion rarely used, complex for TUI apps
-                // See [mod-level docs](crate::vt_100_pty_output_parser) for rationale
+                // See [mod-level docs](crate::core::ansi::vt_100_pty_output_parser) for rationale
                 DEBUG_TUI_VT100_PARSER.then(|| {
                     tracing::warn!("CSI |: DEC Delete Column not implemented");
                 });
@@ -636,54 +637,58 @@ impl Perform for AnsiToOfsBufPerformer<'_> {
             't' => {
                 // Window manipulation (resize, move, iconify, etc.)
                 // Not needed: Window ops handled by terminal emulator, not multiplexer
-                // See [mod-level docs](crate::vt_100_pty_output_parser) for rationale
+                // See [mod-level docs](crate::core::ansi::vt_100_pty_output_parser) for rationale
                 DEBUG_TUI_VT100_PARSER.then(|| {
-                    tracing::warn!("CSI t: Window manipulation not supported in multiplexer");
+                    tracing::warn!(
+                        "CSI t: Window manipulation not supported in multiplexer"
+                    );
                 });
             }
             'c' => {
                 // DA (Device Attributes) - Request terminal type/capabilities
                 // Not needed: Multiplexer doesn't respond to queries, parent terminal
-                // does. See [mod-level docs](crate::vt_100_pty_output_parser) for
+                // does. See [mod-level docs](crate::core::ansi::vt_100_pty_output_parser) for
                 // rationale
                 DEBUG_TUI_VT100_PARSER.then(|| {
                     tracing::warn!(
-                    "CSI c: Device Attributes query not supported in multiplexer"
-                );
+                        "CSI c: Device Attributes query not supported in multiplexer"
+                    );
                 });
             }
             'q' => {
                 // DECSCUSR (Set Cursor Style) - Change cursor shape/blink
                 // Not needed: Cursor rendering handled by terminal emulator.
-                // See [mod-level docs](crate::vt_100_pty_output_parser) for rationale
+                // See [mod-level docs](crate::core::ansi::vt_100_pty_output_parser) for rationale
                 DEBUG_TUI_VT100_PARSER.then(|| {
-                    tracing::warn!("CSI q: Set Cursor Style not supported in multiplexer");
+                    tracing::warn!(
+                        "CSI q: Set Cursor Style not supported in multiplexer"
+                    );
                 });
             }
             'p' => {
                 // Various DEC private sequences (DECRQM, etc.)
                 // Not needed: Private mode requests handled by parent terminal.
-                // See [mod-level docs](crate::vt_100_pty_output_parser) for rationale
+                // See [mod-level docs](crate::core::ansi::vt_100_pty_output_parser) for rationale
                 DEBUG_TUI_VT100_PARSER.then(|| {
                     tracing::warn!(
-                    "CSI p: DEC private sequences not supported in multiplexer"
-                );
+                        "CSI p: DEC private sequences not supported in multiplexer"
+                    );
                 });
             }
             'x' => {
                 // DECREQTPARM (Request Terminal Parameters) - Request terminal settings
                 // Not needed: Terminal parameters managed by parent emulator.
-                // See [mod-level docs](crate::vt_100_pty_output_parser) for rationale
+                // See [mod-level docs](crate::core::ansi::vt_100_pty_output_parser) for rationale
                 DEBUG_TUI_VT100_PARSER.then(|| {
                     tracing::warn!(
-                    "CSI x: Request Terminal Parameters not supported in multiplexer"
-                );
+                        "CSI x: Request Terminal Parameters not supported in multiplexer"
+                    );
                 });
             }
             'z' => {
                 // DECERA/DECSERA (DEC Erase/Selective Erase Rectangular Area)
                 // Not needed: Rectangular operations complex, rarely used
-                // See [mod-level docs](crate::vt_100_pty_output_parser) for rationale
+                // See [mod-level docs](crate::core::ansi::vt_100_pty_output_parser) for rationale
                 DEBUG_TUI_VT100_PARSER.then(|| {
                     tracing::warn!("CSI z: DEC Rectangular Erase not implemented");
                 });
@@ -818,14 +823,14 @@ impl Perform for AnsiToOfsBufPerformer<'_> {
     /// ## Supported [`ESC`] Sequences
     ///
     /// ### Cursor Save/Restore (Requires Persistent State)
-    /// - **[`ESC`] 7 (DECSC)**: Save cursor position to
-    ///   `ofs_buf.my_pos_for_esc_save_and_restore`
-    /// - **[`ESC`] 8 (DECRC)**: Restore cursor from
-    ///   `ofs_buf.my_pos_for_esc_save_and_restore`
+    /// - **[`ESC`] 7 ([`DECSC`])**: Save cursor position to
+    ///   `ofs_buf_vt_100.cursor_pos_for_esc_save_and_restore`
+    /// - **[`ESC`] 8 ([`DECRC`])**: Restore cursor from
+    ///   `ofs_buf_vt_100.cursor_pos_for_esc_save_and_restore`
     ///
     /// ### Character Set Selection (Requires Persistent State)
-    /// - **[`ESC`] ( B**: Select [`ASCII`] character set (normal text)
-    /// - **[`ESC`] ( 0**: Select [`DEC`] graphics (box-drawing characters)
+    /// - **`ESC ( B`**: Select [`ASCII`] character set (normal text)
+    /// - **`ESC ( 0`**: Select [`DEC`] graphics (box-drawing characters)
     ///
     /// ### Scrolling Operations (Stateless)
     /// - **[`ESC`] D (IND)**: Index - move cursor down, scroll if at bottom
@@ -838,14 +843,14 @@ impl Perform for AnsiToOfsBufPerformer<'_> {
     ///
     /// ```text
     /// Session 1: vim at position (5,10) sends ESC 7
-    ///   → AnsiToOfsBufPerformer::new() with ofs_buf.my_pos = (5,10)
+    ///   → AnsiToOfsBufPerformer::new() with ofs_buf_vt_100.cursor_pos = (5,10)
     ///   → esc_dispatch() handles ESC 7
-    ///   → Saves ofs_buf.ansi_parser_support.cursor_pos_for_esc_save_and_restore = Some((5,10))
+    ///   → Saves ofs_buf_vt_100.parser_global_state.cursor_pos_for_esc_save_and_restore = Some((5,10))
     ///
     /// Session 2: vim moves cursor to (20,30), then sends ESC 8
-    ///   → AnsiToOfsBufPerformer::new() with ofs_buf.my_pos = (20,30)
+    ///   → AnsiToOfsBufPerformer::new() with ofs_buf_vt_100.cursor_pos = (20,30)
     ///   → esc_dispatch() handles ESC 8
-    ///   → Restores ofs_buf.my_pos = cursor_pos_for_esc_save_and_restore.unwrap_or() // (5,10)
+    ///   → Restores ofs_buf_vt_100.cursor_pos = cursor_pos_for_esc_save_and_restore.unwrap_or() // (5,10)
     /// ```
     ///
     /// ## Malformed Sequence Handling
@@ -862,6 +867,8 @@ impl Perform for AnsiToOfsBufPerformer<'_> {
     /// [`ASCII`]: https://en.wikipedia.org/wiki/ASCII
     /// [`CSI`]: crate::CsiSequence
     /// [`DEC`]: https://en.wikipedia.org/wiki/Digital_Equipment_Corporation
+    /// [`DECRC`]: https://vt100.net/docs/vt510-rm/DECRC.html
+    /// [`DECSC`]: https://vt100.net/docs/vt510-rm/DECSC.html
     /// [`ESC`]: crate::EscSequence
     /// [`OSC`]: crate::osc_codes::OscSequence
     /// [`Parser`]: vte::Parser
@@ -874,9 +881,9 @@ impl Perform for AnsiToOfsBufPerformer<'_> {
         if ignore {
             DEBUG_TUI_VT100_PARSER.then(|| {
                 tracing::warn!(
-                "ESC {}: Discarding malformed sequence (VTE parser exceeded limits)",
-                byte as char
-            );
+                    "ESC {}: Discarding malformed sequence (VTE parser exceeded limits)",
+                    byte as char
+                );
             });
             return;
         }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/protocols/csi_codes/mod.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/protocols/csi_codes/mod.rs
@@ -42,7 +42,7 @@
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 //! [`CSI`]: crate::CsiSequence
-//! [`esc_codes`]: crate::vt_100_pty_output_parser::protocols::esc_codes
+//! [`esc_codes`]: crate::core::ansi::vt_100_pty_output_parser::protocols::esc_codes
 //! [`ESC`]: crate::EscSequence
 
 // Attach private module to avoid naming conflicts (hide inner details).

--- a/tui/src/core/ansi/vt_100_pty_output_parser/protocols/csi_codes/sequence.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/protocols/csi_codes/sequence.rs
@@ -10,7 +10,6 @@
 
 use super::{erase_mode::{EraseDisplayMode, EraseLineMode},
             private_mode::PrivateModeType};
-use crate::{generate_impl_display_for_fast_stringify, ok};
 use crate::{BufTextStorage, CsiCount, FastStringify, NumericConversions, TermCol,
             TermColDelta, TermRow, TermRowDelta,
             core::ansi::{constants::{CHA_CURSOR_COLUMN, CNL_CURSOR_NEXT_LINE,
@@ -28,6 +27,7 @@ use crate::{BufTextStorage, CsiCount, FastStringify, NumericConversions, TermCol
                                      SD_SCROLL_DOWN, SM_SET_PRIVATE_MODE,
                                      SU_SCROLL_UP, VPA_VERTICAL_POSITION},
                          generator::DsrRequestType},
+            generate_impl_display_for_fast_stringify, ok,
             stack_alloc_types::usize_fmt::{convert_u16_to_string_slice, u16_to_u8_array}};
 use std::fmt::{Formatter, Result};
 
@@ -178,13 +178,15 @@ pub enum CsiSequence {
     /// [`ESC`]: crate::EscSequence
     DeviceStatusReport(DsrRequestType),
     /// Enable Private Mode - [`ESC`] [ ? n h (n = mode number like `DECAWM_AUTO_WRAP`).
-    /// See [`crate::offscreen_buffer::AnsiParserSupport::auto_wrap_mode`]
+    /// See [`auto_wrap_mode`]
     ///
+    /// [`auto_wrap_mode`]: crate::ParserGlobalState::auto_wrap_mode
     /// [`ESC`]: crate::EscSequence
     EnablePrivateMode(PrivateModeType),
     /// Disable Private Mode - [`ESC`] [ ? n l (n = mode number like `DECAWM_AUTO_WRAP`).
-    /// See [`crate::offscreen_buffer::AnsiParserSupport::auto_wrap_mode`]
+    /// See [`auto_wrap_mode`]
     ///
+    /// [`auto_wrap_mode`]: crate::ParserGlobalState::auto_wrap_mode
     /// [`ESC`]: crate::EscSequence
     DisablePrivateMode(PrivateModeType),
     /// Insert Line (IL) - [`ESC`] [ n L.

--- a/tui/src/core/ansi/vt_100_pty_output_parser/protocols/csi_codes/sgr_color_sequences.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/protocols/csi_codes/sgr_color_sequences.rs
@@ -93,13 +93,13 @@
 //! [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
 //! [`VTE`]: mod@vte
 
-use crate::{generate_impl_display_for_fast_stringify, ok};
 use crate::{AnsiValue, RgbValue, TuiColor,
             core::{ansi::constants::{CSI_START, CSI_SUB_PARAM_SEPARATOR,
                                      SGR_BG_EXTENDED, SGR_COLOR_MODE_256,
                                      SGR_COLOR_MODE_RGB, SGR_FG_EXTENDED,
                                      SGR_SET_GRAPHICS},
                    common::fast_stringify::{BufTextStorage, FastStringify}},
+            generate_impl_display_for_fast_stringify, ok,
             stack_alloc_types::usize_fmt::{convert_u16_to_string_slice, u16_to_u8_array}};
 use std::fmt::Result;
 

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/conformance_data/mod.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/conformance_data/mod.rs
@@ -142,16 +142,16 @@
 //! ```ignore
 //! #[test]
 //! fn test_vim_status_line_display() {
-//!     let mut ofs_buf = create_realistic_terminal_buffer();
+//!     let mut ofs_buf_vt_100 = create_realistic_terminal_buffer();
 //!
 //!     // Apply sequence using conformance data
 //!     let sequence = vim_sequences::vim_status_line("INSERT", 25);
-//!     let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(sequence);
+//!     let (osc_events, dsr_responses) = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 //!
 //!     // Validate behavior
 //!     assert_eq!(osc_events.len(), 0);
 //!     assert_eq!(dsr_responses.len(), 0);
-//!     assert_styled_char_at(&ofs_buf, 24, 0, '-',
+//!     assert_styled_char_at(&ofs_buf_vt_100, 24, 0, '-',
 //!         |style| matches!(style.attribs.invert, Some(_)),
 //!         "status line reverse video");
 //! }
@@ -169,11 +169,11 @@
 //!
 //! // Clear screen and move cursor to home
 //! let sequence = basic_sequences::clear_and_home();
-//! ofs_buf.apply_ansi_bytes(sequence);
+//! ofs_buf_vt_100.apply_ansi_bytes(sequence);
 //!
 //! // Print text at specific position
 //! let text_seq = basic_sequences::move_and_print(5, 10, "Hello World");
-//! ofs_buf.apply_ansi_bytes(text_seq);
+//! ofs_buf_vt_100.apply_ansi_bytes(text_seq);
 //! ```
 //!
 //! ### Styling Operations
@@ -187,11 +187,11 @@
 //!
 //! // Apply colored text
 //! let red_text = styling_sequences::colored_text(ANSIBasicColor::Red, "Error");
-//! ofs_buf.apply_ansi_bytes(red_text);
+//! ofs_buf_vt_100.apply_ansi_bytes(red_text);
 //!
 //! // Create rainbow text
 //! let rainbow = styling_sequences::rainbow_text("RAINBOW");
-//! ofs_buf.apply_ansi_bytes(rainbow);
+//! ofs_buf_vt_100.apply_ansi_bytes(rainbow);
 //! ```
 //!
 //! ### Real-World Scenarios
@@ -204,11 +204,11 @@
 //!
 //! // Simulate vim status line
 //! let vim_status = vim_sequences::vim_status_line("NORMAL", 24);
-//! ofs_buf.apply_ansi_bytes(vim_status);
+//! ofs_buf_vt_100.apply_ansi_bytes(vim_status);
 //!
 //! // Simulate tmux status bar
 //! let tmux_status = tmux_sequences::tmux_status_bar();
-//! ofs_buf.apply_ansi_bytes(tmux_status);
+//! ofs_buf_vt_100.apply_ansi_bytes(tmux_status);
 //! ```
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/mod.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/mod.rs
@@ -29,13 +29,13 @@
 //! ```
 //!
 //! These conformance tests **intentionally** test the entire pipeline using
-//! [`OffscreenBuffer::apply_ansi_bytes`], not individual shim or implementation
+//! [`OfsBufVT100::apply_ansi_bytes`], not individual shim or implementation
 //! functions. This approach:
 //!
 //! 1. **Tests Real-World Usage**: Uses the same public API that production code uses
 //! 2. **Validates Complete Pipeline**: Ensures [`ANSI`] parsing → shim → impl → buffer
 //!    works together
-//! 3. **Complements Unit Tests**: While [`vt_100_ansi_impl`] files have unit tests, these
+//! 3. **Complements Unit Tests**: While [`ofs_buf_vt_100`] files have unit tests, these
 //!    test the integrated system
 //! 4. **Replaces Shim Tests**: Since the operation shims are pure delegation, these tests
 //!    provide their coverage
@@ -53,7 +53,7 @@
 //! └────────────────────────────────────────────────────────────────────────────┘
 //!                                     ↕ complements
 //! ┌────────────────────────────────────────────────────────────────────────────┐
-//! │                        UNIT TESTS (vt_100_ansi_impl)                       │
+//! │                        UNIT TESTS (ofs_buf_vt_100)                         │
 //! │  • Direct method calls to implementation functions                         │
 //! │  • Tests isolated buffer manipulation logic                                │
 //! │  • Fast execution, precise error diagnosis                                 │
@@ -69,14 +69,15 @@
 //! When working with any test file, you can navigate to its related implementation
 //! layers:
 //! - **Shim Layer**: The delegation layer being tested indirectly
-//! - **Implementation Layer**: [`vt_100_ansi_impl`] - The business logic being tested
+//! - **Implementation Layer**: [`ofs_buf_vt_100`] - The business logic being tested
 //! - **Testing Philosophy**: For the complete three-layer strategy
 //!
 //! For example, when working on character operations:
 //! 1. **Integration Tests**: Character operation tests (test-only) - Full [`ANSI`]
 //!    sequence testing
 //! 2. **Shim**: The delegation layer (tested indirectly here)
-//! 3. **Implementation**: [`impl_char_ops`] - Buffer logic (has separate unit tests)
+//! 3. **Implementation**: [`vt_100_impl_char_ops`] - Buffer logic (has separate unit
+//!    tests)
 //!
 //! ## Test Organization
 //!
@@ -109,8 +110,8 @@
 //! meant as runnable example -->
 //!
 //! ```ignore
-//! fn create_realistic_terminal_buffer() -> OffscreenBuffer {
-//!     OffscreenBuffer::new_empty(height(25) + width(80))
+//! fn create_realistic_terminal_buffer() -> OfsBufVT100 {
+//!     OfsBufVT100::new_empty(height(25) + width(80))
 //! }
 //! ```
 //!
@@ -318,14 +319,14 @@
 //! use crate::vt_100_pty_output_conformance_tests::conformance_data::vim_sequences;
 //!
 //! // Create realistic terminal buffer
-//! let mut ofs_buf = OffscreenBuffer::new_empty(height(25) + width(80));
+//! let mut ofs_buf_vt_100 = OfsBufVT100::new_empty(height(25) + width(80));
 //!
 //! // Apply vim status line sequence
 //! let sequence = vim_sequences::vim_status_line("INSERT", 25);
-//! let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(sequence);
+//! let (osc_events, dsr_responses) = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 //!
 //! // Verify status line appears at bottom with correct styling
-//! assert_styled_char_at(&ofs_buf, 24, 0, '-', |style| {
+//! assert_styled_char_at(&ofs_buf_vt_100, 24, 0, '-', |style| {
 //!     matches!(style.attribs.invert, Some(_))
 //! }, "status line reverse video");
 //! ```
@@ -337,8 +338,8 @@
 //! [`ESC`]: crate::EscSequence
 //! [`EscSequence`]: crate::EscSequence
 //! [`FastStringify`]: crate::fast_stringify::FastStringify
-//! [`impl_char_ops`]: crate::vt_100_ansi_impl::vt_100_impl_char_ops
-//! [`OffscreenBuffer::apply_ansi_bytes`]: crate::OffscreenBuffer::apply_ansi_bytes
+//! [`ofs_buf_vt_100`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf
+//! [`OfsBufVT100::apply_ansi_bytes`]: crate::OfsBufVT100::apply_ansi_bytes
 //! [`OSC`]: crate::osc_codes::OscSequence
 //! [`OscSequence`]: crate::core::osc::osc_codes::OscSequence
 //! [`SGR`]: crate::SgrCode
@@ -346,7 +347,7 @@
 //! [`test_char_ops`]: tests::vt_100_test_char_ops
 //! [`VT-100` spec]: https://vt100.net/docs/vt100-ug/chapter3.html
 //! [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
-//! [`vt_100_ansi_impl`]: crate::vt_100_ansi_impl
+//! [`vt_100_impl_char_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_char_ops
 //! [`vte`]: https://docs.rs/vte
 
 #[cfg(any(test, doc))]

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/test_fixtures_vt_100_ansi_conformance.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/test_fixtures_vt_100_ansi_conformance.rs
@@ -1,26 +1,28 @@
 // Copyright (c) 2025 R3BL LLC. Licensed under Apache License, Version 2.0.
 
-//! Test modules for ANSI parser implementation.
+//! Test modules for [`ANSI`] parser implementation.
+//!
+//! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 
-use crate::{OffscreenBuffer, TuiStyle, height, width};
+use crate::{OfsBufVT100, TuiStyle, height, width};
 use std::num::NonZeroU16;
 
-/// Creates a test `OffscreenBuffer` with 10x10 dimensions.
+/// Creates a test `OfsBufVT100` with 10x10 dimensions.
 #[must_use]
-pub fn create_test_offscreen_buffer_10r_by_10c() -> OffscreenBuffer {
-    OffscreenBuffer::new_empty(height(10) + width(10))
+pub fn create_test_offscreen_buffer_10r_by_10c() -> OfsBufVT100 {
+    OfsBufVT100::new_empty(height(10) + width(10))
 }
 
-/// Creates a test `OffscreenBuffer` with 20x20 dimensions for larger test scenarios.
+/// Creates a test `OfsBufVT100` with 20x20 dimensions for larger test scenarios.
 #[must_use]
-pub fn create_test_offscreen_buffer_20r_by_20c() -> OffscreenBuffer {
-    OffscreenBuffer::new_empty(height(20) + width(20))
+pub fn create_test_offscreen_buffer_20r_by_20c() -> OfsBufVT100 {
+    OfsBufVT100::new_empty(height(20) + width(20))
 }
 
 /// Creates a test buffer with numbered lines for easier test verification.
 #[must_use]
-pub fn create_numbered_buffer(rows: usize, cols: usize) -> OffscreenBuffer {
-    let mut buf = OffscreenBuffer::new_empty(height(rows) + width(cols));
+pub fn create_numbered_buffer(rows: usize, cols: usize) -> OfsBufVT100 {
+    let mut buf = OfsBufVT100::new_empty(height(rows) + width(cols));
     for r in 0..rows {
         let line_text = format!("Line{r:02}");
         for (c, ch) in line_text.chars().enumerate() {
@@ -43,7 +45,7 @@ pub fn create_numbered_buffer(rows: usize, cols: usize) -> OffscreenBuffer {
 ///
 /// # Panics
 /// Panics if `row` is out of bounds for the buffer.
-pub fn assert_line_content(buf: &OffscreenBuffer, row: usize, expected: &str) {
+pub fn assert_line_content(buf: &OfsBufVT100, row: usize, expected: &str) {
     let actual: String = buf.buffer[row]
         .iter()
         .take(expected.len())
@@ -63,7 +65,7 @@ pub fn assert_line_content(buf: &OffscreenBuffer, row: usize, expected: &str) {
 ///
 /// # Panics
 /// Panics if `row` is out of bounds for the buffer.
-pub fn assert_blank_line(buf: &OffscreenBuffer, row: usize) {
+pub fn assert_blank_line(buf: &OfsBufVT100, row: usize) {
     let is_blank = buf.buffer[row]
         .iter()
         .all(|pixel_char| matches!(pixel_char, crate::PixelChar::Spacer));

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/mod.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/mod.rs
@@ -3,7 +3,7 @@
 //! Test modules for [`VT-100`] [`ANSI`] conformance validation.
 //!
 //! This module organizes conformance tests by functionality and architectural layer:
-//! - Operations tests (test_*_ops.rs) - Test operations modules directly
+//! - Operations tests (test_*_ops.rs) - Test ops modules directly
 //! - Protocol tests (`test_protocol_*.rs`) - Test [`ANSI`]/[`VT-100`] protocol parsing
 //! - System tests (`test_system_*.rs`) - Test system components and lifecycle
 //! - Integration tests (`test_integration_*.rs`) - Test cross-cutting scenarios
@@ -14,9 +14,9 @@
 //! architecture, creating a clear 1:1:1 mapping for navigation:
 //!
 //! ```text
-//! vt_100_test_char_ops ←→ operations/vt_100_shim_char_ops ←→ vt_100_ansi_impl/vt_100_impl_char_ops
-//! vt_100_test_cursor_ops ←→ operations/vt_100_shim_cursor_ops ←→ vt_100_ansi_impl/vt_100_impl_cursor_ops
-//! vt_100_test_sgr_ops ←→ operations/vt_100_shim_sgr_ops ←→ vt_100_ansi_impl/vt_100_impl_sgr_ops
+//! vt_100_test_char_ops ←→ operations/vt_100_shim_char_ops ←→ ofs_buf_vt_100/impl_char_ops
+//! vt_100_test_cursor_ops ←→ operations/vt_100_shim_cursor_ops ←→ ofs_buf_vt_100/impl_cursor_ops
+//! vt_100_test_sgr_ops ←→ operations/vt_100_shim_sgr_ops ←→ ofs_buf_vt_100/impl_sgr_ops
 //! ...and so on
 //! ```
 //!
@@ -24,7 +24,7 @@
 //!
 //! When working on any test file, you can easily navigate to its corresponding:
 //! - **Shim Layer**: [`operations`] - The delegation layer being tested indirectly
-//! - **Implementation Layer**: [`vt_100_ansi_impl`] - The business logic being tested
+//! - **Implementation Layer**: [`ofs_buf_vt_100`] - The business logic being tested
 //! - **Parent Documentation**: See [conformance tests] for the integration testing
 //!   philosophy
 //!
@@ -32,15 +32,15 @@
 //! 1. **Integration**: [`vt_100_test_char_ops`] - Tests using [`apply_ansi_bytes`] public
 //!    API
 //! 2. **Shim**: [`operations::char_ops`] - Parameter translation (no direct tests)
-//! 3. **Implementation**: [`impl_char_ops`] - Buffer logic (has unit tests)
+//! 3. **Implementation**: [`vt_100_impl_char_ops`] - Buffer logic (has unit tests)
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
-//! [`apply_ansi_bytes`]: crate::OffscreenBuffer::apply_ansi_bytes
-//! [`impl_char_ops`]: crate::vt_100_ansi_impl::vt_100_impl_char_ops
-//! [`operations::char_ops`]: super::super::operations::vt_100_shim_char_ops
-//! [`operations`]: super::super::operations
+//! [`apply_ansi_bytes`]: crate::OfsBufVT100::apply_ansi_bytes
+//! [`ofs_buf_vt_100`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf
+//! [`operations::char_ops`]: super::super::ops::vt_100_shim_char_ops
+//! [`operations`]: super::super::ops
 //! [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
-//! [`vt_100_ansi_impl`]: crate::vt_100_ansi_impl
+//! [`vt_100_impl_char_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_char_ops
 //! [conformance tests]: super
 
 // === OPERATIONS TESTS ===

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_char_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_char_ops.rs
@@ -9,12 +9,13 @@
 //!
 //! **Related Files:**
 //! - **Shim**: [`char_ops`] - Parameter translation (tested indirectly by this module)
-//! - **Implementation**: [`impl_char_ops`] - Business logic (has separate unit tests)
+//! - **Implementation**: [`vt_100_impl_char_ops`] - Business logic (has separate unit
+//!   tests)
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
-//! [`apply_ansi_bytes`]: crate::OffscreenBuffer::apply_ansi_bytes
-//! [`char_ops`]: crate::vt_100_pty_output_parser::operations::vt_100_shim_char_ops
-//! [`impl_char_ops`]: crate::vt_100_ansi_impl::vt_100_impl_char_ops
+//! [`apply_ansi_bytes`]: crate::OfsBufVT100::apply_ansi_bytes
+//! [`char_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops::vt_100_shim_char_ops
+//! [`vt_100_impl_char_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_char_ops
 //! [parser module docs]: super::super
 
 use super::super::test_fixtures_vt_100_ansi_conformance::*;
@@ -22,7 +23,7 @@ use crate::{CsiCount, TermCol, TuiStyle,
             core::ansi::vt_100_pty_output_parser::CsiSequence};
 
 /// Helper to create a buffer with "ABCDEFGHIJ" in the first row.
-fn create_alphabet_buffer() -> crate::OffscreenBuffer {
+fn create_alphabet_buffer() -> crate::OfsBufVT100 {
     let mut buf = create_test_offscreen_buffer_10r_by_10c();
     let alphabet = "ABCDEFGHIJ";
     for (i, ch) in alphabet.chars().enumerate() {
@@ -40,7 +41,7 @@ pub mod delete_char {
 
     #[test]
     fn test_delete_single_char() {
-        let mut ofs_buf = create_alphabet_buffer();
+        let mut ofs_buf_vt_100 = create_alphabet_buffer();
 
         // Move cursor to column 3 (letter 'D') and delete one character
         let move_cursor = CsiSequence::CursorHorizontalAbsolute(
@@ -48,15 +49,15 @@ pub mod delete_char {
         ); // Move to column 4 (1-based)
         let delete_char = CsiSequence::DeleteChar(CsiCount::ONE);
         let sequence = format!("{move_cursor}{delete_char}");
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
         // Verify: "ABC" + "EFGHIJ" + " " (D deleted, chars shifted left, blank at end)
-        assert_line_content(&ofs_buf, 0, "ABCEFGHIJ ");
+        assert_line_content(&ofs_buf_vt_100, 0, "ABCEFGHIJ ");
     }
 
     #[test]
     fn test_delete_multiple_chars() {
-        let mut ofs_buf = create_alphabet_buffer();
+        let mut ofs_buf_vt_100 = create_alphabet_buffer();
 
         // Move cursor to column 2 (letter 'C') and delete three characters
         let move_cursor = CsiSequence::CursorHorizontalAbsolute(
@@ -64,16 +65,16 @@ pub mod delete_char {
         ); // Move to column 3 (1-based)
         let delete_chars = CsiSequence::DeleteChar(CsiCount::new(3).unwrap());
         let sequence = format!("{move_cursor}{delete_chars}");
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
         // Verify: "AB" + "FGHIJ" + "   " (CDE deleted, chars shifted left, 3 blanks at
         // end).
-        assert_line_content(&ofs_buf, 0, "ABFGHIJ   ");
+        assert_line_content(&ofs_buf_vt_100, 0, "ABFGHIJ   ");
     }
 
     #[test]
     fn test_delete_chars_at_end_of_line() {
-        let mut ofs_buf = create_alphabet_buffer();
+        let mut ofs_buf_vt_100 = create_alphabet_buffer();
 
         // Move cursor to column 8 (letter 'I') and delete 5 chars
         let move_cursor = CsiSequence::CursorHorizontalAbsolute(
@@ -81,15 +82,15 @@ pub mod delete_char {
         ); // Move to column 9 (1-based)
         let delete_chars = CsiSequence::DeleteChar(CsiCount::new(5).unwrap());
         let sequence = format!("{move_cursor}{delete_chars}");
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
         // Verify: "ABCDEFGH" + "  " (IJ deleted, 2 blanks at end)
-        assert_line_content(&ofs_buf, 0, "ABCDEFGH  ");
+        assert_line_content(&ofs_buf_vt_100, 0, "ABCDEFGH  ");
     }
 
     #[test]
     fn test_delete_chars_beyond_right_margin_ignored() {
-        let mut ofs_buf = create_alphabet_buffer();
+        let mut ofs_buf_vt_100 = create_alphabet_buffer();
 
         // Move cursor beyond right margin and try to delete.
         // The cursor will be clamped to column 10, and delete will happen there.
@@ -98,11 +99,11 @@ pub mod delete_char {
         ); // Move to column 11 (beyond)
         let delete_char = CsiSequence::DeleteChar(CsiCount::ONE);
         let sequence = format!("{move_cursor}{delete_char}");
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
         // When cursor is clamped to position 10, DeleteChar will delete 'J' at position
         // 10, leaving a space at the end.
-        assert_line_content(&ofs_buf, 0, "ABCDEFGHI ");
+        assert_line_content(&ofs_buf_vt_100, 0, "ABCDEFGHI ");
     }
 }
 
@@ -112,7 +113,7 @@ pub mod insert_char {
 
     #[test]
     fn test_insert_single_char() {
-        let mut ofs_buf = create_alphabet_buffer();
+        let mut ofs_buf_vt_100 = create_alphabet_buffer();
 
         // Move cursor to column 3 (letter 'D') and insert one character.
         let move_cursor = CsiSequence::CursorHorizontalAbsolute(
@@ -120,15 +121,15 @@ pub mod insert_char {
         ); // Move to column 4 (1-based)
         let insert_char = CsiSequence::InsertChar(CsiCount::ONE);
         let sequence = format!("{move_cursor}{insert_char}");
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
         // Verify: "ABC" + " " + "DEFGHI" (blank inserted, chars shifted right, J lost).
-        assert_line_content(&ofs_buf, 0, "ABC DEFGHI");
+        assert_line_content(&ofs_buf_vt_100, 0, "ABC DEFGHI");
     }
 
     #[test]
     fn test_insert_multiple_chars() {
-        let mut ofs_buf = create_alphabet_buffer();
+        let mut ofs_buf_vt_100 = create_alphabet_buffer();
 
         // Move cursor to column 2 (letter 'C') and insert three characters
         let move_cursor = CsiSequence::CursorHorizontalAbsolute(
@@ -136,16 +137,16 @@ pub mod insert_char {
         ); // Move to column 3 (1-based)
         let insert_chars = CsiSequence::InsertChar(CsiCount::new(3).unwrap());
         let sequence = format!("{move_cursor}{insert_chars}");
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
         // Verify: "AB" + "   " + "CDEFG" (3 blanks inserted, chars shifted right, HIJ
         // lost).
-        assert_line_content(&ofs_buf, 0, "AB   CDEFG");
+        assert_line_content(&ofs_buf_vt_100, 0, "AB   CDEFG");
     }
 
     #[test]
     fn test_insert_chars_at_end_of_line() {
-        let mut ofs_buf = create_alphabet_buffer();
+        let mut ofs_buf_vt_100 = create_alphabet_buffer();
 
         // Move cursor to column 8 (letter 'I') and insert three characters
         let move_cursor = CsiSequence::CursorHorizontalAbsolute(
@@ -153,15 +154,15 @@ pub mod insert_char {
         ); // Move to column 9 (1-based)
         let insert_chars = CsiSequence::InsertChar(CsiCount::new(3).unwrap());
         let sequence = format!("{move_cursor}{insert_chars}");
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
         // Verify: "ABCDEFGH" + "  " (only 2 blanks can be inserted, IJ lost)
-        assert_line_content(&ofs_buf, 0, "ABCDEFGH  ");
+        assert_line_content(&ofs_buf_vt_100, 0, "ABCDEFGH  ");
     }
 
     #[test]
     fn test_insert_chars_beyond_right_margin_ignored() {
-        let mut ofs_buf = create_alphabet_buffer();
+        let mut ofs_buf_vt_100 = create_alphabet_buffer();
 
         // Move cursor beyond right margin and try to insert.
         // The cursor will be clamped to column 10, and insert will happen there.
@@ -170,11 +171,11 @@ pub mod insert_char {
         ); // Move to column 11 (beyond)
         let insert_char = CsiSequence::InsertChar(CsiCount::ONE);
         let sequence = format!("{move_cursor}{insert_char}");
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
         // When cursor is clamped to position 10, InsertChar will insert a space at
         // position 10, pushing 'J' off the right edge.
-        assert_line_content(&ofs_buf, 0, "ABCDEFGHI ");
+        assert_line_content(&ofs_buf_vt_100, 0, "ABCDEFGHI ");
     }
 }
 
@@ -184,7 +185,7 @@ pub mod erase_char {
 
     #[test]
     fn test_erase_single_char() {
-        let mut ofs_buf = create_alphabet_buffer();
+        let mut ofs_buf_vt_100 = create_alphabet_buffer();
 
         // Move cursor to column 3 (letter 'D') and erase one character
         let move_cursor = CsiSequence::CursorHorizontalAbsolute(
@@ -192,15 +193,15 @@ pub mod erase_char {
         ); // Move to column 4 (1-based)
         let erase_char = CsiSequence::EraseChar(CsiCount::ONE);
         let sequence = format!("{move_cursor}{erase_char}");
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
         // Verify: "ABC" + " " + "EFGHIJ" (D erased to blank, no shifting)
-        assert_line_content(&ofs_buf, 0, "ABC EFGHIJ");
+        assert_line_content(&ofs_buf_vt_100, 0, "ABC EFGHIJ");
     }
 
     #[test]
     fn test_erase_multiple_chars() {
-        let mut ofs_buf = create_alphabet_buffer();
+        let mut ofs_buf_vt_100 = create_alphabet_buffer();
 
         // Move cursor to column 2 (letter 'C') and erase three characters
         let move_cursor = CsiSequence::CursorHorizontalAbsolute(
@@ -208,15 +209,15 @@ pub mod erase_char {
         ); // Move to column 3 (1-based)
         let erase_chars = CsiSequence::EraseChar(CsiCount::new(3).unwrap());
         let sequence = format!("{move_cursor}{erase_chars}");
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
         // Verify: "AB" + "   " + "FGHIJ" (CDE erased to blanks, no shifting)
-        assert_line_content(&ofs_buf, 0, "AB   FGHIJ");
+        assert_line_content(&ofs_buf_vt_100, 0, "AB   FGHIJ");
     }
 
     #[test]
     fn test_erase_chars_at_end_of_line() {
-        let mut ofs_buf = create_alphabet_buffer();
+        let mut ofs_buf_vt_100 = create_alphabet_buffer();
 
         // Move cursor to column 8 (letter 'I') and erase five characters
         let move_cursor = CsiSequence::CursorHorizontalAbsolute(
@@ -224,15 +225,15 @@ pub mod erase_char {
         ); // Move to column 9 (1-based)
         let erase_chars = CsiSequence::EraseChar(CsiCount::new(5).unwrap());
         let sequence = format!("{move_cursor}{erase_chars}");
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
         // Verify: "ABCDEFGH" + "  " (IJ erased to blanks)
-        assert_line_content(&ofs_buf, 0, "ABCDEFGH  ");
+        assert_line_content(&ofs_buf_vt_100, 0, "ABCDEFGH  ");
     }
 
     #[test]
     fn test_erase_chars_beyond_right_margin_ignored() {
-        let mut ofs_buf = create_alphabet_buffer();
+        let mut ofs_buf_vt_100 = create_alphabet_buffer();
 
         // Move cursor beyond right margin and try to erase.
         // The cursor will be clamped to column 10, and erase will happen there.
@@ -241,11 +242,11 @@ pub mod erase_char {
         ); // Move to column 11 (beyond)
         let erase_char = CsiSequence::EraseChar(CsiCount::ONE);
         let sequence = format!("{move_cursor}{erase_char}");
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
         // When cursor is clamped to position 10, EraseChar will erase 'J' at position 10,
         // replacing it with a space.
-        assert_line_content(&ofs_buf, 0, "ABCDEFGHI ");
+        assert_line_content(&ofs_buf_vt_100, 0, "ABCDEFGHI ");
     }
 
     #[test]

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_clear_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_clear_ops.rs
@@ -9,21 +9,24 @@
 //!
 //! **Related Files:**
 //! - **Shim**: [`clear_ops`] - Parameter translation (tested indirectly by this module)
-//! - **Implementation**: [`impl_clear_ops`] - Business logic (has separate unit tests)
+//! - **Implementation**: [`vt_100_impl_clear_ops`] - Business logic (has separate unit
+//!   tests)
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
-//! [`apply_ansi_bytes`]: crate::OffscreenBuffer::apply_ansi_bytes
-//! [`clear_ops`]: crate::vt_100_pty_output_parser::operations::vt_100_shim_clear_ops
-//! [`impl_clear_ops`]: crate::vt_100_ansi_impl::vt_100_impl_clear_ops
+//! [`apply_ansi_bytes`]: crate::OfsBufVT100::apply_ansi_bytes
+//! [`clear_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops::vt_100_shim_clear_ops
+//! [`vt_100_impl_clear_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_clear_ops
 //! [parser module docs]: super::super
 
 use super::super::test_fixtures_vt_100_ansi_conformance::*;
-use crate::{EraseDisplayMode, EraseLineMode, OffscreenBuffer, PixelChar, TuiStyle, col, core::ansi::{constants::{CSI_START, ED_ERASE_DISPLAY, EL_ERASE_LINE},
-                         vt_100_pty_output_parser::CsiSequence}, row};
+use crate::{EraseDisplayMode, EraseLineMode, OfsBufVT100, PixelChar, TuiStyle, col,
+            core::ansi::{constants::{CSI_START, ED_ERASE_DISPLAY, EL_ERASE_LINE},
+                         vt_100_pty_output_parser::CsiSequence},
+            row};
 
 /// Helper to create a fully filled 5x5 offscreen buffer with 'X' characters.
-fn create_filled_5r_by_5c_buffer() -> OffscreenBuffer {
-    let mut buf = OffscreenBuffer::new_empty(crate::height(5) + crate::width(5));
+fn create_filled_5r_by_5c_buffer() -> OfsBufVT100 {
+    let mut buf = OfsBufVT100::new_empty(crate::height(5) + crate::width(5));
     let style = TuiStyle::default();
     let char_x = PixelChar::PlainText {
         display_char: 'X',
@@ -43,39 +46,39 @@ fn test_parameter_defaults() {
 
     // CSI J should be parsed as CSI 0 J (EraseDisplay FromCursorToEnd)
     {
-        let mut ofs_buf = create_filled_5r_by_5c_buffer();
-        ofs_buf.cursor_pos = row(2) + col(2);
+        let mut ofs_buf_vt_100 = create_filled_5r_by_5c_buffer();
+        ofs_buf_vt_100.cursor_pos = row(2) + col(2);
 
         // Apply CSI J (no param)
         let csi_j_no_param = format!("{CSI_START}{ED_ERASE_DISPLAY}");
-        let _result = ofs_buf.apply_ansi_bytes(csi_j_no_param);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(csi_j_no_param);
 
         // Line 2: cursor is at col 2. So cols 2, 3, 4 should be cleared.
-        assert_line_content(&ofs_buf, 2, "XX   ");
+        assert_line_content(&ofs_buf_vt_100, 2, "XX   ");
         // Lines 3 and 4 should be fully cleared.
-        assert_line_content(&ofs_buf, 3, "     ");
-        assert_line_content(&ofs_buf, 4, "     ");
+        assert_line_content(&ofs_buf_vt_100, 3, "     ");
+        assert_line_content(&ofs_buf_vt_100, 4, "     ");
         // Lines 0 and 1 should remain untouched.
-        assert_line_content(&ofs_buf, 0, "XXXXX");
-        assert_line_content(&ofs_buf, 1, "XXXXX");
+        assert_line_content(&ofs_buf_vt_100, 0, "XXXXX");
+        assert_line_content(&ofs_buf_vt_100, 1, "XXXXX");
     }
 
     // CSI K should be parsed as CSI 0 K (EraseLine FromCursorToEnd)
     {
-        let mut ofs_buf = create_filled_5r_by_5c_buffer();
-        ofs_buf.cursor_pos = row(2) + col(2);
+        let mut ofs_buf_vt_100 = create_filled_5r_by_5c_buffer();
+        ofs_buf_vt_100.cursor_pos = row(2) + col(2);
 
         // Apply CSI K (no param)
         let csi_k_no_param = format!("{CSI_START}{EL_ERASE_LINE}");
-        let _result = ofs_buf.apply_ansi_bytes(csi_k_no_param);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(csi_k_no_param);
 
         // Line 2: cursor is at col 2. So cols 2, 3, 4 of Line 2 should be cleared.
-        assert_line_content(&ofs_buf, 2, "XX   ");
+        assert_line_content(&ofs_buf_vt_100, 2, "XX   ");
         // All other lines remain untouched.
-        assert_line_content(&ofs_buf, 0, "XXXXX");
-        assert_line_content(&ofs_buf, 1, "XXXXX");
-        assert_line_content(&ofs_buf, 3, "XXXXX");
-        assert_line_content(&ofs_buf, 4, "XXXXX");
+        assert_line_content(&ofs_buf_vt_100, 0, "XXXXX");
+        assert_line_content(&ofs_buf_vt_100, 1, "XXXXX");
+        assert_line_content(&ofs_buf_vt_100, 3, "XXXXX");
+        assert_line_content(&ofs_buf_vt_100, 4, "XXXXX");
     }
 }
 
@@ -83,53 +86,53 @@ fn test_parameter_defaults() {
 fn test_erase_display_modes() {
     // Mode 0: From Cursor to End
     {
-        let mut ofs_buf = create_filled_5r_by_5c_buffer();
-        ofs_buf.cursor_pos = row(1) + col(3);
+        let mut ofs_buf_vt_100 = create_filled_5r_by_5c_buffer();
+        ofs_buf_vt_100.cursor_pos = row(1) + col(3);
 
         // CSI 0 J
         let sequence =
             CsiSequence::EraseDisplay(EraseDisplayMode::FromCursorToEnd).to_string();
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
-        assert_line_content(&ofs_buf, 0, "XXXXX");
-        assert_line_content(&ofs_buf, 1, "XXX  ");
-        assert_line_content(&ofs_buf, 2, "     ");
-        assert_line_content(&ofs_buf, 3, "     ");
-        assert_line_content(&ofs_buf, 4, "     ");
+        assert_line_content(&ofs_buf_vt_100, 0, "XXXXX");
+        assert_line_content(&ofs_buf_vt_100, 1, "XXX  ");
+        assert_line_content(&ofs_buf_vt_100, 2, "     ");
+        assert_line_content(&ofs_buf_vt_100, 3, "     ");
+        assert_line_content(&ofs_buf_vt_100, 4, "     ");
     }
 
     // Mode 1: From Start to Cursor
     {
-        let mut ofs_buf = create_filled_5r_by_5c_buffer();
-        ofs_buf.cursor_pos = row(2) + col(2);
+        let mut ofs_buf_vt_100 = create_filled_5r_by_5c_buffer();
+        ofs_buf_vt_100.cursor_pos = row(2) + col(2);
 
         // CSI 1 J
         let sequence =
             CsiSequence::EraseDisplay(EraseDisplayMode::FromStartToCursor).to_string();
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
-        assert_line_content(&ofs_buf, 0, "     ");
-        assert_line_content(&ofs_buf, 1, "     ");
-        assert_line_content(&ofs_buf, 2, "   XX");
-        assert_line_content(&ofs_buf, 3, "XXXXX");
-        assert_line_content(&ofs_buf, 4, "XXXXX");
+        assert_line_content(&ofs_buf_vt_100, 0, "     ");
+        assert_line_content(&ofs_buf_vt_100, 1, "     ");
+        assert_line_content(&ofs_buf_vt_100, 2, "   XX");
+        assert_line_content(&ofs_buf_vt_100, 3, "XXXXX");
+        assert_line_content(&ofs_buf_vt_100, 4, "XXXXX");
     }
 
     // Mode 2: Entire Screen
     {
-        let mut ofs_buf = create_filled_5r_by_5c_buffer();
-        ofs_buf.cursor_pos = row(2) + col(2);
+        let mut ofs_buf_vt_100 = create_filled_5r_by_5c_buffer();
+        ofs_buf_vt_100.cursor_pos = row(2) + col(2);
 
         // CSI 2 J
         let sequence =
             CsiSequence::EraseDisplay(EraseDisplayMode::EntireScreen).to_string();
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
-        assert_line_content(&ofs_buf, 0, "     ");
-        assert_line_content(&ofs_buf, 1, "     ");
-        assert_line_content(&ofs_buf, 2, "     ");
-        assert_line_content(&ofs_buf, 3, "     ");
-        assert_line_content(&ofs_buf, 4, "     ");
+        assert_line_content(&ofs_buf_vt_100, 0, "     ");
+        assert_line_content(&ofs_buf_vt_100, 1, "     ");
+        assert_line_content(&ofs_buf_vt_100, 2, "     ");
+        assert_line_content(&ofs_buf_vt_100, 3, "     ");
+        assert_line_content(&ofs_buf_vt_100, 4, "     ");
     }
 }
 
@@ -137,41 +140,41 @@ fn test_erase_display_modes() {
 fn test_erase_line_modes() {
     // Mode 0: From Cursor to End
     {
-        let mut ofs_buf = create_filled_5r_by_5c_buffer();
-        ofs_buf.cursor_pos = row(2) + col(1);
+        let mut ofs_buf_vt_100 = create_filled_5r_by_5c_buffer();
+        ofs_buf_vt_100.cursor_pos = row(2) + col(1);
 
         // CSI 0 K
         let sequence = CsiSequence::EraseLine(EraseLineMode::FromCursorToEnd).to_string();
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
-        assert_line_content(&ofs_buf, 2, "X    ");
-        assert_line_content(&ofs_buf, 1, "XXXXX");
+        assert_line_content(&ofs_buf_vt_100, 2, "X    ");
+        assert_line_content(&ofs_buf_vt_100, 1, "XXXXX");
     }
 
     // Mode 1: From Start to Cursor
     {
-        let mut ofs_buf = create_filled_5r_by_5c_buffer();
-        ofs_buf.cursor_pos = row(2) + col(3);
+        let mut ofs_buf_vt_100 = create_filled_5r_by_5c_buffer();
+        ofs_buf_vt_100.cursor_pos = row(2) + col(3);
 
         // CSI 1 K
         let sequence =
             CsiSequence::EraseLine(EraseLineMode::FromStartToCursor).to_string();
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
-        assert_line_content(&ofs_buf, 2, "    X");
-        assert_line_content(&ofs_buf, 1, "XXXXX");
+        assert_line_content(&ofs_buf_vt_100, 2, "    X");
+        assert_line_content(&ofs_buf_vt_100, 1, "XXXXX");
     }
 
     // Mode 2: Entire Line
     {
-        let mut ofs_buf = create_filled_5r_by_5c_buffer();
-        ofs_buf.cursor_pos = row(2) + col(2);
+        let mut ofs_buf_vt_100 = create_filled_5r_by_5c_buffer();
+        ofs_buf_vt_100.cursor_pos = row(2) + col(2);
 
         // CSI 2 K
         let sequence = CsiSequence::EraseLine(EraseLineMode::EntireLine).to_string();
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
-        assert_line_content(&ofs_buf, 2, "     ");
-        assert_line_content(&ofs_buf, 1, "XXXXX");
+        assert_line_content(&ofs_buf_vt_100, 2, "     ");
+        assert_line_content(&ofs_buf_vt_100, 1, "XXXXX");
     }
 }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_control_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_control_ops.rs
@@ -23,21 +23,21 @@ pub mod basic_tab_operations {
 
     #[test]
     fn test_tab_from_column_zero() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Start at column 0 (origin)
-        assert_eq!(ofs_buf.cursor_pos.col_index, crate::col(0));
+        assert_eq!(ofs_buf_vt_100.cursor_pos.col_index, crate::col(0));
 
         // Send TAB character
-        let _result = ofs_buf.apply_ansi_bytes("\t");
+        let _result = ofs_buf_vt_100.apply_ansi_bytes("\t");
 
         // Should move to column 8 (next 8-column tab stop)
-        assert_eq!(ofs_buf.cursor_pos.col_index, crate::col(8));
+        assert_eq!(ofs_buf_vt_100.cursor_pos.col_index, crate::col(8));
     }
 
     #[test]
     fn test_tab_from_mid_column() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Move cursor to column 3
         let move_sequence = format!(
@@ -47,19 +47,19 @@ pub mod basic_tab_operations {
                 col: term_col(nz(4)) // 1-based column 4 = 0-based column 3
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(move_sequence);
-        assert_eq!(ofs_buf.cursor_pos.col_index, crate::col(3));
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(move_sequence);
+        assert_eq!(ofs_buf_vt_100.cursor_pos.col_index, crate::col(3));
 
         // Send TAB character
-        let _result = ofs_buf.apply_ansi_bytes("\t");
+        let _result = ofs_buf_vt_100.apply_ansi_bytes("\t");
 
         // Should move to column 8 (next 8-column tab stop)
-        assert_eq!(ofs_buf.cursor_pos.col_index, crate::col(8));
+        assert_eq!(ofs_buf_vt_100.cursor_pos.col_index, crate::col(8));
     }
 
     #[test]
     fn test_tab_at_tab_stop_boundary() {
-        let mut ofs_buf = create_test_offscreen_buffer_20r_by_20c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_20r_by_20c();
 
         // Move cursor to column 8 (already at a tab stop)
         let move_sequence = format!(
@@ -69,35 +69,38 @@ pub mod basic_tab_operations {
                 col: term_col(nz(9)) // 1-based column 9 = 0-based column 8
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(move_sequence);
-        assert_eq!(ofs_buf.cursor_pos.col_index, crate::col(8));
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(move_sequence);
+        assert_eq!(ofs_buf_vt_100.cursor_pos.col_index, crate::col(8));
 
         // Send TAB character
-        let _result = ofs_buf.apply_ansi_bytes("\t");
+        let _result = ofs_buf_vt_100.apply_ansi_bytes("\t");
 
         // Should move to column 16 (next 8-column tab stop)
-        assert_eq!(ofs_buf.cursor_pos.col_index, crate::col(16));
+        assert_eq!(ofs_buf_vt_100.cursor_pos.col_index, crate::col(16));
     }
 
     #[test]
     fn test_multiple_consecutive_tabs() {
-        let mut ofs_buf = create_test_offscreen_buffer_20r_by_20c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_20r_by_20c();
 
         // Start at column 0
-        assert_eq!(ofs_buf.cursor_pos.col_index, crate::col(0));
+        assert_eq!(ofs_buf_vt_100.cursor_pos.col_index, crate::col(0));
 
         // Send multiple TAB characters
-        let _result = ofs_buf.apply_ansi_bytes("\t\t\t");
+        let _result = ofs_buf_vt_100.apply_ansi_bytes("\t\t\t");
 
         // Should move through tab stops: 0 → 8 → 16 → 24
         // But buffer is only 20 columns wide, so clamp to max column index 19
         let expected_col = std::cmp::min(24, 20 - 1); // 19
-        assert_eq!(ofs_buf.cursor_pos.col_index, crate::col(expected_col));
+        assert_eq!(
+            ofs_buf_vt_100.cursor_pos.col_index,
+            crate::col(expected_col)
+        );
     }
 
     #[test]
     fn test_tab_near_right_margin() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Move cursor to column 9 (near right margin)
         let move_sequence = format!(
@@ -107,30 +110,30 @@ pub mod basic_tab_operations {
                 col: term_col(nz(10)) // 1-based column 10 = 0-based column 9
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(move_sequence);
-        assert_eq!(ofs_buf.cursor_pos.col_index, crate::col(9));
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(move_sequence);
+        assert_eq!(ofs_buf_vt_100.cursor_pos.col_index, crate::col(9));
 
         // Send TAB character
-        let _result = ofs_buf.apply_ansi_bytes("\t");
+        let _result = ofs_buf_vt_100.apply_ansi_bytes("\t");
 
         // Should clamp to rightmost column (next tab stop would be 16, but buffer is only
         // 10 wide)
-        assert_eq!(ofs_buf.cursor_pos.col_index, crate::col(9)); // Stays at max valid column
+        assert_eq!(ofs_buf_vt_100.cursor_pos.col_index, crate::col(9)); // Stays at max valid column
     }
 
     #[test]
     fn test_tab_with_text() {
-        let mut ofs_buf = create_test_offscreen_buffer_20r_by_20c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_20r_by_20c();
 
         // Write some text, then tab, then more text
-        let _result = ofs_buf.apply_ansi_bytes("ABC\tDEF");
+        let _result = ofs_buf_vt_100.apply_ansi_bytes("ABC\tDEF");
 
         // Check cursor position (ABC = 3 chars, tab moves to column 8, DEF = 3 more
         // chars)
-        assert_eq!(ofs_buf.cursor_pos.col_index, crate::col(11)); // 8 + 3 = 11
+        assert_eq!(ofs_buf_vt_100.cursor_pos.col_index, crate::col(11)); // 8 + 3 = 11
 
         // Verify the text placement
-        let first_row = &ofs_buf.buffer[0];
+        let first_row = &ofs_buf_vt_100.buffer[0];
 
         // Check text positions: "ABC" at 0-2, "DEF" at 8-10
         if let crate::PixelChar::PlainText { display_char, .. } = &first_row[0] {
@@ -149,7 +152,7 @@ pub mod basic_tab_operations {
 
     #[test]
     fn test_tab_behavior_different_starting_positions() {
-        let mut ofs_buf = create_test_offscreen_buffer_20r_by_20c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_20r_by_20c();
 
         // Test tab behavior from different starting positions
         let test_positions = vec![
@@ -172,20 +175,20 @@ pub mod basic_tab_operations {
                     col: term_col(col_nz) // Convert to 1-based
                 }
             );
-            let _result = ofs_buf.apply_ansi_bytes(move_sequence);
-            assert_eq!(ofs_buf.cursor_pos.col_index, crate::col(start_col));
+            let _result = ofs_buf_vt_100.apply_ansi_bytes(move_sequence);
+            assert_eq!(ofs_buf_vt_100.cursor_pos.col_index, crate::col(start_col));
 
             // Send TAB
-            let _result = ofs_buf.apply_ansi_bytes("\t");
+            let _result = ofs_buf_vt_100.apply_ansi_bytes("\t");
 
             // Verify expected position
             assert_eq!(
-                ofs_buf.cursor_pos.col_index,
+                ofs_buf_vt_100.cursor_pos.col_index,
                 crate::col(expected_col),
                 "Tab from column {} should move to column {}, but cursor is at column {}",
                 start_col,
                 expected_col,
-                ofs_buf.cursor_pos.col_index.as_usize()
+                ofs_buf_vt_100.cursor_pos.col_index.as_usize()
             );
         }
     }
@@ -198,7 +201,7 @@ pub mod tab_edge_cases {
 
     #[test]
     fn test_tab_at_exact_buffer_width() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Move to last column
         let move_sequence = format!(
@@ -208,25 +211,25 @@ pub mod tab_edge_cases {
                 col: term_col(nz(10)) // 1-based column 10 = 0-based column 9
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(move_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(move_sequence);
 
         // TAB from last column should not move cursor beyond buffer bounds
-        let _result = ofs_buf.apply_ansi_bytes("\t");
+        let _result = ofs_buf_vt_100.apply_ansi_bytes("\t");
 
         // Should remain at last valid column
-        assert_eq!(ofs_buf.cursor_pos.col_index, crate::col(9));
+        assert_eq!(ofs_buf_vt_100.cursor_pos.col_index, crate::col(9));
     }
 
     #[test]
     fn test_tab_with_line_wrapping_disabled() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Disable auto-wrap mode
         let disable_wrap = format!(
             "{}",
             crate::CsiSequence::DisablePrivateMode(crate::PrivateModeType::AutoWrap)
         );
-        let _result = ofs_buf.apply_ansi_bytes(disable_wrap);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(disable_wrap);
 
         // Move near right edge and tab
         let move_sequence = format!(
@@ -236,32 +239,32 @@ pub mod tab_edge_cases {
                 col: term_col(nz(7)) // 1-based column 7 = 0-based column 6
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(move_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(move_sequence);
 
         // TAB should move to next tab stop, but clamp to buffer width
-        let _result = ofs_buf.apply_ansi_bytes("\t");
+        let _result = ofs_buf_vt_100.apply_ansi_bytes("\t");
 
         // Should move to column 8, but stay within bounds
-        assert_eq!(ofs_buf.cursor_pos.col_index, crate::col(8));
+        assert_eq!(ofs_buf_vt_100.cursor_pos.col_index, crate::col(8));
     }
 
     #[test]
     fn test_tab_sequence_with_other_control_characters() {
-        let mut ofs_buf = create_test_offscreen_buffer_20r_by_20c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_20r_by_20c();
 
         // Mix tab with carriage return and line feed
         let mixed_sequence = "AB\tCD\r\n\tEF";
-        let _result = ofs_buf.apply_ansi_bytes(mixed_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(mixed_sequence);
 
         // Verify final cursor position
         // "AB" (cols 0-1) → TAB (col 8) → "CD" (cols 8-9) → CR (col 0) → LF (next line) →
         // TAB (col 8) → "EF" (cols 8-9)
-        assert_eq!(ofs_buf.cursor_pos.row_index, row(1)); // Second row
-        assert_eq!(ofs_buf.cursor_pos.col_index, col(10)); // After "EF" at tab position
+        assert_eq!(ofs_buf_vt_100.cursor_pos.row_index, row(1)); // Second row
+        assert_eq!(ofs_buf_vt_100.cursor_pos.col_index, col(10)); // After "EF" at tab position
 
         // Verify content placement
-        let first_row = &ofs_buf.buffer[0];
-        let second_row = &ofs_buf.buffer[1];
+        let first_row = &ofs_buf_vt_100.buffer[0];
+        let second_row = &ofs_buf_vt_100.buffer[1];
 
         // First row: "AB" at 0-1, "CD" at 8-9
         if let crate::PixelChar::PlainText { display_char, .. } = &first_row[0] {

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_cursor_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_cursor_ops.rs
@@ -23,10 +23,10 @@ pub mod positioning {
 
     #[test]
     fn test_cursor_move_to_home_position() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
-        // Note: OffscreenBuffer uses 0-based index, and terminal (CSI, ESC seq, etc) uses
-        // 1-based index.
+        // Note: OfsBufVT100 uses 0-based index, and terminal (CSI, ESC seq, etc)
+        // uses 1-based index.
         //
         // Buffer layout:
         //
@@ -44,13 +44,13 @@ pub mod positioning {
         //
         // Sequence: Write 'X' at (r:5,c:5) → ESC[H → Write 'H' at home (r:0,c:0)
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Start at a non-home position.
-        performer.ofs_buf.cursor_pos = row(5) + col(5);
+        performer.ofs_buf_vt_100.cursor_pos = row(5) + col(5);
         performer.print('X');
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(5) + col(6),
             "Cursor should move right after printing X"
         );
@@ -61,32 +61,32 @@ pub mod positioning {
 
         // Verify cursor is at home position (r:0,c:0), in 0-based index
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(0) + col(0),
             "Cursor should be at home position (r:0,c:0)"
         );
 
         performer.print('H'); // Mark home position
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(0) + col(1),
             "Cursor should move right after printing H"
         );
 
         // Verify characters are at correct positions.
-        assert_plain_char_at(&ofs_buf, 5, 5, 'X');
-        assert_plain_char_at(&ofs_buf, 0, 0, 'H');
+        assert_plain_char_at(&ofs_buf_vt_100, 5, 5, 'X');
+        assert_plain_char_at(&ofs_buf_vt_100, 0, 0, 'H');
 
         // Verify final cursor position in buffer (`␩` in the diagram)
-        assert_eq!(ofs_buf.cursor_pos, row(0) + col(1)); // After writing 'H'
+        assert_eq!(ofs_buf_vt_100.cursor_pos, row(0) + col(1)); // After writing 'H'
     }
 
     #[test]
     fn test_cursor_move_to_specific_row_and_column() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
-        // Note: OffscreenBuffer uses 0-based index, and terminal (CSI, ESC seq, etc) uses
-        // 1-based index.
+        // Note: OfsBufVT100 uses 0-based index, and terminal (CSI, ESC seq, etc)
+        // uses 1-based index.
         //
         // Buffer layout:
         //
@@ -104,7 +104,7 @@ pub mod positioning {
         //
         // Sequence: ESC[5;10H → Write 'A' at (r:4,c:9)
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Send ESC[5;10H to move to row 5, column 10 (1-based)
         let sequence = csi_seq_cursor_pos(term_row(nz(5)) + term_col(nz(10))).to_string();
@@ -112,7 +112,7 @@ pub mod positioning {
 
         // Verify cursor is at (r:4,c:9) in 0-based indexing
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(4) + col(9),
             "Cursor should be at (r:4,c:9) in 0-based indexing"
         );
@@ -121,15 +121,15 @@ pub mod positioning {
 
         // Verify cursor moved to next position (r:5,c:0) after writing 'A'
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(5) + col(0),
             "Cursor should move to next line start after writing A"
         );
 
         // Verify character was written at correct position.
-        assert_plain_char_at(&ofs_buf, 4, 9, 'A');
+        assert_plain_char_at(&ofs_buf_vt_100, 4, 9, 'A');
         assert_eq!(
-            ofs_buf.cursor_pos,
+            ofs_buf_vt_100.cursor_pos,
             row(5) + col(0),
             "Final cursor position should be at (r:5,c:0)"
         );
@@ -137,7 +137,7 @@ pub mod positioning {
 
     #[test]
     fn test_cursor_clamps_to_buffer_boundaries_when_out_of_range() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Buffer layout after boundary clamping:
         //
@@ -151,7 +151,7 @@ pub mod positioning {
         //         └───┴─│─┴───┴───┴───┴───┴───┴───┴───┴───┘
         //               ╰─ cursor ends here (r:9,c:9) after printing 'C'
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Try to move cursor beyond buffer bounds (row 15, col 15) - should clamp to
         // (r:9,c:9)
@@ -161,7 +161,7 @@ pub mod positioning {
 
         // Verify cursor is clamped to buffer boundaries (r:9,c:9) in 0-based indexing
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(9) + col(9),
             "Cursor should be clamped to buffer boundaries at (r:9,c:9)"
         );
@@ -177,7 +177,7 @@ pub mod positioning {
         performer.apply_ansi_bytes(raw_sequence);
 
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(0) + col(0),
             "Parser should clamp invalid coordinate 0 to 1, resulting in buffer position (r:0,c:0)"
         );
@@ -185,13 +185,13 @@ pub mod positioning {
         performer.print('C'); // Mark the origin
 
         // Verify characters are at expected positions.
-        assert_plain_char_at(&ofs_buf, 9, 9, 'B'); // At clamped boundary
-        assert_plain_char_at(&ofs_buf, 0, 0, 'C'); // At origin
+        assert_plain_char_at(&ofs_buf_vt_100, 9, 9, 'B'); // At clamped boundary
+        assert_plain_char_at(&ofs_buf_vt_100, 0, 0, 'C'); // At origin
     }
 
     #[test]
     fn test_cursor_alternate_positioning_syntax_works_identically() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Buffer layout after testing both CUP and HVP:
         //
@@ -213,14 +213,14 @@ pub mod positioning {
         //                                       │             then print 'E' there
         //                                       ╰─ cursor ends here (r:5,c:7)
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Test CUP (Cursor Position) - ESC[3;4H
         let cup_sequence =
             csi_seq_cursor_pos(term_row(nz(3)) + term_col(nz(4))).to_string();
         performer.apply_ansi_bytes(cup_sequence);
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(2) + col(3),
             "Cursor should be at (r:2,c:3) after CUP"
         );
@@ -231,20 +231,20 @@ pub mod positioning {
             csi_seq_cursor_pos_alt(term_row(nz(6)) + term_col(nz(7))).to_string();
         performer.apply_ansi_bytes(hvp_sequence);
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(5) + col(6),
             "Cursor should be at (r:5,c:6) after HVP"
         );
         performer.print('E');
 
         // Verify both positioning commands work identically.
-        assert_plain_char_at(&ofs_buf, 2, 3, 'D');
-        assert_plain_char_at(&ofs_buf, 5, 6, 'E');
+        assert_plain_char_at(&ofs_buf_vt_100, 2, 3, 'D');
+        assert_plain_char_at(&ofs_buf_vt_100, 5, 6, 'E');
     }
 
     #[test]
     fn test_cursor_defaults_to_1_when_row_or_column_missing() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Buffer layout after testing default parameter behavior:
         //
@@ -265,12 +265,12 @@ pub mod positioning {
         // Sequence: S@(r:5,c:5) → ESC[H → H@(r:0,c:0) → ESC[3H → R@(r:2,c:0)
         //           → ESC[;5H → C@(r:0,c:4)
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Move to a known position first.
-        performer.ofs_buf.cursor_pos = row(5) + col(5);
+        performer.ofs_buf_vt_100.cursor_pos = row(5) + col(5);
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(5) + col(5),
             "Cursor should be at (r:5,c:5) to start"
         );
@@ -280,7 +280,7 @@ pub mod positioning {
         // 0-based
         performer.apply_ansi_bytes(format!("{CSI_START}H"));
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(0) + col(0),
             "Cursor should be at (r:0,c:0) after ESC[H (no params)"
         );
@@ -290,7 +290,7 @@ pub mod positioning {
         // 0-based
         performer.apply_ansi_bytes(format!("{CSI_START}3H"));
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(2) + col(0),
             "Cursor should be at (r:2,c:0) after ESC[3H (col missing, defaults to 1)"
         );
@@ -300,17 +300,17 @@ pub mod positioning {
         // 0-based
         performer.apply_ansi_bytes(format!("{CSI_START}{CSI_PARAM_SEPARATOR}5H"));
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(0) + col(4),
             "Cursor should be at (r:0,c:4) after ESC[;5H (row missing, defaults to 1)"
         );
         performer.print('C'); // Mark column-only
 
         // Verify default behavior.
-        assert_plain_char_at(&ofs_buf, 5, 5, 'S'); // Start position
-        assert_plain_char_at(&ofs_buf, 0, 0, 'H'); // ESC[H -> (r:0,c:0)
-        assert_plain_char_at(&ofs_buf, 2, 0, 'R'); // ESC[3H -> (r:2,c:0)
-        assert_plain_char_at(&ofs_buf, 0, 4, 'C'); // ESC[;5H -> (r:0,c:4)
+        assert_plain_char_at(&ofs_buf_vt_100, 5, 5, 'S'); // Start position
+        assert_plain_char_at(&ofs_buf_vt_100, 0, 0, 'H'); // ESC[H -> (r:0,c:0)
+        assert_plain_char_at(&ofs_buf_vt_100, 2, 0, 'R'); // ESC[3H -> (r:2,c:0)
+        assert_plain_char_at(&ofs_buf_vt_100, 0, 4, 'C'); // ESC[;5H -> (r:0,c:4)
     }
 }
 
@@ -320,10 +320,10 @@ pub mod movement {
 
     #[test]
     fn test_cursor_movement_up() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
-        // Note: OffscreenBuffer uses 0-based index, and terminal (CSI, ESC seq, etc) uses
-        // 1-based index.
+        // Note: OfsBufVT100 uses 0-based index, and terminal (CSI, ESC seq, etc)
+        // uses 1-based index.
         //
         // Cursor up movement pattern:
         //
@@ -342,54 +342,54 @@ pub mod movement {
         //                                   ╰cursor ends here (r:0,c:5)
 
         // Test cursor up movement with buffer verification.
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // 1. Start at row 5, col 3, write a 'A'.
-        performer.ofs_buf.cursor_pos = row(5) + col(3);
+        performer.ofs_buf_vt_100.cursor_pos = row(5) + col(3);
         performer.print('A');
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(5) + col(4),
             "Cursor should be at (r:5,c:4) after printing 'A'"
         );
 
         // 2. Move up 2 rows and write 'B'.
-        performer.ofs_buf.cursor_up(height(2));
+        performer.ofs_buf_vt_100.cursor_up(height(2));
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(3) + col(4),
             "Cursor should be at (r:3,c:4) after moving up 2 rows, after printing 'A'"
         );
 
         performer.print('B');
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(3) + col(5),
             "Cursor should be at (r:3,c:5) after printing 'B'"
         );
 
         // 3. Try to move up beyond boundary.
-        performer.ofs_buf.cursor_up(height(10));
-        assert_eq!(performer.ofs_buf.cursor_pos.row_index, row(0)); // Should stop at row 0
+        performer.ofs_buf_vt_100.cursor_up(height(10));
+        assert_eq!(performer.ofs_buf_vt_100.cursor_pos.row_index, row(0)); // Should stop at row 0
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(0) + col(5),
             "Column should remain the same, 5, after moving up, row clamped to 0"
         );
         performer.print('C');
 
         // Verify characters are in correct positions.
-        assert_plain_char_at(&ofs_buf, 5, 3, 'A');
-        assert_plain_char_at(&ofs_buf, 3, 4, 'B');
-        assert_plain_char_at(&ofs_buf, 0, 5, 'C');
+        assert_plain_char_at(&ofs_buf_vt_100, 5, 3, 'A');
+        assert_plain_char_at(&ofs_buf_vt_100, 3, 4, 'B');
+        assert_plain_char_at(&ofs_buf_vt_100, 0, 5, 'C');
     }
 
     #[test]
     fn test_cursor_movement_down() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
-        // Note: OffscreenBuffer uses 0-based index, and terminal (CSI, ESC seq, etc) uses
-        // 1-based index.
+        // Note: OfsBufVT100 uses 0-based index, and terminal (CSI, ESC seq, etc)
+        // uses 1-based index.
         //
         // Cursor down movement pattern:
         //
@@ -410,44 +410,44 @@ pub mod movement {
         //                                       ╰─ cursor ends here (r:9,c:6)
 
         // Test cursor down movement with buffer verification.
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // 1. Start at row 2, write a character.
-        performer.ofs_buf.cursor_pos = row(2) + col(4);
+        performer.ofs_buf_vt_100.cursor_pos = row(2) + col(4);
         performer.print('X');
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(2) + col(5),
             "Cursor should move right after printing X, to (r:2,c:5)"
         );
 
         // 2. Move down 3 rows and write another character.
-        performer.ofs_buf.cursor_down(height(3));
+        performer.ofs_buf_vt_100.cursor_down(height(3));
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(5) + col(5),
             "Cursor should be at (r:5,c:5) after moving down 3 rows"
         );
         performer.print('Y');
 
         // 3. Try to move down beyond boundary.
-        performer.ofs_buf.cursor_down(height(10));
+        performer.ofs_buf_vt_100.cursor_down(height(10));
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(9) + col(6),
             "Cursor row should be clamped to bottom boundary, row 9, col remains 6"
         );
         performer.print('Z');
 
         // Verify characters are in correct positions.
-        assert_plain_char_at(&ofs_buf, 2, 4, 'X');
-        assert_plain_char_at(&ofs_buf, 5, 5, 'Y');
-        assert_plain_char_at(&ofs_buf, 9, 6, 'Z');
+        assert_plain_char_at(&ofs_buf_vt_100, 2, 4, 'X');
+        assert_plain_char_at(&ofs_buf_vt_100, 5, 5, 'Y');
+        assert_plain_char_at(&ofs_buf_vt_100, 9, 6, 'Z');
     }
 
     #[test]
     fn test_cursor_movement_forward() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Cursor forward movement pattern:
         //
@@ -465,36 +465,36 @@ pub mod movement {
         //           → N@(r:4,c:9) → cursor@(r:5,c:0)
 
         // Test cursor forward movement with buffer verification.
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // 1. Start at column 3, write a character.
-        performer.ofs_buf.cursor_pos = row(4) + col(3);
+        performer.ofs_buf_vt_100.cursor_pos = row(4) + col(3);
         performer.print('L');
 
         // 2. Move forward 2 columns and write another character.
-        performer.ofs_buf.cursor_forward(width(2));
-        assert_eq!(performer.ofs_buf.cursor_pos.col_index, col(6)); // Should be at column 6
+        performer.ofs_buf_vt_100.cursor_forward(width(2));
+        assert_eq!(performer.ofs_buf_vt_100.cursor_pos.col_index, col(6)); // Should be at column 6
         performer.print('M');
 
         // 3. Try to move forward beyond boundary.
-        performer.ofs_buf.cursor_forward(width(10));
-        assert_eq!(performer.ofs_buf.cursor_pos.col_index, col(9)); // Should stop at column 9
+        performer.ofs_buf_vt_100.cursor_forward(width(10));
+        assert_eq!(performer.ofs_buf_vt_100.cursor_pos.col_index, col(9)); // Should stop at column 9
         performer.print('N');
 
         // Verify characters are in correct positions.
-        assert_plain_char_at(&ofs_buf, 4, 3, 'L');
-        assert_plain_char_at(&ofs_buf, 4, 6, 'M');
-        assert_plain_char_at(&ofs_buf, 4, 9, 'N');
+        assert_plain_char_at(&ofs_buf_vt_100, 4, 3, 'L');
+        assert_plain_char_at(&ofs_buf_vt_100, 4, 6, 'M');
+        assert_plain_char_at(&ofs_buf_vt_100, 4, 9, 'N');
 
         // Verify gaps are empty in row 4.
         for col in [0, 1, 2, 4, 5, 7, 8] {
-            assert_empty_at(&ofs_buf, 4, col);
+            assert_empty_at(&ofs_buf_vt_100, 4, col);
         }
     }
 
     #[test]
     fn test_cursor_movement_backward() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Cursor backward movement pattern:
         //
@@ -507,48 +507,48 @@ pub mod movement {
         // Sequence: P@(r:6,c:7) → back(3) → Q@(r:6,c:5) → back(10) → R@(r:6,c:0)
 
         // Test cursor backward movement with buffer verification.
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // 1. Start at column 7, write a character.
-        performer.ofs_buf.cursor_pos = row(6) + col(7);
+        performer.ofs_buf_vt_100.cursor_pos = row(6) + col(7);
         performer.print('P');
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(6) + col(8),
             "Cursor should move right after printing P, to (r:6,c:8)"
         );
 
         // 2. Move backward 3 columns and write another character.
-        performer.ofs_buf.cursor_backward(width(3));
+        performer.ofs_buf_vt_100.cursor_backward(width(3));
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(6) + col(5),
             "Should be at column 5, row 6, after moving backward 3"
         );
         performer.print('Q');
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(6) + col(6),
             "Cursor should move right after printing Q, to (r:6,c:6)"
         );
 
         // 3. Try to move backward beyond boundary.
-        performer.ofs_buf.cursor_backward(width(10));
+        performer.ofs_buf_vt_100.cursor_backward(width(10));
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(6) + col(0),
             "Should stop at column 0, same row 6, after moving backward and hitting boundary"
         );
         performer.print('R');
 
         // Verify characters are in correct positions.
-        assert_plain_char_at(&ofs_buf, 6, 7, 'P');
-        assert_plain_char_at(&ofs_buf, 6, 5, 'Q');
-        assert_plain_char_at(&ofs_buf, 6, 0, 'R');
+        assert_plain_char_at(&ofs_buf_vt_100, 6, 7, 'P');
+        assert_plain_char_at(&ofs_buf_vt_100, 6, 5, 'Q');
+        assert_plain_char_at(&ofs_buf_vt_100, 6, 0, 'R');
 
         // Verify gaps are empty.
         for col in [1, 2, 3, 4, 6, 8, 9] {
-            assert_empty_at(&ofs_buf, 6, col);
+            assert_empty_at(&ofs_buf_vt_100, 6, col);
         }
     }
 }
@@ -562,7 +562,7 @@ pub mod save_restore {
 
     #[test]
     fn test_csi_save_restore_cursor() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Buffer layout:
         //
@@ -578,13 +578,13 @@ pub mod save_restore {
         //         └───┴───┴───┴───┴───┴───┴───┴─│─┴───┴───┘
         //                                       ╰─ cursor ends here: (r:3,c:7)
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Move to (r:3,c:5) and write 'A'
-        performer.ofs_buf.cursor_pos = row(3) + col(5);
+        performer.ofs_buf_vt_100.cursor_pos = row(3) + col(5);
         performer.print('A');
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(3) + col(6),
             "Cursor should be at (r:3,c:6) after printing 'A'"
         );
@@ -593,10 +593,10 @@ pub mod save_restore {
         performer.apply_ansi_bytes(CsiSequence::SaveCursor.to_string());
 
         // Move elsewhere
-        performer.ofs_buf.cursor_pos = row(7) + col(2);
+        performer.ofs_buf_vt_100.cursor_pos = row(7) + col(2);
         performer.print('B');
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(7) + col(3),
             "Cursor should be at (r:7,c:3) after printing 'B'"
         );
@@ -606,34 +606,34 @@ pub mod save_restore {
 
         // Should be back at saved position.
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(3) + col(6),
             "Cursor should be restored to (r:3,c:6)"
         );
 
         performer.print('C');
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(3) + col(7),
             "Cursor should be at (r:3,c:7) after printing 'C'"
         );
 
         // Verify characters.
-        assert_plain_char_at(&ofs_buf, 3, 5, 'A');
-        assert_plain_char_at(&ofs_buf, 7, 2, 'B');
-        assert_plain_char_at(&ofs_buf, 3, 6, 'C');
+        assert_plain_char_at(&ofs_buf_vt_100, 3, 5, 'A');
+        assert_plain_char_at(&ofs_buf_vt_100, 7, 2, 'B');
+        assert_plain_char_at(&ofs_buf_vt_100, 3, 6, 'C');
 
         // Verify saved cursor position persisted in buffer.
         assert_eq!(
-            ofs_buf.cursor_pos,
+            ofs_buf_vt_100.cursor_pos,
             row(3) + col(7),
-            "ofs_buf cursor pos should be (r:3,c:7) after processing"
+            "ofs_buf_vt_100 cursor pos should be (r:3,c:7) after processing"
         );
     }
 
     #[test]
     fn test_esc_save_restore_cursor() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // ESC save/restore cursor operation pattern:
         //
@@ -649,13 +649,13 @@ pub mod save_restore {
         //         └───┴───┴───┴───┴───┴───┴───┴─│─┴───┴───┘
         //                                       ╰─ cursor ends here: (r:3,c:7)
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Move cursor to position (r:3,c:5) and write 'A'
-        performer.ofs_buf.cursor_pos = row(3) + col(5);
+        performer.ofs_buf_vt_100.cursor_pos = row(3) + col(5);
         performer.print('A');
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(3) + col(6),
             "Cursor should be at (r:3,c:6) after printing 'A'"
         );
@@ -664,10 +664,10 @@ pub mod save_restore {
         performer.apply_ansi_bytes(EscSequence::SaveCursor.to_string());
 
         // Move cursor elsewhere and write 'B'.
-        performer.ofs_buf.cursor_pos = row(7) + col(2);
+        performer.ofs_buf_vt_100.cursor_pos = row(7) + col(2);
         performer.print('B');
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(7) + col(3),
             "Cursor should be at (r:7,c:3) after printing 'B'"
         );
@@ -677,7 +677,7 @@ pub mod save_restore {
 
         // Verify cursor was restored.
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             Pos {
                 row_index: row(3),
                 col_index: col(6),
@@ -687,22 +687,22 @@ pub mod save_restore {
         // Write 'C' at restored position.
         performer.print('C');
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(3) + col(7),
             "Cursor should be at (r:3,c:7) after printing 'C'"
         );
 
         // Verify saved cursor position persisted in buffer.
         assert_eq!(
-            ofs_buf.cursor_pos,
+            ofs_buf_vt_100.cursor_pos,
             row(3) + col(7),
-            "ofs_buf cursor pos should be (r:3,c:7) after processing"
+            "ofs_buf_vt_100 cursor pos should be (r:3,c:7) after processing"
         );
 
         // Verify characters are at expected positions.
-        assert_plain_char_at(&ofs_buf, 3, 5, 'A');
-        assert_plain_char_at(&ofs_buf, 7, 2, 'B');
-        assert_plain_char_at(&ofs_buf, 3, 6, 'C');
+        assert_plain_char_at(&ofs_buf_vt_100, 3, 5, 'A');
+        assert_plain_char_at(&ofs_buf_vt_100, 7, 2, 'B');
+        assert_plain_char_at(&ofs_buf_vt_100, 3, 6, 'C');
     }
 }
 
@@ -712,7 +712,7 @@ pub mod vertical_position_absolute {
 
     #[test]
     fn test_vpa_move_to_specific_row() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Start at position (3, 5) and move to row 7
         let move_cursor = CsiSequence::CursorPosition {
@@ -723,11 +723,11 @@ pub mod vertical_position_absolute {
             TermRow::from_raw_non_zero_value(nz(7)),
         );
         let sequence = format!("{move_cursor}{vpa_sequence}");
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
         // Verify cursor moved to row 6 (0-based), column unchanged
         assert_eq!(
-            ofs_buf.cursor_pos,
+            ofs_buf_vt_100.cursor_pos,
             row(6) + col(5),
             "VPA should move to row 6 (0-based) while preserving column 5"
         );
@@ -735,7 +735,7 @@ pub mod vertical_position_absolute {
 
     #[test]
     fn test_vpa_default_parameter() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Start at position (5, 8) and use VPA with default parameter
         let move_cursor = CsiSequence::CursorPosition {
@@ -744,11 +744,11 @@ pub mod vertical_position_absolute {
         }; // Move to row 6, col 9 (1-based)
         let vpa_sequence = CsiSequence::VerticalPositionAbsolute(TermRow::ONE); // Default to row 1
         let sequence = format!("{move_cursor}{vpa_sequence}");
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
         // Verify cursor moved to row 0 (0-based), column unchanged
         assert_eq!(
-            ofs_buf.cursor_pos,
+            ofs_buf_vt_100.cursor_pos,
             row(0) + col(8),
             "VPA default should move to row 0 (0-based) while preserving column 8"
         );
@@ -756,7 +756,7 @@ pub mod vertical_position_absolute {
 
     #[test]
     fn test_vpa_bounds_checking() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Start at position (5, 3) and try to move beyond bounds
         let move_cursor = CsiSequence::CursorPosition {
@@ -767,11 +767,11 @@ pub mod vertical_position_absolute {
             TermRow::from_raw_non_zero_value(nz(15)),
         ); // Beyond bounds
         let sequence = format!("{move_cursor}{vpa_sequence}");
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
         // Verify cursor clamped to last row (9 in 0-based), column unchanged
         assert_eq!(
-            ofs_buf.cursor_pos,
+            ofs_buf_vt_100.cursor_pos,
             row(9) + col(3),
             "VPA should clamp to row 9 (0-based) when target is beyond buffer"
         );
@@ -779,7 +779,7 @@ pub mod vertical_position_absolute {
 
     #[test]
     fn test_vpa_zero_parameter_treated_as_one() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Start at position (7, 2) and move with parameter 0
         let move_cursor = CsiSequence::CursorPosition {
@@ -790,11 +790,11 @@ pub mod vertical_position_absolute {
         // let's use 1 which represents the first row.
         let vpa_sequence = CsiSequence::VerticalPositionAbsolute(TermRow::ONE);
         let sequence = format!("{move_cursor}{vpa_sequence}");
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
         // Verify cursor moved to row 0 (0-based), column unchanged
         assert_eq!(
-            ofs_buf.cursor_pos,
+            ofs_buf_vt_100.cursor_pos,
             row(0) + col(2),
             "VPA with parameter 1 should move to row 0 (0-based) while preserving column 2"
         );
@@ -804,7 +804,7 @@ pub mod vertical_position_absolute {
     fn test_vpa_preserves_horizontal_position() {
         // Test multiple column positions.
         for col_pos in [0u16, 3, 6, 9] {
-            let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+            let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
             // Move to initial position and then use VPA.
             let col_nz =
@@ -817,11 +817,11 @@ pub mod vertical_position_absolute {
                 TermRow::from_raw_non_zero_value(nz(8)),
             );
             let sequence = format!("{move_cursor}{vpa_sequence}");
-            let _result = ofs_buf.apply_ansi_bytes(sequence);
+            let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
             // Verify column position preserved.
             assert_eq!(
-                ofs_buf.cursor_pos,
+                ofs_buf_vt_100.cursor_pos,
                 row(7) + col(col_pos),
                 "VPA should preserve column {col_pos} when moving to row 7"
             );

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_dsr_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_dsr_ops.rs
@@ -16,14 +16,14 @@ use crate::{
 
 #[test]
 fn test_dsr_status_report() {
-    let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+    let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
     // Send CSI 5n (status report request)
     let dsr_request = format!(
         "{}",
         CsiSequence::DeviceStatusReport(DsrRequestType::RequestStatus)
     );
-    let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(&dsr_request);
+    let (osc_events, dsr_responses) = ofs_buf_vt_100.apply_ansi_bytes(&dsr_request);
 
     // Should not produce OSC events.
     assert_eq!(osc_events.len(), 0, "no OSC events expected");
@@ -49,17 +49,17 @@ fn test_dsr_status_report() {
 
 #[test]
 fn test_dsr_cursor_position_report() {
-    let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+    let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
     // Move cursor to position (3, 5) - 0-based internally
-    ofs_buf.cursor_pos = row(3) + col(5);
+    ofs_buf_vt_100.cursor_pos = row(3) + col(5);
 
     // Send CSI 6n (cursor position report request)
     let dsr_request = format!(
         "{}",
         CsiSequence::DeviceStatusReport(DsrRequestType::RequestCursorPosition)
     );
-    let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(&dsr_request);
+    let (osc_events, dsr_responses) = ofs_buf_vt_100.apply_ansi_bytes(&dsr_request);
 
     // Should not produce OSC events.
     assert_eq!(osc_events.len(), 0, "no OSC events expected");
@@ -89,17 +89,17 @@ fn test_dsr_cursor_position_report() {
 
 #[test]
 fn test_dsr_cursor_position_at_origin() {
-    let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+    let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
     // Cursor starts at (0, 0) - 0-based internally
-    assert_eq!(ofs_buf.cursor_pos, row(0) + col(0));
+    assert_eq!(ofs_buf_vt_100.cursor_pos, row(0) + col(0));
 
     // Send CSI 6n (cursor position report request)
     let dsr_request = format!(
         "{}",
         CsiSequence::DeviceStatusReport(DsrRequestType::RequestCursorPosition)
     );
-    let (_osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(&dsr_request);
+    let (_osc_events, dsr_responses) = ofs_buf_vt_100.apply_ansi_bytes(&dsr_request);
 
     // Should produce cursor position report at (1, 1) in 1-based coordinates
     assert_eq!(
@@ -123,14 +123,14 @@ fn test_dsr_cursor_position_at_origin() {
 
 #[test]
 fn test_dsr_unknown_request() {
-    let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+    let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
     // Send CSI 99n (unknown DSR request)
     let dsr_request = format!(
         "{}",
         CsiSequence::DeviceStatusReport(DsrRequestType::Other(99))
     );
-    let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(&dsr_request);
+    let (osc_events, dsr_responses) = ofs_buf_vt_100.apply_ansi_bytes(&dsr_request);
 
     // Should not produce any events for unknown DSR requests.
     assert_eq!(osc_events.len(), 0, "no OSC events expected");
@@ -143,10 +143,10 @@ fn test_dsr_unknown_request() {
 
 #[test]
 fn test_multiple_dsr_requests() {
-    let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+    let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
     // Move cursor to (2, 3)
-    ofs_buf.cursor_pos = row(2) + col(3);
+    ofs_buf_vt_100.cursor_pos = row(2) + col(3);
 
     // Send multiple DSR requests in one sequence.
     let dsr_requests = format!(
@@ -155,7 +155,7 @@ fn test_multiple_dsr_requests() {
         CsiSequence::DeviceStatusReport(DsrRequestType::RequestCursorPosition), /* Cursor position */
         CsiSequence::DeviceStatusReport(DsrRequestType::Other(99)) // Unknown
     );
-    let (_osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(&dsr_requests);
+    let (_osc_events, dsr_responses) = ofs_buf_vt_100.apply_ansi_bytes(&dsr_requests);
 
     // Should produce exactly two DSR responses (status and cursor position)
     assert_eq!(dsr_responses.len(), 2, "expected two DSR responses");
@@ -173,19 +173,19 @@ fn test_multiple_dsr_requests() {
 
 #[test]
 fn test_dsr_events_are_cleared_after_processing() {
-    let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+    let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
     // First DSR request.
     let dsr_request = format!(
         "{}",
         CsiSequence::DeviceStatusReport(DsrRequestType::RequestStatus)
     );
-    let (_, dsr_responses1) = ofs_buf.apply_ansi_bytes(&dsr_request);
+    let (_, dsr_responses1) = ofs_buf_vt_100.apply_ansi_bytes(&dsr_request);
     assert_eq!(dsr_responses1.len(), 1, "expected one DSR response");
 
     // Second call without any DSR request.
     let plain_text = "Hello";
-    let (_, dsr_responses2) = ofs_buf.apply_ansi_bytes(plain_text);
+    let (_, dsr_responses2) = ofs_buf_vt_100.apply_ansi_bytes(plain_text);
     assert_eq!(
         dsr_responses2.len(),
         0,
@@ -197,7 +197,7 @@ fn test_dsr_events_are_cleared_after_processing() {
         "{}",
         CsiSequence::DeviceStatusReport(DsrRequestType::RequestCursorPosition)
     );
-    let (_, dsr_responses3) = ofs_buf.apply_ansi_bytes(&dsr_request);
+    let (_, dsr_responses3) = ofs_buf_vt_100.apply_ansi_bytes(&dsr_request);
     assert_eq!(
         dsr_responses3.len(),
         1,

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_integration_basic.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_integration_basic.rs
@@ -6,16 +6,16 @@
 
 use super::super::test_fixtures_vt_100_ansi_conformance::*;
 use crate::{
-    ANSIBasicColor, EraseDisplayMode, EscSequence, OffscreenBuffer, SgrCode, height, width,
+    ANSIBasicColor, EraseDisplayMode, EscSequence, OfsBufVT100, SgrCode, height, width,
             offscreen_buffer::test_fixtures_ofs_buf::*,
             term_col, term_row, tui_style_attrib};
 use crate::core::ansi::vt_100_pty_output_parser::{ansi_parser_public_api::AnsiToOfsBufPerformer,
                                             CsiSequence,
                                             vt_100_pty_output_conformance_tests::test_sequence_generators::csi_builders::csi_seq_cursor_pos};
 
-/// Creates a test `OffscreenBuffer` with 24x80 dimensions (more realistic terminal size).
-fn create_offscreen_buffer_24r_by_80c() -> OffscreenBuffer {
-    OffscreenBuffer::new_empty(height(24) + width(80))
+/// Creates a test [`OfsBufVT100`] with 24x80 dimensions (more realistic terminal size).
+fn create_offscreen_buffer_24r_by_80c() -> OfsBufVT100 {
+    OfsBufVT100::new_empty(height(24) + width(80))
 }
 
 /// Tests for complex real-world [`ANSI`] sequences.
@@ -27,9 +27,9 @@ mod full_sequences {
     #[test]
     #[allow(clippy::items_after_statements)]
     fn test_vim_like_sequence() {
-        let mut ofs_buf = create_offscreen_buffer_24r_by_80c();
+        let mut ofs_buf_vt_100 = create_offscreen_buffer_24r_by_80c();
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Simulate a vim-like sequence using proper builders.
         let sequence = format!(
@@ -51,7 +51,7 @@ mod full_sequences {
         // Verify the sequence worked correctly.
         // Status line should be at top with reverse video.
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             0,
             '-',
@@ -60,17 +60,17 @@ mod full_sequences {
         );
 
         // Command prompt should be at bottom.
-        assert_plain_char_at(&ofs_buf, 23, 0, ':');
+        assert_plain_char_at(&ofs_buf_vt_100, 23, 0, ':');
 
         // Content should be restored at saved position.
-        assert_plain_text_at(&ofs_buf, 0, 12, "Hello World!");
+        assert_plain_text_at(&ofs_buf_vt_100, 0, 12, "Hello World!");
     }
 
     #[test]
     fn test_complex_ansi_sequences() {
-        let mut ofs_buf = create_offscreen_buffer_24r_by_80c();
+        let mut ofs_buf_vt_100 = create_offscreen_buffer_24r_by_80c();
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Simulate: Bold text, colored text, cursor movement
         let sequence = format!(
@@ -85,7 +85,7 @@ mod full_sequences {
         // Verify "Bold" with bold style.
         for (i, ch) in "Bold".chars().enumerate() {
             assert_styled_char_at(
-                &ofs_buf,
+                &ofs_buf_vt_100,
                 0,
                 i,
                 ch,
@@ -95,12 +95,12 @@ mod full_sequences {
         }
 
         // Verify space at position 4.
-        assert_plain_char_at(&ofs_buf, 0, 4, ' ');
+        assert_plain_char_at(&ofs_buf_vt_100, 0, 4, ' ');
 
         // Verify "Green" with green color.
         for (i, ch) in "Green".chars().enumerate() {
             assert_styled_char_at(
-                &ofs_buf,
+                &ofs_buf_vt_100,
                 0,
                 5 + i,
                 ch,
@@ -119,10 +119,10 @@ mod vte_parser {
 
     #[test]
     fn test_vte_parser_integration() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Process ANSI sequences through VTE parser.
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Print "Hello" with red foreground.
         let input = format!(
@@ -133,14 +133,14 @@ mod vte_parser {
         performer.apply_ansi_bytes(&input);
 
         // Verify cursor position after processing.
-        assert_eq!(performer.ofs_buf.cursor_pos.col_index.as_usize(), 6);
+        assert_eq!(performer.ofs_buf_vt_100.cursor_pos.col_index.as_usize(), 6);
 
         // Verify "Hello" is in the buffer.
-        assert_plain_text_at(&ofs_buf, 0, 0, "Hello");
+        assert_plain_text_at(&ofs_buf_vt_100, 0, 0, "Hello");
 
         // Verify 'R' has red color.
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             5,
             'R',
@@ -152,7 +152,7 @@ mod vte_parser {
 
         // Verify rest of line is empty.
         for col in 6..10 {
-            assert_empty_at(&ofs_buf, 0, col);
+            assert_empty_at(&ofs_buf_vt_100, 0, col);
         }
     }
 }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_integration_real_world.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_integration_real_world.rs
@@ -16,9 +16,9 @@ use std::cmp::min;
 
 /// Creates a realistic terminal buffer for real-world scenario testing.
 /// Uses standard 80x25 dimensions typical of actual terminal usage.
-fn create_realistic_terminal_buffer() -> crate::OffscreenBuffer {
+fn create_realistic_terminal_buffer() -> crate::OfsBufVT100 {
     use crate::{height, width};
-    crate::OffscreenBuffer::new_empty(height(25) + width(80))
+    crate::OfsBufVT100::new_empty(height(25) + width(80))
 }
 
 /// Test vim status line functionality using builder patterns.
@@ -28,11 +28,11 @@ fn create_realistic_terminal_buffer() -> crate::OffscreenBuffer {
 /// compile-time validation.
 #[test]
 fn test_vim_status_line_pattern() {
-    let mut ofs_buf = create_realistic_terminal_buffer();
+    let mut ofs_buf_vt_100 = create_realistic_terminal_buffer();
 
     // Use the vim_sequences builder to create a realistic status line
     let sequence = vim_sequences::vim_status_line("INSERT", nz(25));
-    let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(sequence);
+    let (osc_events, dsr_responses) = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
     // Verify no OSC/DSR events for this operation
     assert_eq!(osc_events.len(), 0);
@@ -49,7 +49,7 @@ fn test_vim_status_line_pattern() {
 /// complex terminal initialization patterns.
 #[test]
 fn test_terminal_initialization_pattern() {
-    let mut ofs_buf = create_realistic_terminal_buffer();
+    let mut ofs_buf_vt_100 = create_realistic_terminal_buffer();
 
     // Compose multiple operations into a single sequence
     let clear_sequence = basic_sequences::clear_and_home();
@@ -59,17 +59,17 @@ fn test_terminal_initialization_pattern() {
     let position_cursor = cursor_sequences::move_to_position(nz(3), nz(1));
 
     // Apply sequences in order
-    let _unused = ofs_buf.apply_ansi_bytes(clear_sequence);
-    let _unused = ofs_buf.apply_ansi_bytes(welcome_sequence);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(clear_sequence);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(welcome_sequence);
     let _unused =
-        ofs_buf.apply_ansi_bytes(cursor_sequences::move_to_position(nz(2), nz(1)));
-    let _unused = ofs_buf.apply_ansi_bytes(styled_text);
-    let _unused = ofs_buf.apply_ansi_bytes(position_cursor);
+        ofs_buf_vt_100.apply_ansi_bytes(cursor_sequences::move_to_position(nz(2), nz(1)));
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(styled_text);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(position_cursor);
 
     // Verify final state
-    assert_plain_text_at(&ofs_buf, 0, 0, "Welcome!");
+    assert_plain_text_at(&ofs_buf_vt_100, 0, 0, "Welcome!");
     assert_styled_char_at(
-        &ofs_buf,
+        &ofs_buf_vt_100,
         1,
         0,
         'R',
@@ -78,7 +78,7 @@ fn test_terminal_initialization_pattern() {
     );
 
     // Verify cursor position
-    assert_eq!(ofs_buf.cursor_pos, row(2) + col(0));
+    assert_eq!(ofs_buf_vt_100.cursor_pos, row(2) + col(0));
 }
 
 /// Test cursor save/restore patterns using both [`ESC`] and [`CSI`] variants.
@@ -90,7 +90,7 @@ fn test_terminal_initialization_pattern() {
 /// [`ESC`]: crate::EscSequence
 #[test]
 fn test_cursor_save_restore_variants() {
-    let mut ofs_buf = create_realistic_terminal_buffer();
+    let mut ofs_buf_vt_100 = create_realistic_terminal_buffer();
 
     // Test ESC variant (legacy) - using shorter text to fit in 10-column buffer
     let esc_pattern = cursor_sequences::save_do_restore(
@@ -105,15 +105,15 @@ fn test_cursor_save_restore_variants() {
     );
 
     // Apply both patterns
-    let _unused = ofs_buf.apply_ansi_bytes(esc_pattern);
-    let _unused = ofs_buf.apply_ansi_bytes(csi_pattern);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(esc_pattern);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(csi_pattern);
 
     // Both should work identically
-    assert_plain_text_at(&ofs_buf, 2, 2, "ESC");
-    assert_plain_text_at(&ofs_buf, 4, 4, "CSI");
+    assert_plain_text_at(&ofs_buf_vt_100, 2, 2, "ESC");
+    assert_plain_text_at(&ofs_buf_vt_100, 4, 4, "CSI");
 
     // Cursor should be back at origin after save/restore operations
-    assert_eq!(ofs_buf.cursor_pos, row(0) + col(0));
+    assert_eq!(ofs_buf_vt_100.cursor_pos, row(0) + col(0));
 }
 
 /// Test complex styling combinations using the styling sequences.
@@ -122,7 +122,7 @@ fn test_cursor_save_restore_variants() {
 /// ensuring proper style state management.
 #[test]
 fn test_complex_styling_patterns() {
-    let mut ofs_buf = create_realistic_terminal_buffer();
+    let mut ofs_buf_vt_100 = create_realistic_terminal_buffer();
 
     // Test multiple style application
     let multi_style = styling_sequences::multi_style_text(
@@ -136,14 +136,14 @@ fn test_complex_styling_patterns() {
     // Test partial reset functionality
     let partial_reset = styling_sequences::partial_reset_test();
 
-    let _unused = ofs_buf.apply_ansi_bytes(multi_style);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(multi_style);
     let _unused =
-        ofs_buf.apply_ansi_bytes(cursor_sequences::move_to_position(nz(2), nz(1)));
-    let _unused = ofs_buf.apply_ansi_bytes(partial_reset);
+        ofs_buf_vt_100.apply_ansi_bytes(cursor_sequences::move_to_position(nz(2), nz(1)));
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(partial_reset);
 
     // Verify bold red text
     assert_styled_char_at(
-        &ofs_buf,
+        &ofs_buf_vt_100,
         0,
         0,
         'B',
@@ -166,16 +166,16 @@ fn test_complex_styling_patterns() {
 /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 #[test]
 fn test_rainbow_color_pattern() {
-    let mut ofs_buf = create_realistic_terminal_buffer();
+    let mut ofs_buf_vt_100 = create_realistic_terminal_buffer();
 
     let rainbow = styling_sequences::rainbow_text("RAINBOW");
-    let _unused = ofs_buf.apply_ansi_bytes(rainbow);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(rainbow);
 
     // Verify each character has a different color
     // This test demonstrates the pattern - full implementation would
     // verify the specific color sequence applied to each character
     assert_styled_char_at(
-        &ofs_buf,
+        &ofs_buf_vt_100,
         0,
         0,
         'R',
@@ -183,7 +183,7 @@ fn test_rainbow_color_pattern() {
         "red color on R",
     );
     assert_styled_char_at(
-        &ofs_buf,
+        &ofs_buf_vt_100,
         0,
         1,
         'A',
@@ -193,7 +193,7 @@ fn test_rainbow_color_pattern() {
         "yellow color on A",
     );
     assert_styled_char_at(
-        &ofs_buf,
+        &ofs_buf_vt_100,
         0,
         2,
         'I',
@@ -209,17 +209,17 @@ fn test_rainbow_color_pattern() {
 /// positioning accuracy and sequence ordering.
 #[test]
 fn test_cursor_box_drawing_pattern() {
-    let mut ofs_buf = create_realistic_terminal_buffer();
+    let mut ofs_buf_vt_100 = create_realistic_terminal_buffer();
 
     let box_pattern = cursor_sequences::draw_box_outline(2, 2, 6, 4);
-    let _unused = ofs_buf.apply_ansi_bytes(box_pattern);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(box_pattern);
 
     // Verify box corners and edges are drawn correctly
     // This tests precise cursor positioning and movement sequences
-    assert_plain_char_at(&ofs_buf, 1, 1, '+'); // Top-left corner
-    assert_plain_char_at(&ofs_buf, 1, 6, '+'); // Top-right corner
-    assert_plain_char_at(&ofs_buf, 4, 1, '+'); // Bottom-left corner
-    assert_plain_char_at(&ofs_buf, 4, 6, '+'); // Bottom-right corner
+    assert_plain_char_at(&ofs_buf_vt_100, 1, 1, '+'); // Top-left corner
+    assert_plain_char_at(&ofs_buf_vt_100, 1, 6, '+'); // Top-right corner
+    assert_plain_char_at(&ofs_buf_vt_100, 4, 1, '+'); // Bottom-left corner
+    assert_plain_char_at(&ofs_buf_vt_100, 4, 6, '+'); // Bottom-right corner
 }
 
 /// Test vim's syntax highlighting functionality.
@@ -228,16 +228,16 @@ fn test_cursor_box_drawing_pattern() {
 /// actual vim syntax highlighting for code.
 #[test]
 fn test_vim_syntax_highlighting_pattern() {
-    let mut ofs_buf = create_realistic_terminal_buffer();
+    let mut ofs_buf_vt_100 = create_realistic_terminal_buffer();
 
     let syntax_sequence = vim_sequences::vim_syntax_highlighting();
-    let _result = ofs_buf.apply_ansi_bytes(syntax_sequence);
+    let _result = ofs_buf_vt_100.apply_ansi_bytes(syntax_sequence);
 
     // Verify syntax highlighting colors are applied
     // Note: This test demonstrates the pattern - full implementation would
     // verify each colored segment matches the expected syntax highlighting
     assert_styled_char_at(
-        &ofs_buf,
+        &ofs_buf_vt_100,
         0,
         0,
         'f',
@@ -255,15 +255,15 @@ fn test_vim_syntax_highlighting_pattern() {
 /// and styling that matches vim's behavior.
 #[test]
 fn test_vim_error_message_pattern() {
-    let mut ofs_buf = create_realistic_terminal_buffer();
+    let mut ofs_buf_vt_100 = create_realistic_terminal_buffer();
 
     let error_sequence = vim_sequences::vim_error_message("E32: No such file", nz(25));
-    let _result = ofs_buf.apply_ansi_bytes(error_sequence);
+    let _result = ofs_buf_vt_100.apply_ansi_bytes(error_sequence);
 
     // Verify error message appears at bottom with proper styling
     // The exact verification depends on the error message format
     assert_styled_char_at(
-        &ofs_buf,
+        &ofs_buf_vt_100,
         24,
         0,
         'E',
@@ -278,15 +278,15 @@ fn test_vim_error_message_pattern() {
 /// showing how different editors use similar but distinct patterns.
 #[test]
 fn test_emacs_mode_line_pattern() {
-    let mut ofs_buf = create_realistic_terminal_buffer();
+    let mut ofs_buf_vt_100 = create_realistic_terminal_buffer();
 
     let mode_line = emacs_sequences::emacs_mode_line();
-    let _result = ofs_buf.apply_ansi_bytes(mode_line);
+    let _result = ofs_buf_vt_100.apply_ansi_bytes(mode_line);
 
     // Verify mode line appears with emacs-style formatting
     // This test demonstrates cross-editor compatibility testing
     assert_styled_char_at(
-        &ofs_buf,
+        &ofs_buf_vt_100,
         24,
         0,
         '-',
@@ -301,15 +301,15 @@ fn test_emacs_mode_line_pattern() {
 /// useful for testing complex multi-pane terminal applications.
 #[test]
 fn test_tmux_status_bar_pattern() {
-    let mut ofs_buf = create_realistic_terminal_buffer();
+    let mut ofs_buf_vt_100 = create_realistic_terminal_buffer();
 
     let status_bar = tmux_sequences::tmux_status_bar();
-    let _result = ofs_buf.apply_ansi_bytes(status_bar);
+    let _result = ofs_buf_vt_100.apply_ansi_bytes(status_bar);
 
     // Verify tmux status bar appears with proper formatting
     // Tests terminal multiplexer integration patterns
     assert_styled_char_at(
-        &ofs_buf,
+        &ofs_buf_vt_100,
         24,
         0,
         '[',
@@ -324,42 +324,42 @@ fn test_tmux_status_bar_pattern() {
 /// movement, and text styling - using only implemented functions.
 #[test]
 fn test_text_editor_workflow() {
-    let mut ofs_buf = create_realistic_terminal_buffer();
+    let mut ofs_buf_vt_100 = create_realistic_terminal_buffer();
 
     // Clear screen and start fresh
-    let _unused = ofs_buf.apply_ansi_bytes(basic_sequences::clear_and_home());
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(basic_sequences::clear_and_home());
 
     // Type the first line of code with syntax highlighting
     let line1 = basic_sequences::move_and_print(nz(1), nz(1), "def ");
     let function_name = styling_sequences::bold_text("main");
     let parentheses = basic_sequences::insert_text("():");
 
-    let _unused = ofs_buf.apply_ansi_bytes(line1);
-    let _unused = ofs_buf.apply_ansi_bytes(function_name);
-    let _unused = ofs_buf.apply_ansi_bytes(parentheses);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(line1);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(function_name);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(parentheses);
 
     // Move to next line and add indented content
     let line2_pos = cursor_sequences::move_to_position(nz(2), nz(5)); // Indent 4 spaces
     let print_stmt = styling_sequences::colored_text(ANSIBasicColor::Blue, "print");
     let string_content = basic_sequences::insert_text("(\"Hello World!\")");
 
-    let _unused = ofs_buf.apply_ansi_bytes(line2_pos);
-    let _unused = ofs_buf.apply_ansi_bytes(print_stmt);
-    let _unused = ofs_buf.apply_ansi_bytes(string_content);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(line2_pos);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(print_stmt);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(string_content);
 
     // Verify the editor content
-    assert_plain_text_at(&ofs_buf, 0, 0, "def ");
+    assert_plain_text_at(&ofs_buf_vt_100, 0, 0, "def ");
     assert_styled_char_at(
-        &ofs_buf,
+        &ofs_buf_vt_100,
         0,
         4,
         'm', // First letter of "main"
         |style_from_buf| style_from_buf.attribs == tui_style_attrib::Bold.into(),
         "bold function name",
     );
-    assert_plain_text_at(&ofs_buf, 0, 8, "():");
+    assert_plain_text_at(&ofs_buf_vt_100, 0, 8, "():");
     assert_styled_char_at(
-        &ofs_buf,
+        &ofs_buf_vt_100,
         1,
         4,
         'p', // First letter of "print"
@@ -368,8 +368,8 @@ fn test_text_editor_workflow() {
     );
 
     // Cursor should be at end of second line
-    assert_eq!(ofs_buf.cursor_pos.row_index, row(1));
-    assert!(ofs_buf.cursor_pos.col_index.as_usize() > 15);
+    assert_eq!(ofs_buf_vt_100.cursor_pos.row_index, row(1));
+    assert!(ofs_buf_vt_100.cursor_pos.col_index.as_usize() > 15);
 }
 
 /// Test shell prompt with command editing simulation.
@@ -378,45 +378,45 @@ fn test_text_editor_workflow() {
 /// conformance data functions for realistic terminal behavior.
 #[test]
 fn test_shell_prompt_workflow() {
-    let mut ofs_buf = create_realistic_terminal_buffer();
+    let mut ofs_buf_vt_100 = create_realistic_terminal_buffer();
 
     // Display shell prompt
     let prompt = styling_sequences::colored_text(ANSIBasicColor::Green, "user@host");
     let separator = styling_sequences::colored_text(ANSIBasicColor::Blue, ":~$ ");
 
-    let _unused = ofs_buf.apply_ansi_bytes(prompt);
-    let _unused = ofs_buf.apply_ansi_bytes(separator);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(prompt);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(separator);
 
     // User starts typing a command
     let partial_command = basic_sequences::insert_text("ls -l");
-    let _unused = ofs_buf.apply_ansi_bytes(partial_command);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(partial_command);
 
     // Simulate backspace editing - move cursor left and delete
     let backspace_pos = cursor_sequences::move_left(1); // Move back 1 char
     let delete_char = basic_sequences::move_and_delete_chars(
-        TermCol::from_zero_based(ofs_buf.cursor_pos.col_index),
+        TermCol::from_zero_based(ofs_buf_vt_100.cursor_pos.col_index),
         CsiCount::ONE,
     );
     let new_char = basic_sequences::insert_text("a");
 
-    let _unused = ofs_buf.apply_ansi_bytes(backspace_pos);
-    let _unused = ofs_buf.apply_ansi_bytes(delete_char);
-    let _unused = ofs_buf.apply_ansi_bytes(new_char);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(backspace_pos);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(delete_char);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(new_char);
 
     // Simulate pressing Enter (move to next line)
     let enter_key = cursor_sequences::next_line();
-    let _unused = ofs_buf.apply_ansi_bytes(enter_key);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(enter_key);
 
     // Display command output with different colors
     let directory = styling_sequences::colored_text(ANSIBasicColor::Cyan, "drwxr-xr-x");
     let filename = basic_sequences::insert_text(" 5 user user 4096 Dec 25 file.txt");
 
-    let _unused = ofs_buf.apply_ansi_bytes(directory);
-    let _unused = ofs_buf.apply_ansi_bytes(filename);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(directory);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(filename);
 
     // Verify prompt formatting
     assert_styled_char_at(
-        &ofs_buf,
+        &ofs_buf_vt_100,
         0,
         0,
         'u', // First letter of "user@host"
@@ -425,7 +425,7 @@ fn test_shell_prompt_workflow() {
     );
 
     assert_styled_char_at(
-        &ofs_buf,
+        &ofs_buf_vt_100,
         0,
         9, // Position of colon
         ':',
@@ -436,7 +436,7 @@ fn test_shell_prompt_workflow() {
     // Verify command was correctly modified to "ls -la"
     // Note: The text may retain styling from the prompt, so just check characters exist
     // without asserting they have no styling
-    let row = &ofs_buf.buffer[0];
+    let row = &ofs_buf_vt_100.buffer[0];
 
     // Extract characters around where command should be
     let mut command_chars = Vec::new();
@@ -455,12 +455,12 @@ fn test_shell_prompt_workflow() {
     // Verify output formatting (may be on a different row due to text flow)
     // Just check that we have some cyan styled text somewhere in the buffer
     let mut found_cyan_text = false;
-    for row_idx in 0..min(5, ofs_buf.buffer.len()) {
-        for col_idx in 0..min(20, ofs_buf.buffer[row_idx].len()) {
+    for row_idx in 0..min(5, ofs_buf_vt_100.buffer.len()) {
+        for col_idx in 0..min(20, ofs_buf_vt_100.buffer[row_idx].len()) {
             if let PixelChar::PlainText {
                 display_char: _,
                 style,
-            } = ofs_buf.buffer[row_idx][col_idx]
+            } = ofs_buf_vt_100.buffer[row_idx][col_idx]
                 && style.color_fg == Some(ANSIBasicColor::Cyan.into())
             {
                 found_cyan_text = true;
@@ -480,44 +480,44 @@ fn test_shell_prompt_workflow() {
 /// for different log levels, demonstrating practical color usage.
 #[test]
 fn test_log_viewer_color_coding() {
-    let mut ofs_buf = create_realistic_terminal_buffer();
+    let mut ofs_buf_vt_100 = create_realistic_terminal_buffer();
 
     // Clear screen and set up log viewer
-    let _unused = ofs_buf.apply_ansi_bytes(basic_sequences::clear_and_home());
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(basic_sequences::clear_and_home());
 
     // Header line with reverse video
     let header = styling_sequences::reverse_text("Application Logs - Live View");
-    let _unused = ofs_buf.apply_ansi_bytes(header);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(header);
     let _unused =
-        ofs_buf.apply_ansi_bytes(cursor_sequences::move_to_position(nz(2), nz(1)));
+        ofs_buf_vt_100.apply_ansi_bytes(cursor_sequences::move_to_position(nz(2), nz(1)));
 
     // Different log levels with appropriate colors
     let info_log = styling_sequences::colored_text(ANSIBasicColor::Cyan, "[INFO]");
     let info_msg = basic_sequences::insert_text(" Server started on port 8080");
 
-    let _unused = ofs_buf.apply_ansi_bytes(info_log);
-    let _unused = ofs_buf.apply_ansi_bytes(info_msg);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(info_log);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(info_msg);
     let _unused =
-        ofs_buf.apply_ansi_bytes(cursor_sequences::move_to_position(nz(3), nz(1)));
+        ofs_buf_vt_100.apply_ansi_bytes(cursor_sequences::move_to_position(nz(3), nz(1)));
 
     let warn_log = styling_sequences::colored_text(ANSIBasicColor::Yellow, "[WARN]");
     let warn_msg = basic_sequences::insert_text(" High memory usage detected");
 
-    let _unused = ofs_buf.apply_ansi_bytes(warn_log);
-    let _unused = ofs_buf.apply_ansi_bytes(warn_msg);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(warn_log);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(warn_msg);
     let _unused =
-        ofs_buf.apply_ansi_bytes(cursor_sequences::move_to_position(nz(4), nz(1)));
+        ofs_buf_vt_100.apply_ansi_bytes(cursor_sequences::move_to_position(nz(4), nz(1)));
 
     // Error log with both color and bold
     let error_log = styling_sequences::colored_text(ANSIBasicColor::Red, "[ERROR]");
     let error_msg = basic_sequences::insert_text(" Database connection failed");
 
-    let _unused = ofs_buf.apply_ansi_bytes(error_log);
-    let _unused = ofs_buf.apply_ansi_bytes(error_msg);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(error_log);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(error_msg);
 
     // Verify header is reverse video
     assert_styled_char_at(
-        &ofs_buf,
+        &ofs_buf_vt_100,
         0,
         0,
         'A',
@@ -527,7 +527,7 @@ fn test_log_viewer_color_coding() {
 
     // Verify log level colors
     assert_styled_char_at(
-        &ofs_buf,
+        &ofs_buf_vt_100,
         1,
         1, // Position of 'I' in "[INFO]"
         'I',
@@ -536,7 +536,7 @@ fn test_log_viewer_color_coding() {
     );
 
     assert_styled_char_at(
-        &ofs_buf,
+        &ofs_buf_vt_100,
         2,
         1, // Position of 'W' in "[WARN]"
         'W',
@@ -547,7 +547,7 @@ fn test_log_viewer_color_coding() {
     );
 
     assert_styled_char_at(
-        &ofs_buf,
+        &ofs_buf_vt_100,
         3,
         1, // Position of 'E' in "[ERROR]"
         'E',
@@ -562,37 +562,37 @@ fn test_log_viewer_color_coding() {
 /// cursor sequence functions for UI drawing scenarios.
 #[test]
 fn test_interface_drawing_with_cursor_ops() {
-    let mut ofs_buf = create_realistic_terminal_buffer();
+    let mut ofs_buf_vt_100 = create_realistic_terminal_buffer();
 
     // Clear and draw a simple text-based interface
-    let _unused = ofs_buf.apply_ansi_bytes(basic_sequences::clear_and_home());
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(basic_sequences::clear_and_home());
 
     // Draw a header box using cursor movement (adjust size for buffer)
     let box_sequence = cursor_sequences::draw_box_outline(2, 2, 15, 4);
-    let _unused = ofs_buf.apply_ansi_bytes(box_sequence);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(box_sequence);
 
     // Add title inside the box
     let title_pos = cursor_sequences::move_to_position(nz(3), nz(8));
     let title = styling_sequences::bold_text("Settings Menu");
-    let _unused = ofs_buf.apply_ansi_bytes(title_pos);
-    let _unused = ofs_buf.apply_ansi_bytes(title);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(title_pos);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(title);
 
     // Add menu options with cursor positioning
     let option1_pos = cursor_sequences::move_to_position(nz(5), nz(4));
     let option1 = basic_sequences::insert_text("1. Display Settings");
-    let _unused = ofs_buf.apply_ansi_bytes(option1_pos);
-    let _unused = ofs_buf.apply_ansi_bytes(option1);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(option1_pos);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(option1);
 
     let option2_pos = cursor_sequences::move_to_position(nz(6), nz(4));
     let option2 = basic_sequences::insert_text("2. Audio Settings");
-    let _unused = ofs_buf.apply_ansi_bytes(option2_pos);
-    let _unused = ofs_buf.apply_ansi_bytes(option2);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(option2_pos);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(option2);
 
     // Highlight selected option
     let highlight_pos = cursor_sequences::move_to_position(nz(7), nz(4));
     let selected = styling_sequences::reverse_text("3. Network Settings");
-    let _unused = ofs_buf.apply_ansi_bytes(highlight_pos);
-    let _unused = ofs_buf.apply_ansi_bytes(selected);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(highlight_pos);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(selected);
 
     // Test save/restore cursor for status bar
     let save_cursor = cursor_sequences::save_cursor_csi();
@@ -600,18 +600,18 @@ fn test_interface_drawing_with_cursor_ops() {
     let status = styling_sequences::colored_text(ANSIBasicColor::Green, "Ready");
     let restore_cursor = cursor_sequences::restore_cursor_csi();
 
-    let _unused = ofs_buf.apply_ansi_bytes(save_cursor);
-    let _unused = ofs_buf.apply_ansi_bytes(status_pos);
-    let _unused = ofs_buf.apply_ansi_bytes(status);
-    let _unused = ofs_buf.apply_ansi_bytes(restore_cursor);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(save_cursor);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(status_pos);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(status);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(restore_cursor);
 
     // Verify box drawing was attempted (may not be exactly at expected coordinates)
     // Just check that some characters were drawn by the box sequence
     let mut found_box_chars = false;
-    for row_idx in 0..min(10, ofs_buf.buffer.len()) {
-        for col_idx in 0..min(20, ofs_buf.buffer[row_idx].len()) {
+    for row_idx in 0..min(10, ofs_buf_vt_100.buffer.len()) {
+        for col_idx in 0..min(20, ofs_buf_vt_100.buffer[row_idx].len()) {
             if let PixelChar::PlainText { display_char, .. } =
-                ofs_buf.buffer[row_idx][col_idx]
+                ofs_buf_vt_100.buffer[row_idx][col_idx]
                 && (display_char == '+' || display_char == '-' || display_char == '|')
             {
                 found_box_chars = true;
@@ -629,7 +629,7 @@ fn test_interface_drawing_with_cursor_ops() {
 
     // Verify title is bold
     assert_styled_char_at(
-        &ofs_buf,
+        &ofs_buf_vt_100,
         2,
         7,
         'S', // First letter of "Settings"
@@ -639,7 +639,7 @@ fn test_interface_drawing_with_cursor_ops() {
 
     // Verify highlighted option
     assert_styled_char_at(
-        &ofs_buf,
+        &ofs_buf_vt_100,
         6,
         3,
         '3',
@@ -649,7 +649,7 @@ fn test_interface_drawing_with_cursor_ops() {
 
     // Verify status bar
     assert_styled_char_at(
-        &ofs_buf,
+        &ofs_buf_vt_100,
         24,
         0,
         'R', // First letter of "Ready"
@@ -664,43 +664,43 @@ fn test_interface_drawing_with_cursor_ops() {
 /// `vim_sequences` conformance data functions.
 #[test]
 fn test_practical_vim_editing_patterns() {
-    let mut ofs_buf = create_realistic_terminal_buffer();
+    let mut ofs_buf_vt_100 = create_realistic_terminal_buffer();
 
     // Clear screen and set up vim-like interface
-    let _unused = ofs_buf.apply_ansi_bytes(vim_sequences::vim_clear_and_redraw());
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(vim_sequences::vim_clear_and_redraw());
 
     // Display file content with line numbers
     let line1 = vim_sequences::vim_line_with_number(1, nz(1), "#!/bin/bash");
     let line2 = vim_sequences::vim_line_with_number(2, nz(2), "");
     let line3 = vim_sequences::vim_line_with_number(3, nz(3), "echo \"Hello World!\"");
 
-    let _unused = ofs_buf.apply_ansi_bytes(line1);
-    let _unused = ofs_buf.apply_ansi_bytes(line2);
-    let _unused = ofs_buf.apply_ansi_bytes(line3);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(line1);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(line2);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(line3);
 
     // Show command line mode
     let command_line = vim_sequences::vim_command_line(':', nz(25));
-    let _unused = ofs_buf.apply_ansi_bytes(command_line);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(command_line);
 
     // Add syntax highlighting to the echo command
     let highlight_pos = cursor_sequences::move_to_position(nz(3), nz(14)); // Position of "echo"
     let highlighted_echo = styling_sequences::colored_text(ANSIBasicColor::Blue, "echo");
-    let _unused = ofs_buf.apply_ansi_bytes(cursor_sequences::save_cursor_csi());
-    let _unused = ofs_buf.apply_ansi_bytes(highlight_pos);
-    let _unused = ofs_buf.apply_ansi_bytes(highlighted_echo);
-    let _unused = ofs_buf.apply_ansi_bytes(cursor_sequences::restore_cursor_csi());
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(cursor_sequences::save_cursor_csi());
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(highlight_pos);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(highlighted_echo);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(cursor_sequences::restore_cursor_csi());
 
     // Show search highlighting
     let search_highlight = vim_sequences::vim_search_highlight(nz(1), nz(3), "bin");
-    let _unused = ofs_buf.apply_ansi_bytes(search_highlight);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(search_highlight);
 
     // Verify line numbers are displayed (may have styling from vim functions)
     // Just check that the characters are present, regardless of styling
-    let first_char = match ofs_buf.buffer[0][0] {
+    let first_char = match ofs_buf_vt_100.buffer[0][0] {
         PixelChar::PlainText { display_char, .. } => display_char,
         _ => ' ',
     };
-    let third_line_char = match ofs_buf.buffer[2][0] {
+    let third_line_char = match ofs_buf_vt_100.buffer[2][0] {
         PixelChar::PlainText { display_char, .. } => display_char,
         _ => ' ',
     };
@@ -711,8 +711,8 @@ fn test_practical_vim_editing_patterns() {
 
     // Verify file content (may have styling from vim functions, so just check characters
     // exist)
-    let row0 = &ofs_buf.buffer[0];
-    let row2 = &ofs_buf.buffer[2];
+    let row0 = &ofs_buf_vt_100.buffer[0];
+    let row2 = &ofs_buf_vt_100.buffer[2];
 
     // Extract text from row 0 starting at column 2
     let mut row0_text = String::new();
@@ -742,11 +742,11 @@ fn test_practical_vim_editing_patterns() {
     );
 
     // Verify command line mode indicator
-    assert_plain_char_at(&ofs_buf, 24, 0, ':');
+    assert_plain_char_at(&ofs_buf_vt_100, 24, 0, ':');
 
     // Verify syntax highlighting was applied
     assert_styled_char_at(
-        &ofs_buf,
+        &ofs_buf_vt_100,
         2,
         13, // Position where "echo" was highlighted
         'e',
@@ -761,12 +761,12 @@ fn test_practical_vim_editing_patterns() {
 /// functions for realistic text manipulation scenarios.
 #[test]
 fn test_text_manipulation_operations() {
-    let mut ofs_buf = create_realistic_terminal_buffer();
+    let mut ofs_buf_vt_100 = create_realistic_terminal_buffer();
 
     // Start with some initial text
     let initial_text =
         basic_sequences::move_and_print(nz(1), nz(1), "The quick fox jumps");
-    let _unused = ofs_buf.apply_ansi_bytes(initial_text);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(initial_text);
 
     // Insert "brown " before "fox" using character insertion
     let insert_pos = cursor_sequences::move_to_position(nz(1), nz(11)); // Before "fox"
@@ -776,20 +776,20 @@ fn test_text_manipulation_operations() {
     ); // Insert 6 chars
     let brown_text = basic_sequences::insert_text("brown ");
 
-    let _unused = ofs_buf.apply_ansi_bytes(insert_pos);
-    let _unused = ofs_buf.apply_ansi_bytes(insert_chars);
-    let _unused = ofs_buf.apply_ansi_bytes(brown_text);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(insert_pos);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(insert_chars);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(brown_text);
 
     // Move to end and add more text
     let end_pos = cursor_sequences::move_to_position(nz(1), nz(25));
     let over_text = basic_sequences::insert_text(" over the lazy dog");
 
-    let _unused = ofs_buf.apply_ansi_bytes(end_pos);
-    let _unused = ofs_buf.apply_ansi_bytes(over_text);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(end_pos);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(over_text);
 
     // Verify the complete sentence was built correctly
     // Character insertion operations may not work as expected - verify actual result
-    let first_row = &ofs_buf.buffer[0];
+    let first_row = &ofs_buf_vt_100.buffer[0];
     let mut actual_text = String::new();
     for i in 0..min(40, first_row.len()) {
         let ch = match first_row[i] {
@@ -811,16 +811,16 @@ fn test_text_manipulation_operations() {
         CsiCount::from_non_zero_value(nz(6)),
     ); // Delete "jumps "
 
-    let _unused = ofs_buf.apply_ansi_bytes(delete_pos);
-    let _unused = ofs_buf.apply_ansi_bytes(delete_chars);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(delete_pos);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(delete_chars);
 
     // Insert replacement text
     let replacement = basic_sequences::insert_text("leaps");
-    let _unused = ofs_buf.apply_ansi_bytes(replacement);
+    let _unused = ofs_buf_vt_100.apply_ansi_bytes(replacement);
 
     // Verify that text editing operations were applied
     // The exact result may differ based on how character operations work
-    let final_row = &ofs_buf.buffer[0];
+    let final_row = &ofs_buf_vt_100.buffer[0];
     let mut final_text = String::new();
     for i in 0..min(40, final_row.len()) {
         let ch = match final_row[i] {

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_line_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_line_ops.rs
@@ -9,12 +9,13 @@
 //!
 //! **Related Files:**
 //! - **Shim**: [`line_ops`] - Parameter translation (tested indirectly by this module)
-//! - **Implementation**: [`impl_line_ops`] - Business logic (has separate unit tests)
+//! - **Implementation**: [`vt_100_impl_line_ops`] - Business logic (has separate unit
+//!   tests)
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
-//! [`apply_ansi_bytes`]: crate::OffscreenBuffer::apply_ansi_bytes
-//! [`impl_line_ops`]: crate::vt_100_ansi_impl::vt_100_impl_line_ops
-//! [`line_ops`]: crate::vt_100_pty_output_parser::operations::vt_100_shim_line_ops
+//! [`apply_ansi_bytes`]: crate::OfsBufVT100::apply_ansi_bytes
+//! [`line_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops::vt_100_shim_line_ops
+//! [`vt_100_impl_line_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_line_ops
 //! [parser module docs]: super::super
 
 use super::super::test_fixtures_vt_100_ansi_conformance::*;
@@ -29,52 +30,52 @@ pub mod insert_line {
 
     #[test]
     fn test_insert_single_line() {
-        let mut ofs_buf = create_numbered_buffer(5, 10);
+        let mut ofs_buf_vt_100 = create_numbered_buffer(5, 10);
 
         // Move cursor to row 2 (0-based) and insert one line
         let move_cursor = term_row(nz(3)) + term_col(nz(1)); // Move to row 3, col 1 (1-based)
         let insert_line = CsiSequence::InsertLine(CsiCount::ONE);
         let sequence = format!("{move_cursor}{insert_line}");
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
         // Verify lines have shifted down.
-        assert_blank_line(&ofs_buf, 2); // New blank line at cursor
-        assert_line_content(&ofs_buf, 0, "Line00"); // Line 0 unchanged
-        assert_line_content(&ofs_buf, 1, "Line01"); // Line 1 unchanged
-        assert_line_content(&ofs_buf, 3, "Line02"); // Line 2 shifted to 3
-        assert_line_content(&ofs_buf, 4, "Line03"); // Line 3 shifted to 4
+        assert_blank_line(&ofs_buf_vt_100, 2); // New blank line at cursor
+        assert_line_content(&ofs_buf_vt_100, 0, "Line00"); // Line 0 unchanged
+        assert_line_content(&ofs_buf_vt_100, 1, "Line01"); // Line 1 unchanged
+        assert_line_content(&ofs_buf_vt_100, 3, "Line02"); // Line 2 shifted to 3
+        assert_line_content(&ofs_buf_vt_100, 4, "Line03"); // Line 3 shifted to 4
         // Line 4 ("Line04") was lost (shifted off bottom)
     }
 
     #[test]
     fn test_insert_multiple_lines() {
-        let mut ofs_buf = create_numbered_buffer(5, 10);
+        let mut ofs_buf_vt_100 = create_numbered_buffer(5, 10);
 
         // Move cursor to row 1 (0-based) and insert three lines
         let move_cursor = term_row(nz(2)) + term_col(nz(1)); // Move to row 2, col 1 (1-based)
         let insert_lines = CsiSequence::InsertLine(CsiCount::new(3).unwrap());
         let sequence = format!("{move_cursor}{insert_lines}");
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
         // Verify lines have shifted down by 3.
-        assert_line_content(&ofs_buf, 0, "Line00"); // Line 0 unchanged
-        assert_blank_line(&ofs_buf, 1); // New blank lines
-        assert_blank_line(&ofs_buf, 2);
-        assert_blank_line(&ofs_buf, 3);
-        assert_line_content(&ofs_buf, 4, "Line01"); // Line 1 shifted to 4
+        assert_line_content(&ofs_buf_vt_100, 0, "Line00"); // Line 0 unchanged
+        assert_blank_line(&ofs_buf_vt_100, 1); // New blank lines
+        assert_blank_line(&ofs_buf_vt_100, 2);
+        assert_blank_line(&ofs_buf_vt_100, 3);
+        assert_line_content(&ofs_buf_vt_100, 4, "Line01"); // Line 1 shifted to 4
         // Lines 2, 3, 4 were lost.
     }
 
     #[test]
     fn test_insert_lines_with_margins() {
-        let mut ofs_buf = create_numbered_buffer(10, 10);
+        let mut ofs_buf_vt_100 = create_numbered_buffer(10, 10);
 
         // Set scroll margins: rows 3-7 (1-based)
         let set_margins = CsiSequence::SetScrollingMargins {
             top: Some(term_row(nz(3))),
             bottom: Some(term_row(nz(7))),
         };
-        let _result = ofs_buf.apply_ansi_bytes(format!("{set_margins}"));
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(format!("{set_margins}"));
 
         // Move cursor to row 5 (1-based, within margins) and insert one line
         let move_cursor = CsiSequence::CursorPosition {
@@ -83,42 +84,47 @@ pub mod insert_line {
         };
         let insert_line = CsiSequence::InsertLine(CsiCount::ONE);
         let sequence = format!("{move_cursor}{insert_line}");
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
         // Verify only lines within margins are affected.
-        assert_line_content(&ofs_buf, 0, "Line00"); // Outside margins, unchanged
-        assert_line_content(&ofs_buf, 1, "Line01"); // Outside margins, unchanged
-        assert_line_content(&ofs_buf, 2, "Line02"); // Top margin, unchanged
-        assert_line_content(&ofs_buf, 3, "Line03"); // Within margins, unchanged
-        assert_blank_line(&ofs_buf, 4); // Inserted blank line
-        assert_line_content(&ofs_buf, 5, "Line04"); // Shifted within margins
-        assert_line_content(&ofs_buf, 6, "Line05"); // Shifted within margins
+        assert_line_content(&ofs_buf_vt_100, 0, "Line00"); // Outside margins, unchanged
+        assert_line_content(&ofs_buf_vt_100, 1, "Line01"); // Outside margins, unchanged
+        assert_line_content(&ofs_buf_vt_100, 2, "Line02"); // Top margin, unchanged
+        assert_line_content(&ofs_buf_vt_100, 3, "Line03"); // Within margins, unchanged
+        assert_blank_line(&ofs_buf_vt_100, 4); // Inserted blank line
+        assert_line_content(&ofs_buf_vt_100, 5, "Line04"); // Shifted within margins
+        assert_line_content(&ofs_buf_vt_100, 6, "Line05"); // Shifted within margins
         // Line06 was lost at bottom of scroll region.
-        assert_line_content(&ofs_buf, 7, "Line07"); // Outside margins, unchanged
-        assert_line_content(&ofs_buf, 8, "Line08"); // Outside margins, unchanged
-        assert_line_content(&ofs_buf, 9, "Line09"); // Outside margins, unchanged
+        assert_line_content(&ofs_buf_vt_100, 7, "Line07"); // Outside margins, unchanged
+        assert_line_content(&ofs_buf_vt_100, 8, "Line08"); // Outside margins, unchanged
+        assert_line_content(&ofs_buf_vt_100, 9, "Line09"); // Outside margins, unchanged
     }
 
     #[test]
     fn test_insert_line_outside_margins_ignored() {
-        let mut ofs_buf = create_numbered_buffer(5, 10);
-        let performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_numbered_buffer(5, 10);
+        let performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Set scroll margins: rows 2-4 (1-based) = 1-3 (0-based)
-        performer.ofs_buf.ansi_parser_support.scroll_region_top = Some(term_row(nz(2)));
-        performer.ofs_buf.ansi_parser_support.scroll_region_bottom =
-            Some(term_row(nz(4)));
+        performer
+            .ofs_buf_vt_100
+            .parser_global_state
+            .scroll_region_top = Some(term_row(nz(2)));
+        performer
+            .ofs_buf_vt_100
+            .parser_global_state
+            .scroll_region_bottom = Some(term_row(nz(4)));
 
         // Move cursor to row 0 (outside margins)
-        performer.ofs_buf.cursor_pos = row(0) + col(0);
+        performer.ofs_buf_vt_100.cursor_pos = row(0) + col(0);
 
         // Try to insert line: ESC[L (should be ignored)
         let insert_line_sequence = format!("{}", CsiSequence::InsertLine(CsiCount::ONE));
-        let _result = ofs_buf.apply_ansi_bytes(insert_line_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(insert_line_sequence);
 
         // Verify no changes occurred.
         for r in 0..5 {
-            assert_line_content(&ofs_buf, r, &format!("Line{r:02}"));
+            assert_line_content(&ofs_buf_vt_100, r, &format!("Line{r:02}"));
         }
     }
 }
@@ -129,7 +135,7 @@ pub mod delete_line {
 
     #[test]
     fn test_delete_single_line() {
-        let mut ofs_buf = create_numbered_buffer(5, 10);
+        let mut ofs_buf_vt_100 = create_numbered_buffer(5, 10);
 
         // Move cursor to row 3 (1-based) and delete one line
         let move_cursor = CsiSequence::CursorPosition {
@@ -138,20 +144,20 @@ pub mod delete_line {
         };
         let delete_line = CsiSequence::DeleteLine(CsiCount::ONE);
         let sequence = format!("{move_cursor}{delete_line}");
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
         // Verify lines have shifted up.
-        assert_line_content(&ofs_buf, 0, "Line00"); // Line 0 unchanged
-        assert_line_content(&ofs_buf, 1, "Line01"); // Line 1 unchanged
-        assert_line_content(&ofs_buf, 2, "Line03"); // Line 3 shifted to 2
-        assert_line_content(&ofs_buf, 3, "Line04"); // Line 4 shifted to 3
-        assert_blank_line(&ofs_buf, 4); // New blank line at bottom
+        assert_line_content(&ofs_buf_vt_100, 0, "Line00"); // Line 0 unchanged
+        assert_line_content(&ofs_buf_vt_100, 1, "Line01"); // Line 1 unchanged
+        assert_line_content(&ofs_buf_vt_100, 2, "Line03"); // Line 3 shifted to 2
+        assert_line_content(&ofs_buf_vt_100, 3, "Line04"); // Line 4 shifted to 3
+        assert_blank_line(&ofs_buf_vt_100, 4); // New blank line at bottom
         // Line 2 ("Line02") was deleted
     }
 
     #[test]
     fn test_delete_multiple_lines() {
-        let mut ofs_buf = create_numbered_buffer(5, 10);
+        let mut ofs_buf_vt_100 = create_numbered_buffer(5, 10);
 
         // Move cursor to row 2 (1-based) and delete three lines
         let move_cursor = CsiSequence::CursorPosition {
@@ -160,27 +166,27 @@ pub mod delete_line {
         };
         let delete_lines = CsiSequence::DeleteLine(CsiCount::new(3).unwrap());
         let sequence = format!("{move_cursor}{delete_lines}");
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
         // Verify lines have shifted up by 3.
-        assert_line_content(&ofs_buf, 0, "Line00"); // Line 0 unchanged
-        assert_line_content(&ofs_buf, 1, "Line04"); // Line 4 shifted to 1
-        assert_blank_line(&ofs_buf, 2); // New blank lines at bottom
-        assert_blank_line(&ofs_buf, 3);
-        assert_blank_line(&ofs_buf, 4);
+        assert_line_content(&ofs_buf_vt_100, 0, "Line00"); // Line 0 unchanged
+        assert_line_content(&ofs_buf_vt_100, 1, "Line04"); // Line 4 shifted to 1
+        assert_blank_line(&ofs_buf_vt_100, 2); // New blank lines at bottom
+        assert_blank_line(&ofs_buf_vt_100, 3);
+        assert_blank_line(&ofs_buf_vt_100, 4);
         // Lines 1, 2, 3 were deleted.
     }
 
     #[test]
     fn test_delete_lines_with_margins() {
-        let mut ofs_buf = create_numbered_buffer(10, 10);
+        let mut ofs_buf_vt_100 = create_numbered_buffer(10, 10);
 
         // Set scroll margins: rows 3-7 (1-based)
         let set_margins = CsiSequence::SetScrollingMargins {
             top: Some(term_row(nz(3))),
             bottom: Some(term_row(nz(7))),
         };
-        let _result = ofs_buf.apply_ansi_bytes(format!("{set_margins}"));
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(format!("{set_margins}"));
 
         // Move cursor to row 5 (1-based, within margins) and delete one line
         let move_cursor = CsiSequence::CursorPosition {
@@ -189,42 +195,47 @@ pub mod delete_line {
         };
         let delete_line = CsiSequence::DeleteLine(CsiCount::ONE);
         let sequence = format!("{move_cursor}{delete_line}");
-        let _result = ofs_buf.apply_ansi_bytes(sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
         // Verify only lines within margins are affected.
-        assert_line_content(&ofs_buf, 0, "Line00"); // Outside margins, unchanged
-        assert_line_content(&ofs_buf, 1, "Line01"); // Outside margins, unchanged
-        assert_line_content(&ofs_buf, 2, "Line02"); // Top margin, unchanged
-        assert_line_content(&ofs_buf, 3, "Line03"); // Within margins, unchanged
-        assert_line_content(&ofs_buf, 4, "Line05"); // Line05 shifted to 4
-        assert_line_content(&ofs_buf, 5, "Line06"); // Line06 shifted to 5
-        assert_blank_line(&ofs_buf, 6); // New blank line at bottom of region
-        assert_line_content(&ofs_buf, 7, "Line07"); // Outside margins, unchanged
-        assert_line_content(&ofs_buf, 8, "Line08"); // Outside margins, unchanged
-        assert_line_content(&ofs_buf, 9, "Line09"); // Outside margins, unchanged
+        assert_line_content(&ofs_buf_vt_100, 0, "Line00"); // Outside margins, unchanged
+        assert_line_content(&ofs_buf_vt_100, 1, "Line01"); // Outside margins, unchanged
+        assert_line_content(&ofs_buf_vt_100, 2, "Line02"); // Top margin, unchanged
+        assert_line_content(&ofs_buf_vt_100, 3, "Line03"); // Within margins, unchanged
+        assert_line_content(&ofs_buf_vt_100, 4, "Line05"); // Line05 shifted to 4
+        assert_line_content(&ofs_buf_vt_100, 5, "Line06"); // Line06 shifted to 5
+        assert_blank_line(&ofs_buf_vt_100, 6); // New blank line at bottom of region
+        assert_line_content(&ofs_buf_vt_100, 7, "Line07"); // Outside margins, unchanged
+        assert_line_content(&ofs_buf_vt_100, 8, "Line08"); // Outside margins, unchanged
+        assert_line_content(&ofs_buf_vt_100, 9, "Line09"); // Outside margins, unchanged
         // Line04 was deleted.
     }
 
     #[test]
     fn test_delete_line_outside_margins_ignored() {
-        let mut ofs_buf = create_numbered_buffer(5, 10);
-        let performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_numbered_buffer(5, 10);
+        let performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Set scroll margins: rows 2-4 (1-based) = 1-3 (0-based)
-        performer.ofs_buf.ansi_parser_support.scroll_region_top = Some(term_row(nz(2)));
-        performer.ofs_buf.ansi_parser_support.scroll_region_bottom =
-            Some(term_row(nz(4)));
+        performer
+            .ofs_buf_vt_100
+            .parser_global_state
+            .scroll_region_top = Some(term_row(nz(2)));
+        performer
+            .ofs_buf_vt_100
+            .parser_global_state
+            .scroll_region_bottom = Some(term_row(nz(4)));
 
         // Move cursor to row 4 (outside margins)
-        performer.ofs_buf.cursor_pos = row(4) + col(0);
+        performer.ofs_buf_vt_100.cursor_pos = row(4) + col(0);
 
         // Try to delete line: ESC[M (should be ignored)
         let delete_line_sequence = format!("{}", CsiSequence::DeleteLine(CsiCount::ONE));
-        let _result = ofs_buf.apply_ansi_bytes(delete_line_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(delete_line_sequence);
 
         // Verify no changes occurred.
         for r in 0..5 {
-            assert_line_content(&ofs_buf, r, &format!("Line{r:02}"));
+            assert_line_content(&ofs_buf_vt_100, r, &format!("Line{r:02}"));
         }
     }
 }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_margin_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_margin_ops.rs
@@ -22,7 +22,7 @@ pub mod decstbm_margins {
 
     #[test]
     fn test_set_margins_valid_range() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Set margins from row 3 to 7 (1-based)
         let csi_sequence = format!(
@@ -32,19 +32,22 @@ pub mod decstbm_margins {
                 bottom: Some(term_row(nz(7)))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(csi_sequence.as_bytes());
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(csi_sequence.as_bytes());
 
         // For this basic test, just verify the sequence was processed
-        // (The exact margin behavior would be tested in the operations module)
+        // (The exact margin behavior would be tested in the ops module)
     }
 
     #[test]
     fn test_basic_margin_functionality() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Verify initial state - no margins set
-        assert_eq!(ofs_buf.ansi_parser_support.scroll_region_top, None);
-        assert_eq!(ofs_buf.ansi_parser_support.scroll_region_bottom, None);
+        assert_eq!(ofs_buf_vt_100.parser_global_state.scroll_region_top, None);
+        assert_eq!(
+            ofs_buf_vt_100.parser_global_state.scroll_region_bottom,
+            None
+        );
 
         // Set margins from row 3 to 7 (1-based)
         let csi_sequence = format!(
@@ -54,15 +57,15 @@ pub mod decstbm_margins {
                 bottom: Some(term_row(nz(7)))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(csi_sequence.as_bytes());
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(csi_sequence.as_bytes());
 
         // For this basic test, just verify the sequence was processed
-        // (The exact margin behavior would be tested in the operations module)
+        // (The exact margin behavior would be tested in the ops module)
     }
 
     #[test]
     fn test_margin_edge_cases() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Test setting margins to full buffer
         let full_buffer = format!(
@@ -72,7 +75,7 @@ pub mod decstbm_margins {
                 bottom: Some(term_row(nz(10)))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(full_buffer.as_bytes());
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(full_buffer.as_bytes());
 
         // Test invalid range (bottom < top)
         let invalid_range = format!(
@@ -82,7 +85,7 @@ pub mod decstbm_margins {
                 bottom: Some(term_row(nz(3)))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(invalid_range.as_bytes());
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(invalid_range.as_bytes());
 
         // Test reset margins (no parameters = reset to full screen)
         let reset = format!(
@@ -92,7 +95,7 @@ pub mod decstbm_margins {
                 bottom: None
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(reset.as_bytes());
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(reset.as_bytes());
 
         // Basic functionality test - the detailed behavior is tested elsewhere
     }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_mode_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_mode_ops.rs
@@ -16,13 +16,14 @@
 //!
 //! **Related Files:**
 //! - **Shim**: [`mode_ops`] - Parameter translation (tested indirectly by this module)
-//! - **Implementation**: [`impl_mode_ops`] - Business logic (has separate unit tests)
+//! - **Implementation**: [`vt_100_impl_mode_ops`] - Business logic (has separate unit
+//!   tests)
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
-//! [`apply_ansi_bytes`]: crate::OffscreenBuffer::apply_ansi_bytes
+//! [`apply_ansi_bytes`]: crate::OfsBufVT100::apply_ansi_bytes
 //! [`CSI`]: crate::CsiSequence
-//! [`impl_mode_ops`]: crate::vt_100_ansi_impl::vt_100_impl_mode_ops
-//! [`mode_ops`]: crate::vt_100_pty_output_parser::operations::vt_100_shim_mode_ops
+//! [`mode_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops::vt_100_shim_mode_ops
+//! [`vt_100_impl_mode_ops`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf::vt_100_impl_mode_ops
 //! [parser module docs]: super::super
 
 use super::super::test_fixtures_vt_100_ansi_conformance::*;
@@ -31,105 +32,122 @@ use crate::{core::ansi::vt_100_pty_output_parser::{CsiSequence, PrivateModeType}
 
 /// Tests for DECAWM (Auto Wrap Mode) operations.
 pub mod auto_wrap_mode {
+    use super::*;
     use crate::AutoWrapState;
-
-use super::*;
 
     #[test]
     fn test_decawm_enable() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Auto wrap is enabled by default
-        assert_eq!(ofs_buf.ansi_parser_support.auto_wrap_mode, AutoWrapState::Enabled);
+        assert_eq!(
+            ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Enabled
+        );
 
         // Disable first to test enable
         let disable_sequence = format!(
             "{}",
             CsiSequence::DisablePrivateMode(PrivateModeType::AutoWrap)
         );
-        let _result = ofs_buf.apply_ansi_bytes(disable_sequence);
-        assert_eq!(ofs_buf.ansi_parser_support.auto_wrap_mode, AutoWrapState::Disabled);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(disable_sequence);
+        assert_eq!(
+            ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Disabled
+        );
 
         // Enable auto wrap mode
         let enable_sequence = format!(
             "{}",
             CsiSequence::EnablePrivateMode(PrivateModeType::AutoWrap)
         );
-        let _result = ofs_buf.apply_ansi_bytes(enable_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(enable_sequence);
 
         // Verify mode is enabled
-        assert_eq!(ofs_buf.ansi_parser_support.auto_wrap_mode, AutoWrapState::Enabled);
+        assert_eq!(
+            ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Enabled
+        );
     }
 
     #[test]
     fn test_decawm_disable() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Auto wrap is enabled by default
-        assert_eq!(ofs_buf.ansi_parser_support.auto_wrap_mode, AutoWrapState::Enabled);
+        assert_eq!(
+            ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Enabled
+        );
 
         // Disable auto wrap mode
         let disable_sequence = format!(
             "{}",
             CsiSequence::DisablePrivateMode(PrivateModeType::AutoWrap)
         );
-        let _result = ofs_buf.apply_ansi_bytes(disable_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(disable_sequence);
 
         // Verify mode is disabled
-        assert_eq!(ofs_buf.ansi_parser_support.auto_wrap_mode, AutoWrapState::Disabled);
+        assert_eq!(
+            ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Disabled
+        );
     }
 
     #[test]
     fn test_decawm_behavior_with_text_wrapping() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Enable auto wrap (default)
         let enable_sequence = format!(
             "{}",
             CsiSequence::EnablePrivateMode(PrivateModeType::AutoWrap)
         );
-        let _result = ofs_buf.apply_ansi_bytes(enable_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(enable_sequence);
 
         // Write text that exceeds line width
         let long_text = "ABCDEFGHIJKLMNOP"; // 16 chars, buffer is 10 wide
-        let _result = ofs_buf.apply_ansi_bytes(long_text);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(long_text);
 
         // Should wrap to next line
-        assert_line_content(&ofs_buf, 0, "ABCDEFGHIJ");
-        assert_line_content(&ofs_buf, 1, "KLMNOP");
+        assert_line_content(&ofs_buf_vt_100, 0, "ABCDEFGHIJ");
+        assert_line_content(&ofs_buf_vt_100, 1, "KLMNOP");
     }
 
     #[test]
     fn test_decawm_behavior_without_wrapping() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Disable auto wrap
         let disable_sequence = format!(
             "{}",
             CsiSequence::DisablePrivateMode(PrivateModeType::AutoWrap)
         );
-        let _result = ofs_buf.apply_ansi_bytes(disable_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(disable_sequence);
 
         // Write text that exceeds line width
         let long_text = "ABCDEFGHIJKLMNOP"; // 16 chars, buffer is 10 wide
-        let _result = ofs_buf.apply_ansi_bytes(long_text);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(long_text);
 
         // Should not wrap, last character should overwrite at right margin
-        assert_line_content(&ofs_buf, 0, "ABCDEFGHIP"); // Last 'P' overwrites 'J'
-        assert_blank_line(&ofs_buf, 1); // Second line should be blank
+        assert_line_content(&ofs_buf_vt_100, 0, "ABCDEFGHIP"); // Last 'P' overwrites 'J'
+        assert_blank_line(&ofs_buf_vt_100, 1); // Second line should be blank
     }
 
     #[test]
     fn test_decawm_mode_persistence() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Disable auto wrap
         let disable_sequence = format!(
             "{}",
             CsiSequence::DisablePrivateMode(PrivateModeType::AutoWrap)
         );
-        let _result = ofs_buf.apply_ansi_bytes(disable_sequence);
-        assert_eq!(ofs_buf.ansi_parser_support.auto_wrap_mode, AutoWrapState::Disabled);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(disable_sequence);
+        assert_eq!(
+            ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Disabled
+        );
 
         // Perform other operations
         let move_sequence = format!(
@@ -139,88 +157,114 @@ use super::*;
                 col: term_col(nz(5))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(move_sequence);
-        let _result = ofs_buf.apply_ansi_bytes("Test");
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(move_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes("Test");
 
         // Mode should persist
-        assert_eq!(ofs_buf.ansi_parser_support.auto_wrap_mode, AutoWrapState::Disabled);
+        assert_eq!(
+            ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Disabled
+        );
 
         // Re-enable and verify
         let enable_sequence = format!(
             "{}",
             CsiSequence::EnablePrivateMode(PrivateModeType::AutoWrap)
         );
-        let _result = ofs_buf.apply_ansi_bytes(enable_sequence);
-        assert_eq!(ofs_buf.ansi_parser_support.auto_wrap_mode, AutoWrapState::Enabled);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(enable_sequence);
+        assert_eq!(
+            ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Enabled
+        );
     }
 }
 
 /// Tests for mode state combinations and interactions.
 pub mod mode_interactions {
+    use super::*;
     use crate::AutoWrapState;
-
-use super::*;
 
     #[test]
     fn test_multiple_mode_changes() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Start with defaults
-        assert_eq!(ofs_buf.ansi_parser_support.auto_wrap_mode, AutoWrapState::Enabled);
+        assert_eq!(
+            ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Enabled
+        );
 
         // Toggle auto wrap multiple times
         let disable_sequence = format!(
             "{}",
             CsiSequence::DisablePrivateMode(PrivateModeType::AutoWrap)
         );
-        let _result = ofs_buf.apply_ansi_bytes(disable_sequence);
-        assert_eq!(ofs_buf.ansi_parser_support.auto_wrap_mode, AutoWrapState::Disabled);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(disable_sequence);
+        assert_eq!(
+            ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Disabled
+        );
 
         let enable_sequence = format!(
             "{}",
             CsiSequence::EnablePrivateMode(PrivateModeType::AutoWrap)
         );
-        let _result = ofs_buf.apply_ansi_bytes(enable_sequence);
-        assert_eq!(ofs_buf.ansi_parser_support.auto_wrap_mode, AutoWrapState::Enabled);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(enable_sequence);
+        assert_eq!(
+            ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Enabled
+        );
 
         let disable_sequence2 = format!(
             "{}",
             CsiSequence::DisablePrivateMode(PrivateModeType::AutoWrap)
         );
-        let _result = ofs_buf.apply_ansi_bytes(disable_sequence2);
-        assert_eq!(ofs_buf.ansi_parser_support.auto_wrap_mode, AutoWrapState::Disabled);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(disable_sequence2);
+        assert_eq!(
+            ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Disabled
+        );
     }
 
     #[test]
     fn test_mode_with_cursor_save_restore() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Disable auto wrap
         let disable_sequence = format!(
             "{}",
             CsiSequence::DisablePrivateMode(PrivateModeType::AutoWrap)
         );
-        let _result = ofs_buf.apply_ansi_bytes(disable_sequence);
-        assert_eq!(ofs_buf.ansi_parser_support.auto_wrap_mode, AutoWrapState::Disabled);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(disable_sequence);
+        assert_eq!(
+            ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Disabled
+        );
 
         // Save cursor
         let save_sequence = format!("{}", CsiSequence::SaveCursor);
-        let _result = ofs_buf.apply_ansi_bytes(save_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(save_sequence);
 
         // Enable auto wrap
         let enable_sequence = format!(
             "{}",
             CsiSequence::EnablePrivateMode(PrivateModeType::AutoWrap)
         );
-        let _result = ofs_buf.apply_ansi_bytes(enable_sequence);
-        assert_eq!(ofs_buf.ansi_parser_support.auto_wrap_mode, AutoWrapState::Enabled);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(enable_sequence);
+        assert_eq!(
+            ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Enabled
+        );
 
         // Restore cursor
         let restore_sequence = format!("{}", CsiSequence::RestoreCursor);
-        let _result = ofs_buf.apply_ansi_bytes(restore_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(restore_sequence);
 
         // Mode should persist (not affected by cursor restore)
-        assert_eq!(ofs_buf.ansi_parser_support.auto_wrap_mode, AutoWrapState::Enabled);
+        assert_eq!(
+            ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Enabled
+        );
     }
 }
 
@@ -231,11 +275,11 @@ pub mod alt_screen_mode {
 
     #[test]
     fn test_alt_screen_enable_and_disable_via_ansi() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Initially inactive.
         assert_eq!(
-            ofs_buf.terminal_mode.alternate_screen,
+            ofs_buf_vt_100.terminal_mode.alternate_screen,
             AlternateScreenState::Inactive
         );
 
@@ -244,9 +288,9 @@ pub mod alt_screen_mode {
             "{}",
             CsiSequence::EnablePrivateMode(PrivateModeType::AlternateScreenBuffer)
         );
-        let _result = ofs_buf.apply_ansi_bytes(enable_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(enable_sequence);
         assert_eq!(
-            ofs_buf.terminal_mode.alternate_screen,
+            ofs_buf_vt_100.terminal_mode.alternate_screen,
             AlternateScreenState::Active
         );
 
@@ -255,9 +299,9 @@ pub mod alt_screen_mode {
             "{}",
             CsiSequence::DisablePrivateMode(PrivateModeType::AlternateScreenBuffer)
         );
-        let _result = ofs_buf.apply_ansi_bytes(disable_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(disable_sequence);
         assert_eq!(
-            ofs_buf.terminal_mode.alternate_screen,
+            ofs_buf_vt_100.terminal_mode.alternate_screen,
             AlternateScreenState::Inactive
         );
     }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_osc_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_osc_ops.rs
@@ -10,11 +10,11 @@ use crate::{core::osc::{OscEvent, osc_codes::OscSequence},
 
 #[test]
 fn test_osc_title_sequences() {
-    let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+    let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
     // Test OSC 0 (set title and icon)
     let sequence1 = OscSequence::SetTitleAndIcon("Test Title".to_string()).to_string();
-    let (osc_events1, dsr_responses1) = ofs_buf.apply_ansi_bytes(sequence1);
+    let (osc_events1, dsr_responses1) = ofs_buf_vt_100.apply_ansi_bytes(sequence1);
 
     // Should get one OSC event.
     assert_eq!(osc_events1.len(), 1);
@@ -29,7 +29,7 @@ fn test_osc_title_sequences() {
 
     // Test OSC 2 (set title only)
     let sequence2 = OscSequence::SetTitle("Window Title".to_string()).to_string();
-    let (osc_events2, dsr_responses2) = ofs_buf.apply_ansi_bytes(sequence2);
+    let (osc_events2, dsr_responses2) = ofs_buf_vt_100.apply_ansi_bytes(sequence2);
 
     // Should get one new OSC event (not accumulated)
     assert_eq!(osc_events2.len(), 1);
@@ -45,7 +45,7 @@ fn test_osc_title_sequences() {
 
 #[test]
 fn test_osc_hyperlink() {
-    let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+    let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
     // Test OSC 8 hyperlink.
     let hyperlink_start = OscSequence::HyperlinkStart {
@@ -54,7 +54,7 @@ fn test_osc_hyperlink() {
     };
     let hyperlink_end = OscSequence::HyperlinkEnd;
     let sequence = format!("{hyperlink_start}Link Text{hyperlink_end}");
-    let (osc_events, dsr_responses) = ofs_buf.apply_ansi_bytes(sequence);
+    let (osc_events, dsr_responses) = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
     // Should get two OSC events (start and end hyperlink)
     assert_eq!(osc_events.len(), 2);
@@ -68,10 +68,10 @@ fn test_osc_hyperlink() {
     }
 
     // Verify text was written.
-    assert_plain_text_at(&ofs_buf, 0, 0, "Link Text");
+    assert_plain_text_at(&ofs_buf_vt_100, 0, 0, "Link Text");
 
     // Verify events are drained on next call.
-    let (osc_events2, dsr_responses2) = ofs_buf.apply_ansi_bytes("more text");
+    let (osc_events2, dsr_responses2) = ofs_buf_vt_100.apply_ansi_bytes("more text");
     assert_eq!(osc_events2.len(), 0, "OSC events should be drained");
     assert_eq!(dsr_responses2.len(), 0, "DSR responses should be empty");
 }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_protocol_char_encoding.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_protocol_char_encoding.rs
@@ -10,10 +10,10 @@ use vte::Perform;
 
 #[test]
 fn test_utf8_characters() {
-    let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+    let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
     // Process UTF-8 characters including emojis.
-    let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+    let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
     // Print various UTF-8 characters.
     performer.print('H');
@@ -23,21 +23,21 @@ fn test_utf8_characters() {
     performer.print('!');
 
     // Verify all UTF-8 characters are in the buffer.
-    assert_plain_char_at(&ofs_buf, 0, 0, 'H');
-    assert_plain_char_at(&ofs_buf, 0, 1, 'é');
-    assert_plain_char_at(&ofs_buf, 0, 2, '中');
-    assert_plain_char_at(&ofs_buf, 0, 3, '🦀');
-    assert_plain_char_at(&ofs_buf, 0, 4, '!');
+    assert_plain_char_at(&ofs_buf_vt_100, 0, 0, 'H');
+    assert_plain_char_at(&ofs_buf_vt_100, 0, 1, 'é');
+    assert_plain_char_at(&ofs_buf_vt_100, 0, 2, '中');
+    assert_plain_char_at(&ofs_buf_vt_100, 0, 3, '🦀');
+    assert_plain_char_at(&ofs_buf_vt_100, 0, 4, '!');
 
     // Verify rest of line is empty.
     for col in 5..10 {
-        assert_empty_at(&ofs_buf, 0, col);
+        assert_empty_at(&ofs_buf_vt_100, 0, col);
     }
 
     // Verify the rest of the buffer is empty.
     for row in 1..10 {
         for col in 0..10 {
-            assert_empty_at(&ofs_buf, row, col);
+            assert_empty_at(&ofs_buf_vt_100, row, col);
         }
     }
 }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_protocol_control_chars.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_protocol_control_chars.rs
@@ -12,10 +12,10 @@ use vte::Perform;
 /// Tests for C0 control characters (CR, LF, Tab, Backspace, etc.).
 #[test]
 fn test_control_characters() {
-    let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+    let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
     // Test various control characters.
-    let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+    let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
     // Print some text
     performer.print('A');
@@ -25,7 +25,7 @@ fn test_control_characters() {
     // Carriage return should move to start of line.
     performer.execute(CARRIAGE_RETURN);
     assert_eq!(
-        performer.ofs_buf.cursor_pos,
+        performer.ofs_buf_vt_100.cursor_pos,
         row(0) + col(0),
         "Cursor should be at start of line after CR"
     );
@@ -34,53 +34,53 @@ fn test_control_characters() {
     // Line feed should move to next line, but same column.
     performer.execute(LINE_FEED);
     assert_eq!(
-        performer.ofs_buf.cursor_pos,
+        performer.ofs_buf_vt_100.cursor_pos,
         row(1) + col(1),
         "Cursor should move to next row after LF, but same column"
     );
 
     // Reset column for next test.
-    performer.ofs_buf.cursor_pos.col_index = col(0);
+    performer.ofs_buf_vt_100.cursor_pos.col_index = col(0);
     performer.print('Y');
 
     // Tab should advance cursor.
     performer.execute(TAB);
     assert_eq!(
-        performer.ofs_buf.cursor_pos,
+        performer.ofs_buf_vt_100.cursor_pos,
         row(1) + col(8),
         "Cursor should move to col 8 after tab"
     );
     performer.print('Z');
 
     // Backspace should move cursor back.
-    performer.ofs_buf.cursor_pos.col_index = col(3);
+    performer.ofs_buf_vt_100.cursor_pos.col_index = col(3);
     performer.print('M');
     performer.execute(BACKSPACE); // Backspace
     assert_eq!(
-        performer.ofs_buf.cursor_pos,
+        performer.ofs_buf_vt_100.cursor_pos,
         row(1) + col(3),
         "Cursor should move back one column after BS, to col 3"
     );
     performer.print('N'); // Should overwrite 'M' at col 3
     assert_eq!(
-        performer.ofs_buf.cursor_pos,
+        performer.ofs_buf_vt_100.cursor_pos,
         row(1) + col(4),
         "Cursor should move to col 4 after printing 'N', same row"
     );
 
-    // Verify final ofs_buf cursor position.
+    // Verify final ofs_buf_vt_100 cursor position.
     assert_eq!(
-        ofs_buf.cursor_pos,
+        ofs_buf_vt_100.cursor_pos,
         row(1) + col(4),
         "Final cursor position should be row 1, col 4"
     );
 
     // Verify buffer contents.
-    assert_plain_char_at(&ofs_buf, 0, 0, 'X'); // 'A' was overwritten by 'X' after CR
-    assert_plain_char_at(&ofs_buf, 0, 1, 'B');
-    assert_plain_char_at(&ofs_buf, 0, 2, 'C');
+    assert_plain_char_at(&ofs_buf_vt_100, 0, 0, 'X'); // 'A' was overwritten by 'X' after CR
+    assert_plain_char_at(&ofs_buf_vt_100, 0, 1, 'B');
+    assert_plain_char_at(&ofs_buf_vt_100, 0, 2, 'C');
 
-    assert_plain_char_at(&ofs_buf, 1, 0, 'Y'); // After line feed
-    assert_plain_char_at(&ofs_buf, 1, 8, 'Z'); // After tab
-    assert_plain_char_at(&ofs_buf, 1, 3, 'N'); // N overwrote M at position 3
+    assert_plain_char_at(&ofs_buf_vt_100, 1, 0, 'Y'); // After line feed
+    assert_plain_char_at(&ofs_buf_vt_100, 1, 8, 'Z'); // After tab
+    assert_plain_char_at(&ofs_buf_vt_100, 1, 3, 'N'); // N overwrote M at position 3
 }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_protocol_csi_basic.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_protocol_csi_basic.rs
@@ -13,40 +13,40 @@ use crate::{CsiCount, TermCol, TermRow, col, row};
 
 #[test]
 fn test_basic_delete_char_integration() {
-    let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+    let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
     // Write test text using our sequence builder
     let text_sequence = basic_sequences::insert_text("ABCDEF");
-    let _write_result = ofs_buf.apply_ansi_bytes(text_sequence);
+    let _write_result = ofs_buf_vt_100.apply_ansi_bytes(text_sequence);
 
     // Move to position 4 (letter 'D') and delete it using sequence builder
     let delete_sequence = basic_sequences::move_and_delete_chars(
         TermCol::from_raw_non_zero_value(nz(4)),
         CsiCount::ONE,
     );
-    let _result = ofs_buf.apply_ansi_bytes(delete_sequence);
+    let _result = ofs_buf_vt_100.apply_ansi_bytes(delete_sequence);
 
     // Should now read "ABCEF " (D deleted, chars shifted left, blank at end)
-    assert_line_content(&ofs_buf, 0, "ABCEF ");
+    assert_line_content(&ofs_buf_vt_100, 0, "ABCEF ");
 }
 
 #[test]
 fn test_basic_insert_char_integration() {
-    let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+    let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
     // Write test text using our sequence builder
     let text_sequence = basic_sequences::insert_text("HELLO");
-    let _write_result = ofs_buf.apply_ansi_bytes(text_sequence);
+    let _write_result = ofs_buf_vt_100.apply_ansi_bytes(text_sequence);
 
     // Move to position 3 and insert a blank character using sequence builder
     let insert_sequence = basic_sequences::move_and_insert_chars(
         TermCol::from_raw_non_zero_value(nz(3)),
         CsiCount::ONE,
     );
-    let _result = ofs_buf.apply_ansi_bytes(insert_sequence);
+    let _result = ofs_buf_vt_100.apply_ansi_bytes(insert_sequence);
 
     // Should now read "HE LLO" (blank inserted at position 3)
-    let actual: String = ofs_buf.buffer[0]
+    let actual: String = ofs_buf_vt_100.buffer[0]
         .iter()
         .take(6) // "HE LLO" is 6 chars
         .map(|pixel_char| match pixel_char {
@@ -59,21 +59,21 @@ fn test_basic_insert_char_integration() {
 
 #[test]
 fn test_basic_erase_char_integration() {
-    let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+    let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
     // Write test text using our sequence builder
     let text_sequence = basic_sequences::insert_text("HELLO");
-    let _write_result = ofs_buf.apply_ansi_bytes(text_sequence);
+    let _write_result = ofs_buf_vt_100.apply_ansi_bytes(text_sequence);
 
     // Move to position 3 ('L') and erase it using sequence builder
     let erase_sequence = basic_sequences::move_and_erase_chars(
         TermCol::from_raw_non_zero_value(nz(3)),
         CsiCount::ONE,
     );
-    let _result = ofs_buf.apply_ansi_bytes(erase_sequence);
+    let _result = ofs_buf_vt_100.apply_ansi_bytes(erase_sequence);
 
     // Should now read "HE LO" (L erased to blank, no shifting)
-    let actual: String = ofs_buf.buffer[0]
+    let actual: String = ofs_buf_vt_100.buffer[0]
         .iter()
         .take(5) // "HE LO" is 5 chars
         .map(|pixel_char| match pixel_char {
@@ -86,17 +86,17 @@ fn test_basic_erase_char_integration() {
 
 #[test]
 fn test_basic_vpa_integration() {
-    let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+    let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
     // Move to specific position using our sequence builder
     let move_sequence = cursor_sequences::move_to_position(nz(5), nz(7));
-    let _move_result = ofs_buf.apply_ansi_bytes(move_sequence);
+    let _move_result = ofs_buf_vt_100.apply_ansi_bytes(move_sequence);
 
     // Use VPA to move to specific row while maintaining column
     let vpa_sequence =
         cursor_sequences::move_to_row(TermRow::from_raw_non_zero_value(nz(3)));
-    let _result = ofs_buf.apply_ansi_bytes(vpa_sequence);
+    let _result = ofs_buf_vt_100.apply_ansi_bytes(vpa_sequence);
 
     // Should be at row 2 (0-based), column 6 (0-based)
-    assert_eq!(ofs_buf.cursor_pos, row(2) + col(6));
+    assert_eq!(ofs_buf_vt_100.cursor_pos, row(2) + col(6));
 }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_scroll_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_scroll_ops.rs
@@ -13,8 +13,7 @@
 //! - Interactions between scroll regions and cursor positioning
 
 use super::super::test_fixtures_vt_100_ansi_conformance::*;
-use crate::AutoWrapState;
-use crate::{EscSequence, TuiStyle, col,
+use crate::{AutoWrapState, EscSequence, TuiStyle, col,
             core::ansi::{constants::{IND_INDEX_DOWN, RI_REVERSE_INDEX_UP},
                          vt_100_pty_output_parser::{CsiSequence, PrivateModeType,
                                                     ansi_parser_public_api::AnsiToOfsBufPerformer}},
@@ -22,11 +21,11 @@ use crate::{EscSequence, TuiStyle, col,
             row, term_col, term_row, term_row_delta};
 use vte::Perform;
 
-fn fill_buffer_with_lines(ofs_buf: &mut crate::OffscreenBuffer) {
-    for r in 0..ofs_buf.window_size.row_height.as_usize() {
+fn fill_buffer_with_lines(ofs_buf_vt_100: &mut crate::OfsBufVT100) {
+    for r in 0..ofs_buf_vt_100.window_size.row_height.as_usize() {
         let line_text = format!("Line-{r}");
         for (c, char) in line_text.chars().enumerate() {
-            ofs_buf.buffer[r][c] = crate::PixelChar::PlainText {
+            ofs_buf_vt_100.buffer[r][c] = crate::PixelChar::PlainText {
                 display_char: char,
                 style: TuiStyle::default(),
             };
@@ -40,14 +39,14 @@ pub mod auto_wrap {
 
     #[test]
     fn test_auto_wrap_enabled_by_default() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Auto-wrap should be enabled by default.
         // This test verifies that characters wrap to the next line when reaching the
         // right margin.
         //
-        // Note: OffscreenBuffer uses 0-based index, and terminal (CSI, ESC seq, etc) uses
-        // 1-based index.
+        // Note: OfsBufVT100 uses 0-based index, and terminal (CSI, ESC seq, etc)
+        // uses 1-based index.
         //
         // Buffer layout:
         //
@@ -61,11 +60,12 @@ pub mod auto_wrap {
         //         └───┴─│─┴───┴───┴───┴───┴───┴───┴───┴───┘
         //               ╰─ cursor at (r:1,c:1)
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Verify auto-wrap is enabled by default.
         assert!(
-            performer.ofs_buf.ansi_parser_support.auto_wrap_mode == AutoWrapState::Enabled,
+            performer.ofs_buf_vt_100.parser_global_state.auto_wrap_mode
+                == AutoWrapState::Enabled,
             "Auto-wrap mode should be enabled by default"
         );
 
@@ -77,7 +77,7 @@ pub mod auto_wrap {
         // Verify cursor is at (r:1,c:0) - wrapped to next line after hitting right
         // boundary
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(1) + col(0),
             "Cursor should be at (r:1,c:0) after printing 10 characters"
         );
@@ -87,25 +87,25 @@ pub mod auto_wrap {
 
         // Verify cursor wrapped to next line.
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(1) + col(1),
             "Cursor should be at (r:1,c:1) after wrapping"
         );
 
         // Verify buffer contents.
-        assert_plain_text_at(&ofs_buf, 0, 0, "0123456789");
-        assert_plain_char_at(&ofs_buf, 1, 0, 'A');
+        assert_plain_text_at(&ofs_buf_vt_100, 0, 0, "0123456789");
+        assert_plain_char_at(&ofs_buf_vt_100, 1, 0, 'A');
     }
 
     #[test]
     fn test_auto_wrap_can_be_disabled() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // When auto-wrap is disabled, characters beyond the right margin
         // should overwrite the last column instead of wrapping.
         //
-        // Note: OffscreenBuffer uses 0-based index, and terminal (CSI, ESC seq, etc) uses
-        // 1-based index.
+        // Note: OfsBufVT100 uses 0-based index, and terminal (CSI, ESC seq, etc)
+        // uses 1-based index.
         //
         // Buffer layout:
         //
@@ -118,7 +118,7 @@ pub mod auto_wrap {
         //         │ … │ … │ … │ … │ … │ … │ … │ … │ … │ … │
         //         └───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Disable auto-wrap mode using CSI `?7l`.
         let sequence =
@@ -127,7 +127,8 @@ pub mod auto_wrap {
 
         // Verify auto-wrap is now disabled.
         assert!(
-            performer.ofs_buf.ansi_parser_support.auto_wrap_mode == AutoWrapState::Disabled,
+            performer.ofs_buf_vt_100.parser_global_state.auto_wrap_mode
+                == AutoWrapState::Disabled,
             "Auto-wrap mode should be disabled after CSI ?7l"
         );
 
@@ -141,35 +142,44 @@ pub mod auto_wrap {
 
         // Verify cursor stays at right margin.
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(0) + col(9),
             "Cursor should stay at (r:0,c:9) without wrapping"
         );
 
         // Verify buffer contents - 'X' should overwrite '9'.
-        assert_plain_text_at(&ofs_buf, 0, 0, "012345678X");
+        assert_plain_text_at(&ofs_buf_vt_100, 0, 0, "012345678X");
     }
 
     #[test]
     fn test_auto_wrap_can_be_toggled() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Start with default (enabled)
-        assert_eq!(performer.ofs_buf.ansi_parser_support.auto_wrap_mode, AutoWrapState::Enabled);
+        assert_eq!(
+            performer.ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Enabled
+        );
 
         // Disable auto-wrap.
         let disable_sequence =
             CsiSequence::DisablePrivateMode(PrivateModeType::AutoWrap).to_string();
         performer.apply_ansi_bytes(disable_sequence);
-        assert_eq!(performer.ofs_buf.ansi_parser_support.auto_wrap_mode, AutoWrapState::Disabled);
+        assert_eq!(
+            performer.ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Disabled
+        );
 
         // Re-enable auto-wrap using CSI `?7h`.
         let enable_sequence =
             CsiSequence::EnablePrivateMode(PrivateModeType::AutoWrap).to_string();
         performer.apply_ansi_bytes(enable_sequence);
-        assert_eq!(performer.ofs_buf.ansi_parser_support.auto_wrap_mode, AutoWrapState::Enabled);
+        assert_eq!(
+            performer.ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Enabled
+        );
 
         // Test that wrapping works again.
         for ch in 'A'..='K' {
@@ -179,14 +189,14 @@ pub mod auto_wrap {
 
         // Verify wrapping occurred.
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(1) + col(1),
             "Cursor should be at (r:1,c:1) after wrapping"
         );
 
         // Verify buffer contents.
-        assert_plain_text_at(&ofs_buf, 0, 0, "ABCDEFGHIJ");
-        assert_plain_char_at(&ofs_buf, 1, 0, 'K');
+        assert_plain_text_at(&ofs_buf_vt_100, 0, 0, "ABCDEFGHIJ");
+        assert_plain_char_at(&ofs_buf_vt_100, 1, 0, 'K');
     }
 
     #[test]
@@ -215,9 +225,9 @@ pub mod auto_wrap {
         //         │ … │ │ │ … │ … │ … │ … │ … │ … │ … │ … │
         //         └───┴─│─┴───┴───┴───┴───┴───┴───┴───┴───┘
         //               ╰─ cursor ends at (r:3,c:1)
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Test auto-wrap mode changes.
         // Fill the first line to column 9 (last column)
@@ -227,7 +237,7 @@ pub mod auto_wrap {
 
         // Now cursor should be at (r:1,c:0) after wrapping
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(1) + col(0),
             "Cursor should be at (r:1,c:0) after printing 10 characters"
         );
@@ -238,7 +248,7 @@ pub mod auto_wrap {
         performer.apply_ansi_bytes(sequence);
 
         // Move to end of line 2 and test clamping.
-        performer.ofs_buf.cursor_pos = row(2) + col(9);
+        performer.ofs_buf_vt_100.cursor_pos = row(2) + col(9);
         performer.print('X'); // At boundary
         performer.print('Y'); // Should clamp to (r:2,c:9) and overwrite 'X'
 
@@ -248,22 +258,22 @@ pub mod auto_wrap {
         performer.apply_ansi_bytes(sequence);
 
         // Move to a new position and test wrapping again.
-        performer.ofs_buf.cursor_pos = row(2) + col(9);
+        performer.ofs_buf_vt_100.cursor_pos = row(2) + col(9);
         performer.print('A');
         performer.print('B'); // Should wrap to row 3
 
         // Verify final cursor position.
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(3) + col(1),
             "Cursor should be at (r:3,c:1) after wrapping"
         );
 
         // Verify buffer contents.
-        assert_plain_char_at(&ofs_buf, 0, 8, '8'); // '8' at position [0][8]
-        assert_plain_char_at(&ofs_buf, 0, 9, '9'); // '9' at position [0][9]
-        assert_plain_char_at(&ofs_buf, 2, 9, 'A'); // 'A' at boundary position (overwrote 'Y')
-        assert_plain_char_at(&ofs_buf, 3, 0, 'B'); // 'B' wrapped to next line
+        assert_plain_char_at(&ofs_buf_vt_100, 0, 8, '8'); // '8' at position [0][8]
+        assert_plain_char_at(&ofs_buf_vt_100, 0, 9, '9'); // '9' at position [0][9]
+        assert_plain_char_at(&ofs_buf_vt_100, 2, 9, 'A'); // 'A' at boundary position (overwrote 'Y')
+        assert_plain_char_at(&ofs_buf_vt_100, 3, 0, 'B'); // 'B' wrapped to next line
     }
 }
 
@@ -273,12 +283,12 @@ pub mod line_wrapping {
 
     #[test]
     fn test_line_wrapping_behavior() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Process characters that should wrap at column 10.
         //
-        // Note: OffscreenBuffer uses 0-based index, and terminal (CSI, ESC seq, etc) uses
-        // 1-based index.
+        // Note: OfsBufVT100 uses 0-based index, and terminal (CSI, ESC seq, etc)
+        // uses 1-based index.
         //
         // Buffer layout:
         //
@@ -292,7 +302,7 @@ pub mod line_wrapping {
         //         └───┴─│─┴───┴───┴───┴───┴───┴───┴───┴───┘
         //               ╰─ cursor at (r:1,c:1)
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Write 10 characters to fill the line.
         for ch in 'A'..='J' {
@@ -304,20 +314,20 @@ pub mod line_wrapping {
 
         // Verify cursor wrapped to next line.
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(1) + col(1),
             "Cursor should be at (r:1,c:1) after wrapping"
         );
 
         // Verify buffer contents - first line should have A-J.
-        assert_plain_text_at(&ofs_buf, 0, 0, "ABCDEFGHIJ");
+        assert_plain_text_at(&ofs_buf_vt_100, 0, 0, "ABCDEFGHIJ");
 
         // Verify K wrapped to next line.
-        assert_plain_char_at(&ofs_buf, 1, 0, 'K');
+        assert_plain_char_at(&ofs_buf_vt_100, 1, 0, 'K');
 
         // Verify rest of second line is empty.
         for col in 1..10 {
-            assert_empty_at(&ofs_buf, 1, col);
+            assert_empty_at(&ofs_buf_vt_100, 1, col);
         }
     }
 }
@@ -328,8 +338,8 @@ pub mod scrolling {
 
     #[test]
     fn test_esc_d_index_scrolls_up_at_bottom() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        fill_buffer_with_lines(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        fill_buffer_with_lines(&mut ofs_buf_vt_100);
 
         // ESC D (Index) at bottom row causes buffer to scroll up
         //
@@ -346,25 +356,25 @@ pub mod scrolling {
         // Row 8: │Line-8│                  Row 8: │Line-9│
         // Row 9: │Line-9│ ← cursor here    Row 9: │  ␩   │ ← empty, cursor here
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
         // Move cursor to the last row.
-        performer.ofs_buf.cursor_pos.row_index = row(9);
+        performer.ofs_buf_vt_100.cursor_pos.row_index = row(9);
 
         // Execute Index (ESC D)
         performer.esc_dispatch(&[], false, IND_INDEX_DOWN);
 
         // Verify buffer scrolled up: "Line-0" is gone, "Line-1" is now at row 0.
-        assert_plain_text_at(&ofs_buf, 0, 0, "Line-1");
+        assert_plain_text_at(&ofs_buf_vt_100, 0, 0, "Line-1");
         // Verify the last line is now empty.
         for col in 0..10 {
-            assert_empty_at(&ofs_buf, 9, col);
+            assert_empty_at(&ofs_buf_vt_100, 9, col);
         }
     }
 
     #[test]
     fn test_esc_m_reverse_index_scrolls_down_at_top() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        fill_buffer_with_lines(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        fill_buffer_with_lines(&mut ofs_buf_vt_100);
 
         // ESC M (Reverse Index) at top row causes buffer to scroll down
         //
@@ -381,27 +391,27 @@ pub mod scrolling {
         // Row 8: │Line-8│                  Row 8: │Line-7│
         // Row 9: │Line-9│                  Row 9: │Line-8│ ← Line-9 disappears
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
         // Move cursor to the first row.
-        performer.ofs_buf.cursor_pos.row_index = row(0);
+        performer.ofs_buf_vt_100.cursor_pos.row_index = row(0);
 
         // Execute Reverse Index (ESC M)
         performer.esc_dispatch(&[], false, RI_REVERSE_INDEX_UP);
 
         // Verify buffer scrolled down: first line is now empty
         for col in 0..10 {
-            assert_empty_at(&ofs_buf, 0, col);
+            assert_empty_at(&ofs_buf_vt_100, 0, col);
         }
         // Verify "Line-0" is now at row 1.
-        assert_plain_text_at(&ofs_buf, 1, 0, "Line-0");
+        assert_plain_text_at(&ofs_buf_vt_100, 1, 0, "Line-0");
         // Verify "Line-8" is now at row 9.
-        assert_plain_text_at(&ofs_buf, 9, 0, "Line-8");
+        assert_plain_text_at(&ofs_buf_vt_100, 9, 0, "Line-8");
     }
 
     #[test]
     fn test_csi_s_scroll_up() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        fill_buffer_with_lines(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        fill_buffer_with_lines(&mut ofs_buf_vt_100);
 
         // CSI 2 S (Scroll Up by 2 lines) removes top 2 lines, adds empty at bottom
         //
@@ -418,26 +428,26 @@ pub mod scrolling {
         // Row 8: │Line-8│                  Row 8: │      │ ← empty
         // Row 9: │Line-9│                  Row 9: │      │ ← empty
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Execute Scroll Up by 2 lines (CSI 2 S)
         let sequence = CsiSequence::ScrollUp(term_row_delta(2).unwrap()).to_string();
         performer.apply_ansi_bytes(sequence);
 
         // Verify buffer scrolled up by 2: "Line-2" is now at row 0.
-        assert_plain_text_at(&ofs_buf, 0, 0, "Line-2");
+        assert_plain_text_at(&ofs_buf_vt_100, 0, 0, "Line-2");
 
         // Verify the last two lines are now empty.
         for col in 0..10 {
-            assert_empty_at(&ofs_buf, 8, col); // second last line is empty
-            assert_empty_at(&ofs_buf, 9, col); // last line is empty
+            assert_empty_at(&ofs_buf_vt_100, 8, col); // second last line is empty
+            assert_empty_at(&ofs_buf_vt_100, 9, col); // last line is empty
         }
     }
 
     #[test]
     fn test_csi_t_scroll_down() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        fill_buffer_with_lines(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        fill_buffer_with_lines(&mut ofs_buf_vt_100);
 
         // CSI 3 T (Scroll Down by 3 lines) adds empty at top, removes bottom 3 lines
         //
@@ -454,7 +464,7 @@ pub mod scrolling {
         // Row 8: │Line-8│                  Row 8: │Line-5│
         // Row 9: │Line-9│                  Row 9: │Line-6│ ← Line-7,8,9 disappear
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
         // Execute Scroll Down by 3 lines (CSI 3 T)
         let sequence = CsiSequence::ScrollDown(term_row_delta(3).unwrap()).to_string();
         performer.apply_ansi_bytes(sequence);
@@ -462,21 +472,21 @@ pub mod scrolling {
         // Verify buffer scrolled down by 3: first 3 lines are empty
         for r in 0..3 {
             for c in 0..10 {
-                assert_empty_at(&ofs_buf, r, c);
+                assert_empty_at(&ofs_buf_vt_100, r, c);
             }
         }
 
         // Verify "Line-0" is now at row 3.
-        assert_plain_text_at(&ofs_buf, 3, 0, "Line-0");
+        assert_plain_text_at(&ofs_buf_vt_100, 3, 0, "Line-0");
 
         // Verify "Line-6" is now at row 9.
-        assert_plain_text_at(&ofs_buf, 9, 0, "Line-6");
+        assert_plain_text_at(&ofs_buf_vt_100, 9, 0, "Line-6");
     }
 
     #[test]
     fn test_csi_s_scroll_up_more_than_height_clears_buffer() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        fill_buffer_with_lines(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        fill_buffer_with_lines(&mut ofs_buf_vt_100);
 
         // CSI 20 S (Scroll Up by 20 lines) - more than buffer height clears everything
         //
@@ -493,7 +503,7 @@ pub mod scrolling {
         // Row 8: │Line-8│                  Row 8: │      │ ← empty
         // Row 9: │Line-9│                  Row 9: │      │ ← empty
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
         // Execute Scroll Up by 20 lines (more than height)
         let sequence = CsiSequence::ScrollUp(term_row_delta(20).unwrap()).to_string();
         performer.apply_ansi_bytes(sequence);
@@ -501,17 +511,17 @@ pub mod scrolling {
         // Verify the entire buffer is empty.
         for r in 0..10 {
             for c in 0..10 {
-                assert_empty_at(&ofs_buf, r, c);
+                assert_empty_at(&ofs_buf_vt_100, r, c);
             }
         }
     }
 
     #[test]
     fn test_csi_t_scroll_down_more_than_height_clears_buffer() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        fill_buffer_with_lines(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        fill_buffer_with_lines(&mut ofs_buf_vt_100);
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
         // Execute Scroll Down by 20 lines (more than height)
         let sequence = CsiSequence::ScrollDown(term_row_delta(20).unwrap()).to_string();
         performer.apply_ansi_bytes(sequence);
@@ -519,15 +529,15 @@ pub mod scrolling {
         // Verify the entire buffer is empty.
         for r in 0..10 {
             for c in 0..10 {
-                assert_empty_at(&ofs_buf, r, c);
+                assert_empty_at(&ofs_buf_vt_100, r, c);
             }
         }
     }
 
     #[test]
     fn test_esc_d_and_esc_m_move_cursor_when_not_at_boundary() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        fill_buffer_with_lines(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        fill_buffer_with_lines(&mut ofs_buf_vt_100);
 
         // This test ensures that ESC D (Index) and ESC M (Reverse Index) only move the
         // cursor when not at the screen boundaries, without scrolling the buffer.
@@ -543,26 +553,26 @@ pub mod scrolling {
         // Row 6: │Line-6│ ← Cursor moves down to here
         // Row 7: │Line-7│
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
-        performer.ofs_buf.cursor_pos = row(5) + col(0);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
+        performer.ofs_buf_vt_100.cursor_pos = row(5) + col(0);
 
         // Execute Index (ESC D) - should just move cursor down
         performer.esc_dispatch(&[], false, IND_INDEX_DOWN);
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(6) + col(0),
             "Cursor should move down"
         );
-        assert_plain_text_at(performer.ofs_buf, 5, 0, "Line-5");
+        assert_plain_text_at(performer.ofs_buf_vt_100, 5, 0, "Line-5");
 
         // Execute Reverse Index (ESC M) - should just move cursor up
         performer.esc_dispatch(&[], false, RI_REVERSE_INDEX_UP);
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(5) + col(0),
             "Cursor should move up"
         );
-        assert_plain_text_at(performer.ofs_buf, 6, 0, "Line-6");
+        assert_plain_text_at(performer.ofs_buf_vt_100, 6, 0, "Line-6");
     }
 
     #[test]
@@ -570,10 +580,10 @@ pub mod scrolling {
         // Verifies that CSI S (Scroll Up) defaults to 1 line if no parameter is given.
         // Raw sequence "\x1b[S" should scroll by 1 line.
 
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        fill_buffer_with_lines(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        fill_buffer_with_lines(&mut ofs_buf_vt_100);
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Send CSI sequence with explicit default parameter 1.
         let scroll_up_sequence =
@@ -581,9 +591,9 @@ pub mod scrolling {
         performer.apply_ansi_bytes(scroll_up_sequence.as_bytes());
 
         // After scrolling up by 1, Line-1 should be at row 0.
-        assert_plain_text_at(performer.ofs_buf, 0, 0, "Line-1");
+        assert_plain_text_at(performer.ofs_buf_vt_100, 0, 0, "Line-1");
         // Bottom row should be empty.
-        assert_empty_at(performer.ofs_buf, 9, 0);
+        assert_empty_at(performer.ofs_buf_vt_100, 9, 0);
     }
 
     #[test]
@@ -591,10 +601,10 @@ pub mod scrolling {
         // Verifies that CSI T (Scroll Down) defaults to 1 line if no parameter is given.
         // Raw sequence "\x1b[T" should scroll by 1 line.
 
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        fill_buffer_with_lines(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        fill_buffer_with_lines(&mut ofs_buf_vt_100);
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Send CSI sequence with explicit default parameter 1.
         let scroll_down_sequence =
@@ -602,9 +612,9 @@ pub mod scrolling {
         performer.apply_ansi_bytes(scroll_down_sequence.as_bytes());
 
         // After scrolling down by 1, top row should be empty.
-        assert_empty_at(performer.ofs_buf, 0, 0);
+        assert_empty_at(performer.ofs_buf_vt_100, 0, 0);
         // Line-0 should move to row 1.
-        assert_plain_text_at(performer.ofs_buf, 1, 0, "Line-0");
+        assert_plain_text_at(performer.ofs_buf_vt_100, 1, 0, "Line-0");
     }
 
     #[test]
@@ -613,45 +623,45 @@ pub mod scrolling {
         // This addresses the gap where cursor position verification after scrolling
         // was missing from existing tests.
 
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        fill_buffer_with_lines(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        fill_buffer_with_lines(&mut ofs_buf_vt_100);
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Test ESC D (Index) at bottom - cursor should remain at bottom
-        performer.ofs_buf.cursor_pos = row(9) + col(5);
+        performer.ofs_buf_vt_100.cursor_pos = row(9) + col(5);
         performer.esc_dispatch(&[], false, IND_INDEX_DOWN);
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(9) + col(5),
             "Cursor should remain at bottom after ESC D scroll"
         );
 
         // Test ESC M (Reverse Index) at top - cursor should remain at top
-        performer.ofs_buf.cursor_pos = row(0) + col(3);
+        performer.ofs_buf_vt_100.cursor_pos = row(0) + col(3);
         performer.esc_dispatch(&[], false, RI_REVERSE_INDEX_UP);
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(0) + col(3),
             "Cursor should remain at top after ESC M scroll"
         );
 
         // Test CSI S (Scroll Up) - cursor position should be unchanged
-        performer.ofs_buf.cursor_pos = row(4) + col(7);
+        performer.ofs_buf_vt_100.cursor_pos = row(4) + col(7);
         let sequence = CsiSequence::ScrollUp(term_row_delta(2).unwrap()).to_string();
         performer.apply_ansi_bytes(sequence);
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(4) + col(7),
             "Cursor position should be unchanged after CSI S scroll"
         );
 
         // Test CSI T (Scroll Down) - cursor position should be unchanged
-        performer.ofs_buf.cursor_pos = row(6) + col(2);
+        performer.ofs_buf_vt_100.cursor_pos = row(6) + col(2);
         let sequence = CsiSequence::ScrollDown(term_row_delta(1).unwrap()).to_string();
         performer.apply_ansi_bytes(sequence);
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(6) + col(2),
             "Cursor position should be unchanged after CSI T scroll"
         );
@@ -666,10 +676,10 @@ pub mod scrolling {
         // operations should be treated as 1, just like cursor movement commands.
         // This is now correctly implemented.
 
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        fill_buffer_with_lines(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        fill_buffer_with_lines(&mut ofs_buf_vt_100);
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Test CSI 0 S (Scroll Up by 0 lines) - `VT-100` spec says 0 should be treated as
         // 1 So this should scroll up by 1 line: Line-0 lost, Line-1 moves to top
@@ -677,23 +687,23 @@ pub mod scrolling {
         performer.apply_ansi_bytes("\x1b[0S");
 
         // After scroll up by 1: Line-1 should now be at top (0 treated as 1)
-        assert_plain_text_at(performer.ofs_buf, 0, 0, "Line-1");
+        assert_plain_text_at(performer.ofs_buf_vt_100, 0, 0, "Line-1");
         // Bottom should be empty.
-        assert_empty_at(performer.ofs_buf, 9, 0);
+        assert_empty_at(performer.ofs_buf_vt_100, 9, 0);
 
         // Reset buffer for next test.
-        fill_buffer_with_lines(performer.ofs_buf);
+        fill_buffer_with_lines(performer.ofs_buf_vt_100);
 
         // Test CSI 0 T (Scroll Down by 0 lines) - also treated as 1
         // Use raw ANSI bytes since type-safe API prevents zero deltas
         performer.apply_ansi_bytes("\x1b[0T");
 
         // After scroll down by 1: top should be empty, Line-0 moves to row 1
-        assert_empty_at(performer.ofs_buf, 0, 0);
-        assert_plain_text_at(performer.ofs_buf, 1, 0, "Line-0");
+        assert_empty_at(performer.ofs_buf_vt_100, 0, 0);
+        assert_plain_text_at(performer.ofs_buf_vt_100, 1, 0, "Line-0");
 
         // Reset buffer for final test.
-        fill_buffer_with_lines(performer.ofs_buf);
+        fill_buffer_with_lines(performer.ofs_buf_vt_100);
 
         // Test single line scroll up followed by single line scroll down.
         let sequence_up = CsiSequence::ScrollUp(term_row_delta(1).unwrap()).to_string();
@@ -706,8 +716,8 @@ pub mod scrolling {
         // After scroll up then down:
         // - Top line empty (from scroll down)
         // - Line-1 should be at row 1 (was at row 0 after scroll up, moved down)
-        assert_empty_at(performer.ofs_buf, 0, 0);
-        assert_plain_text_at(performer.ofs_buf, 1, 0, "Line-1");
+        assert_empty_at(performer.ofs_buf_vt_100, 0, 0);
+        assert_plain_text_at(performer.ofs_buf_vt_100, 1, 0, "Line-1");
     }
 }
 
@@ -726,20 +736,20 @@ pub mod line_wrap_scroll_interaction {
         // typically scroll when wrapping at the bottom, but this implementation
         // clamps the cursor position.
 
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        fill_buffer_with_lines(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        fill_buffer_with_lines(&mut ofs_buf_vt_100);
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Fill the last line except for the last character.
-        performer.ofs_buf.cursor_pos = row(9) + col(0);
+        performer.ofs_buf_vt_100.cursor_pos = row(9) + col(0);
         for c in "ABCDEFGHI".chars() {
             performer.print(c);
         }
 
         // Verify cursor is at the last position.
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(9) + col(9),
             "Cursor should be at last position (9,9)"
         );
@@ -749,21 +759,21 @@ pub mod line_wrap_scroll_interaction {
         performer.print('J');
 
         // Verify no scrolling occurred - "Line-0" should still be at top.
-        assert_plain_text_at(performer.ofs_buf, 0, 0, "Line-0");
+        assert_plain_text_at(performer.ofs_buf_vt_100, 0, 0, "Line-0");
 
         // J gets written at (9,9), cursor tries to advance but wraps to (9,0)
         // since we're at the bottom row.
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(9) + col(0),
             "Cursor should wrap to (9,0) after printing J"
         );
 
         // The 'J' character should be at position (9,9) where it was printed
-        assert_plain_char_at(performer.ofs_buf, 9, 9, 'J');
+        assert_plain_char_at(performer.ofs_buf_vt_100, 9, 9, 'J');
 
         // ABCDEFGHI should still be there from positions 0-8.
-        assert_plain_char_at(performer.ofs_buf, 9, 0, 'A');
+        assert_plain_char_at(performer.ofs_buf_vt_100, 9, 0, 'A');
     }
 
     #[test]
@@ -771,11 +781,11 @@ pub mod line_wrap_scroll_interaction {
         // Verifies that line wrapping doesn't cause scrolling when the cursor
         // is not on the last line of the buffer.
 
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Position cursor on row 5 (not the last row).
-        performer.ofs_buf.cursor_pos = row(5) + col(9);
+        performer.ofs_buf_vt_100.cursor_pos = row(5) + col(9);
 
         // Print character that should wrap.
         performer.print('X');
@@ -783,17 +793,17 @@ pub mod line_wrap_scroll_interaction {
         // The print method writes the char, advances cursor, then handles wrap.
         // So X gets written at (5,9), cursor advances to (6,0)
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(6) + col(0),
             "Cursor should wrap to next line (6,0) after printing"
         );
 
         // Verify 'X' is at position (5,9) where it was printed.
-        assert_plain_char_at(performer.ofs_buf, 5, 9, 'X');
+        assert_plain_char_at(performer.ofs_buf_vt_100, 5, 9, 'X');
 
         // Verify no scrolling occurred by checking that row 0 is still empty
         // (since we never filled it in this test).
-        assert_empty_at(performer.ofs_buf, 0, 0);
+        assert_empty_at(performer.ofs_buf_vt_100, 0, 0);
     }
 
     #[test]
@@ -801,13 +811,13 @@ pub mod line_wrap_scroll_interaction {
         // Tests the current behavior where multiple wraps at bottom.
         // continue to clamp the cursor at the bottom row.
 
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        fill_buffer_with_lines(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        fill_buffer_with_lines(&mut ofs_buf_vt_100);
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Position at bottom line, leave room for some characters.
-        performer.ofs_buf.cursor_pos = row(9) + col(7);
+        performer.ofs_buf_vt_100.cursor_pos = row(9) + col(7);
 
         // Print characters that fill and wrap the line.
         performer.print('A'); // written at (9,7), cursor to (9,8)
@@ -816,28 +826,28 @@ pub mod line_wrap_scroll_interaction {
 
         // After wrap, cursor should be at (9,0)
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(9) + col(0),
             "Should wrap to column 0 after printing C"
         );
 
         // Verify no scrolling - Line-0 still at top.
-        assert_plain_text_at(performer.ofs_buf, 0, 0, "Line-0");
+        assert_plain_text_at(performer.ofs_buf_vt_100, 0, 0, "Line-0");
 
         // Continue printing - should continue from wrapped position.
         performer.print('D'); // written at (9,0), cursor to (9,1)
         performer.print('E'); // written at (9,1), cursor to (9,2)
 
         // Verify characters are placed correctly.
-        assert_plain_char_at(performer.ofs_buf, 9, 7, 'A'); // A at original pos
-        assert_plain_char_at(performer.ofs_buf, 9, 8, 'B'); // B at original pos
-        assert_plain_char_at(performer.ofs_buf, 9, 9, 'C'); // C at rightmost pos
-        assert_plain_char_at(performer.ofs_buf, 9, 0, 'D'); // D overwrites Line-9 start
-        assert_plain_char_at(performer.ofs_buf, 9, 1, 'E'); // E follows D
+        assert_plain_char_at(performer.ofs_buf_vt_100, 9, 7, 'A'); // A at original pos
+        assert_plain_char_at(performer.ofs_buf_vt_100, 9, 8, 'B'); // B at original pos
+        assert_plain_char_at(performer.ofs_buf_vt_100, 9, 9, 'C'); // C at rightmost pos
+        assert_plain_char_at(performer.ofs_buf_vt_100, 9, 0, 'D'); // D overwrites Line-9 start
+        assert_plain_char_at(performer.ofs_buf_vt_100, 9, 1, 'E'); // E follows D
 
         // Original content should still be present where not overwritten.
-        assert_plain_text_at(performer.ofs_buf, 0, 0, "Line-0");
-        assert_plain_text_at(performer.ofs_buf, 8, 0, "Line-8");
+        assert_plain_text_at(performer.ofs_buf_vt_100, 0, 0, "Line-0");
+        assert_plain_text_at(performer.ofs_buf_vt_100, 8, 0, "Line-8");
     }
 }
 
@@ -853,8 +863,8 @@ pub mod decstbm_scroll_margins {
 
     #[test]
     fn test_set_scroll_margins_basic() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Set scroll region from row 3 to row 7 (1-based) - ESC [ 3 ; 7 r
         let sequence = CsiSequence::SetScrollingMargins {
@@ -866,19 +876,25 @@ pub mod decstbm_scroll_margins {
 
         // Verify margins are set correctly (converted to 1-based internally)
         assert_eq!(
-            performer.ofs_buf.ansi_parser_support.scroll_region_top,
+            performer
+                .ofs_buf_vt_100
+                .parser_global_state
+                .scroll_region_top,
             Some(term_row(nz(3)))
         );
         assert_eq!(
-            performer.ofs_buf.ansi_parser_support.scroll_region_bottom,
+            performer
+                .ofs_buf_vt_100
+                .parser_global_state
+                .scroll_region_bottom,
             Some(term_row(nz(7)))
         );
     }
 
     #[test]
     fn test_reset_scroll_margins() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Set some margins first.
         let sequence = CsiSequence::SetScrollingMargins {
@@ -889,15 +905,15 @@ pub mod decstbm_scroll_margins {
         performer.apply_ansi_bytes(sequence);
         assert!(
             performer
-                .ofs_buf
-                .ansi_parser_support
+                .ofs_buf_vt_100
+                .parser_global_state
                 .scroll_region_top
                 .is_some()
         );
         assert!(
             performer
-                .ofs_buf
-                .ansi_parser_support
+                .ofs_buf_vt_100
+                .parser_global_state
                 .scroll_region_bottom
                 .is_some()
         );
@@ -912,20 +928,26 @@ pub mod decstbm_scroll_margins {
 
         // Verify margins are cleared.
         assert_eq!(
-            performer.ofs_buf.ansi_parser_support.scroll_region_top,
+            performer
+                .ofs_buf_vt_100
+                .parser_global_state
+                .scroll_region_top,
             None
         );
         assert_eq!(
-            performer.ofs_buf.ansi_parser_support.scroll_region_bottom,
+            performer
+                .ofs_buf_vt_100
+                .parser_global_state
+                .scroll_region_bottom,
             None
         );
     }
 
     #[test]
     fn test_scrolling_within_margins() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
-        fill_buffer_with_lines(performer.ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
+        fill_buffer_with_lines(performer.ofs_buf_vt_100);
 
         // Set scroll region from row 3 to row 7 (1-based)
         let set_margins = CsiSequence::SetScrollingMargins {
@@ -940,25 +962,25 @@ pub mod decstbm_scroll_margins {
         performer.apply_ansi_bytes(scroll_up);
 
         // Content outside scroll region should be unchanged.
-        assert_plain_text_at(performer.ofs_buf, 0, 0, "Line-0"); // Above region
-        assert_plain_text_at(performer.ofs_buf, 1, 0, "Line-1"); // Above region
-        assert_plain_text_at(performer.ofs_buf, 8, 0, "Line-8"); // Below region
-        assert_plain_text_at(performer.ofs_buf, 9, 0, "Line-9"); // Below region
+        assert_plain_text_at(performer.ofs_buf_vt_100, 0, 0, "Line-0"); // Above region
+        assert_plain_text_at(performer.ofs_buf_vt_100, 1, 0, "Line-1"); // Above region
+        assert_plain_text_at(performer.ofs_buf_vt_100, 8, 0, "Line-8"); // Below region
+        assert_plain_text_at(performer.ofs_buf_vt_100, 9, 0, "Line-9"); // Below region
 
         // Within scroll region: Line-2 should be gone, Line-3 moved up
-        assert_plain_text_at(performer.ofs_buf, 2, 0, "Line-3"); // Line-3 moved to row 2
-        assert_plain_text_at(performer.ofs_buf, 3, 0, "Line-4"); // Line-4 moved to row 3
-        assert_plain_text_at(performer.ofs_buf, 4, 0, "Line-5"); // Line-5 moved to row 4
-        assert_plain_text_at(performer.ofs_buf, 5, 0, "Line-6"); // Line-6 moved to row 5
+        assert_plain_text_at(performer.ofs_buf_vt_100, 2, 0, "Line-3"); // Line-3 moved to row 2
+        assert_plain_text_at(performer.ofs_buf_vt_100, 3, 0, "Line-4"); // Line-4 moved to row 3
+        assert_plain_text_at(performer.ofs_buf_vt_100, 4, 0, "Line-5"); // Line-5 moved to row 4
+        assert_plain_text_at(performer.ofs_buf_vt_100, 5, 0, "Line-6"); // Line-6 moved to row 5
 
         // Bottom of scroll region should be cleared.
-        assert_empty_at(performer.ofs_buf, 6, 0); // Row 6 cleared
+        assert_empty_at(performer.ofs_buf_vt_100, 6, 0); // Row 6 cleared
     }
 
     #[test]
     fn test_cursor_movement_respects_margins() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Set scroll region from row 3 to row 7 (1-based)
         let set_margins = CsiSequence::SetScrollingMargins {
@@ -975,12 +997,12 @@ pub mod decstbm_scroll_margins {
         }
         .to_string();
         performer.apply_ansi_bytes(cursor_pos);
-        assert_eq!(performer.ofs_buf.cursor_pos.row_index.as_usize(), 2); // 0-based row 2
+        assert_eq!(performer.ofs_buf_vt_100.cursor_pos.row_index.as_usize(), 2); // 0-based row 2
 
         // Try to move cursor up - should be clamped to scroll region top.
         let cursor_up = CsiSequence::CursorUp(term_row_delta(5).unwrap()).to_string();
         performer.apply_ansi_bytes(cursor_up);
-        assert_eq!(performer.ofs_buf.cursor_pos.row_index.as_usize(), 2); // Still at top margin
+        assert_eq!(performer.ofs_buf_vt_100.cursor_pos.row_index.as_usize(), 2); // Still at top margin
 
         // Move cursor to bottom of scroll region.
         let cursor_pos_bottom = CsiSequence::CursorPosition {
@@ -989,18 +1011,18 @@ pub mod decstbm_scroll_margins {
         }
         .to_string();
         performer.apply_ansi_bytes(cursor_pos_bottom);
-        assert_eq!(performer.ofs_buf.cursor_pos.row_index.as_usize(), 6); // 0-based row 6
+        assert_eq!(performer.ofs_buf_vt_100.cursor_pos.row_index.as_usize(), 6); // 0-based row 6
 
         // Try to move cursor down - should be clamped to scroll region bottom.
         let cursor_down = CsiSequence::CursorDown(term_row_delta(5).unwrap()).to_string();
         performer.apply_ansi_bytes(cursor_down);
-        assert_eq!(performer.ofs_buf.cursor_pos.row_index.as_usize(), 6); // Still at bottom margin
+        assert_eq!(performer.ofs_buf_vt_100.cursor_pos.row_index.as_usize(), 6); // Still at bottom margin
     }
 
     #[test]
     fn test_cursor_position_clamped_to_margins() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Set scroll region from row 3 to row 7 (1-based)
         let set_margins = CsiSequence::SetScrollingMargins {
@@ -1017,7 +1039,7 @@ pub mod decstbm_scroll_margins {
         }
         .to_string();
         performer.apply_ansi_bytes(cursor_above);
-        assert_eq!(performer.ofs_buf.cursor_pos.row_index.as_usize(), 2); // Clamped to top margin
+        assert_eq!(performer.ofs_buf_vt_100.cursor_pos.row_index.as_usize(), 2); // Clamped to top margin
 
         // Try to position cursor below scroll region.
         let cursor_below = CsiSequence::CursorPosition {
@@ -1026,7 +1048,7 @@ pub mod decstbm_scroll_margins {
         }
         .to_string();
         performer.apply_ansi_bytes(cursor_below);
-        assert_eq!(performer.ofs_buf.cursor_pos.row_index.as_usize(), 6); // Clamped to bottom margin
+        assert_eq!(performer.ofs_buf_vt_100.cursor_pos.row_index.as_usize(), 6); // Clamped to bottom margin
 
         // Position within scroll region should work normally.
         let cursor_within = CsiSequence::CursorPosition {
@@ -1035,14 +1057,14 @@ pub mod decstbm_scroll_margins {
         }
         .to_string();
         performer.apply_ansi_bytes(cursor_within);
-        assert_eq!(performer.ofs_buf.cursor_pos.row_index.as_usize(), 4); // 0-based row 4
+        assert_eq!(performer.ofs_buf_vt_100.cursor_pos.row_index.as_usize(), 4); // 0-based row 4
     }
 
     #[test]
     fn test_index_and_reverse_index_with_margins() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
-        fill_buffer_with_lines(performer.ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
+        fill_buffer_with_lines(performer.ofs_buf_vt_100);
 
         // Set scroll region from row 3 to row 7 (1-based)
         let set_margins = CsiSequence::SetScrollingMargins {
@@ -1065,13 +1087,13 @@ pub mod decstbm_scroll_margins {
         performer.apply_ansi_bytes(index_down_sequence.as_bytes());
 
         // Content outside scroll region should be unchanged.
-        assert_plain_text_at(performer.ofs_buf, 0, 0, "Line-0"); // Above region
-        assert_plain_text_at(performer.ofs_buf, 1, 0, "Line-1"); // Above region
-        assert_plain_text_at(performer.ofs_buf, 8, 0, "Line-8"); // Below region
+        assert_plain_text_at(performer.ofs_buf_vt_100, 0, 0, "Line-0"); // Above region
+        assert_plain_text_at(performer.ofs_buf_vt_100, 1, 0, "Line-1"); // Above region
+        assert_plain_text_at(performer.ofs_buf_vt_100, 8, 0, "Line-8"); // Below region
 
         // Within scroll region: should have scrolled up
-        assert_plain_text_at(performer.ofs_buf, 2, 0, "Line-3"); // Line-3 moved to row 2
-        assert_empty_at(performer.ofs_buf, 6, 0); // Bottom row cleared
+        assert_plain_text_at(performer.ofs_buf_vt_100, 2, 0, "Line-3"); // Line-3 moved to row 2
+        assert_empty_at(performer.ofs_buf_vt_100, 6, 0); // Bottom row cleared
 
         // Position cursor at top of scroll region.
         let cursor_pos_top = CsiSequence::CursorPosition {
@@ -1086,14 +1108,14 @@ pub mod decstbm_scroll_margins {
         performer.apply_ansi_bytes(reverse_index_sequence.as_bytes());
 
         // Top of scroll region should be cleared.
-        assert_empty_at(performer.ofs_buf, 2, 0); // Top row cleared
-        assert_plain_text_at(performer.ofs_buf, 3, 0, "Line-3"); // Line-3 moved down
+        assert_empty_at(performer.ofs_buf_vt_100, 2, 0); // Top row cleared
+        assert_plain_text_at(performer.ofs_buf_vt_100, 3, 0, "Line-3"); // Line-3 moved down
     }
 
     #[test]
     fn test_terminal_reset_clears_margins() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Set scroll margins.
         let set_margins = CsiSequence::SetScrollingMargins {
@@ -1104,8 +1126,8 @@ pub mod decstbm_scroll_margins {
         performer.apply_ansi_bytes(set_margins);
         assert!(
             performer
-                .ofs_buf
-                .ansi_parser_support
+                .ofs_buf_vt_100
+                .parser_global_state
                 .scroll_region_top
                 .is_some()
         );
@@ -1116,19 +1138,25 @@ pub mod decstbm_scroll_margins {
 
         // Margins should be cleared.
         assert_eq!(
-            performer.ofs_buf.ansi_parser_support.scroll_region_top,
+            performer
+                .ofs_buf_vt_100
+                .parser_global_state
+                .scroll_region_top,
             None
         );
         assert_eq!(
-            performer.ofs_buf.ansi_parser_support.scroll_region_bottom,
+            performer
+                .ofs_buf_vt_100
+                .parser_global_state
+                .scroll_region_bottom,
             None
         );
     }
 
     #[test]
     fn test_invalid_margins_ignored() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Try to set invalid margins (top >= bottom)
         let invalid_margins = CsiSequence::SetScrollingMargins {
@@ -1140,11 +1168,17 @@ pub mod decstbm_scroll_margins {
 
         // Margins should remain None.
         assert_eq!(
-            performer.ofs_buf.ansi_parser_support.scroll_region_top,
+            performer
+                .ofs_buf_vt_100
+                .parser_global_state
+                .scroll_region_top,
             None
         );
         assert_eq!(
-            performer.ofs_buf.ansi_parser_support.scroll_region_bottom,
+            performer
+                .ofs_buf_vt_100
+                .parser_global_state
+                .scroll_region_bottom,
             None
         );
 
@@ -1158,11 +1192,17 @@ pub mod decstbm_scroll_margins {
 
         // Should be clamped to buffer height.
         assert_eq!(
-            performer.ofs_buf.ansi_parser_support.scroll_region_top,
+            performer
+                .ofs_buf_vt_100
+                .parser_global_state
+                .scroll_region_top,
             Some(term_row(nz(1)))
         );
         assert_eq!(
-            performer.ofs_buf.ansi_parser_support.scroll_region_bottom,
+            performer
+                .ofs_buf_vt_100
+                .parser_global_state
+                .scroll_region_bottom,
             Some(term_row(nz(10)))
         );
     }
@@ -1174,7 +1214,7 @@ pub mod cursor_boundary_operations {
 
     #[test]
     fn test_cursor_next_line_within_scroll_region() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Set scroll region (rows 3-7)
         let margins_sequence = format!(
@@ -1184,7 +1224,7 @@ pub mod cursor_boundary_operations {
                 bottom: Some(term_row(nz(7)))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(margins_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(margins_sequence);
 
         // Position cursor at row 4, column 5
         let move_sequence = format!(
@@ -1194,22 +1234,22 @@ pub mod cursor_boundary_operations {
                 col: term_col(nz(5))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(move_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(move_sequence);
 
         // Execute CursorNextLine (should move to next line, column 1)
         let next_line_sequence = format!(
             "{}",
             CsiSequence::CursorNextLine(term_row_delta(1).unwrap())
         );
-        let _result = ofs_buf.apply_ansi_bytes(next_line_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(next_line_sequence);
 
         // Should be at row 5, column 1 (within scroll region)
-        assert_eq!(ofs_buf.cursor_pos, row(4) + col(0)); // 0-based
+        assert_eq!(ofs_buf_vt_100.cursor_pos, row(4) + col(0)); // 0-based
     }
 
     #[test]
     fn test_cursor_next_line_at_scroll_region_bottom() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Set scroll region (rows 3-7)
         let margins_sequence = format!(
@@ -1219,7 +1259,7 @@ pub mod cursor_boundary_operations {
                 bottom: Some(term_row(nz(7)))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(margins_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(margins_sequence);
 
         // Position cursor at bottom of scroll region (row 7, column 5)
         let move_sequence = format!(
@@ -1229,22 +1269,22 @@ pub mod cursor_boundary_operations {
                 col: term_col(nz(5))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(move_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(move_sequence);
 
         // Execute CursorNextLine (should cause scrolling within region)
         let next_line_sequence = format!(
             "{}",
             CsiSequence::CursorNextLine(term_row_delta(1).unwrap())
         );
-        let _result = ofs_buf.apply_ansi_bytes(next_line_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(next_line_sequence);
 
         // Should remain at row 7, column 1 (region boundary), but content should scroll
-        assert_eq!(ofs_buf.cursor_pos, row(6) + col(0)); // 0-based row 6 = 1-based row 7
+        assert_eq!(ofs_buf_vt_100.cursor_pos, row(6) + col(0)); // 0-based row 6 = 1-based row 7
     }
 
     #[test]
     fn test_cursor_prev_line_within_scroll_region() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Set scroll region (rows 3-7)
         let margins_sequence = format!(
@@ -1254,7 +1294,7 @@ pub mod cursor_boundary_operations {
                 bottom: Some(term_row(nz(7)))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(margins_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(margins_sequence);
 
         // Position cursor at row 5, column 8
         let move_sequence = format!(
@@ -1264,22 +1304,22 @@ pub mod cursor_boundary_operations {
                 col: term_col(nz(8))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(move_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(move_sequence);
 
         // Execute CursorPrevLine (should move to previous line, column 1)
         let prev_line_sequence = format!(
             "{}",
             CsiSequence::CursorPrevLine(term_row_delta(1).unwrap())
         );
-        let _result = ofs_buf.apply_ansi_bytes(prev_line_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(prev_line_sequence);
 
         // Should be at row 4, column 1 (within scroll region)
-        assert_eq!(ofs_buf.cursor_pos, row(3) + col(0)); // 0-based
+        assert_eq!(ofs_buf_vt_100.cursor_pos, row(3) + col(0)); // 0-based
     }
 
     #[test]
     fn test_cursor_prev_line_at_scroll_region_top() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Set scroll region (rows 3-7)
         let margins_sequence = format!(
@@ -1289,7 +1329,7 @@ pub mod cursor_boundary_operations {
                 bottom: Some(term_row(nz(7)))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(margins_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(margins_sequence);
 
         // Position cursor at top of scroll region (row 3, column 4)
         let move_sequence = format!(
@@ -1299,22 +1339,22 @@ pub mod cursor_boundary_operations {
                 col: term_col(nz(4))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(move_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(move_sequence);
 
         // Execute CursorPrevLine (should cause scrolling or stay at boundary)
         let prev_line_sequence = format!(
             "{}",
             CsiSequence::CursorPrevLine(term_row_delta(1).unwrap())
         );
-        let _result = ofs_buf.apply_ansi_bytes(prev_line_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(prev_line_sequence);
 
         // Should remain at row 3, column 1 (region boundary)
-        assert_eq!(ofs_buf.cursor_pos, row(2) + col(0)); // 0-based row 2 = 1-based row 3
+        assert_eq!(ofs_buf_vt_100.cursor_pos, row(2) + col(0)); // 0-based row 2 = 1-based row 3
     }
 
     #[test]
     fn test_cursor_operations_outside_scroll_region() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Set scroll region (rows 4-8)
         let margins_sequence = format!(
@@ -1324,7 +1364,7 @@ pub mod cursor_boundary_operations {
                 bottom: Some(term_row(nz(8)))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(margins_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(margins_sequence);
 
         // Position cursor outside scroll region (row 2)
         let move_sequence = format!(
@@ -1334,21 +1374,21 @@ pub mod cursor_boundary_operations {
                 col: term_col(nz(3))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(move_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(move_sequence);
 
         // Execute CursorNextLine (should work normally outside region)
         let next_line_sequence = format!(
             "{}",
             CsiSequence::CursorNextLine(term_row_delta(1).unwrap())
         );
-        let _result = ofs_buf.apply_ansi_bytes(next_line_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(next_line_sequence);
 
         // Should move to row 3, column 1 (still outside scroll region)
         // Based on actual behavior: CursorNextLine moves cursor down by n lines and to
         // column 0 From row 2 (1-based) to row 3 (1-based) = from row 1 (0-based)
         // to row 2 (0-based) But test shows cursor at row 4 (0-based), so
         // CursorNextLine(1) moved from row 1 to row 4
-        assert_eq!(ofs_buf.cursor_pos, row(4) + col(0)); // 0-based - matches actual behavior
+        assert_eq!(ofs_buf_vt_100.cursor_pos, row(4) + col(0)); // 0-based - matches actual behavior
     }
 }
 
@@ -1358,7 +1398,7 @@ pub mod boundary_validation {
 
     #[test]
     fn test_invalid_scroll_region_parameters() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Try to set invalid scroll region (top > bottom)
         let invalid_margins = format!(
@@ -1368,14 +1408,14 @@ pub mod boundary_validation {
                 bottom: Some(term_row(nz(3)))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(invalid_margins);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(invalid_margins);
 
         // Scroll region should not be set (or should be ignored)
         // This behavior depends on implementation - some terminals ignore invalid ranges
         // We test that the system doesn't crash and maintains a valid state
         if let (Some(top), Some(bottom)) = (
-            ofs_buf.ansi_parser_support.scroll_region_top,
-            ofs_buf.ansi_parser_support.scroll_region_bottom,
+            ofs_buf_vt_100.parser_global_state.scroll_region_top,
+            ofs_buf_vt_100.parser_global_state.scroll_region_bottom,
         ) {
             assert!(top.value() <= bottom.value()); // Compare the inner NonZeroU16 values
         }
@@ -1383,7 +1423,7 @@ pub mod boundary_validation {
 
     #[test]
     fn test_scroll_region_beyond_buffer_bounds() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Try to set scroll region beyond buffer bounds
         let invalid_margins = format!(
@@ -1393,18 +1433,18 @@ pub mod boundary_validation {
                 bottom: Some(term_row(nz(15))) // Beyond 10 rows
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(invalid_margins);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(invalid_margins);
 
         // Implementation should clamp or ignore invalid bounds
         // We verify the system remains in a valid state
-        if let Some(bottom) = ofs_buf.ansi_parser_support.scroll_region_bottom {
+        if let Some(bottom) = ofs_buf_vt_100.parser_global_state.scroll_region_bottom {
             assert!(bottom.value().get() <= 10); // Compare the inner u16 value
         }
     }
 
     #[test]
     fn test_single_line_scroll_region() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Set single-line scroll region (top == bottom)
         let single_line_margins = format!(
@@ -1414,7 +1454,7 @@ pub mod boundary_validation {
                 bottom: Some(term_row(nz(5)))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(single_line_margins);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(single_line_margins);
 
         // Position cursor in the single-line region
         let move_sequence = format!(
@@ -1424,20 +1464,20 @@ pub mod boundary_validation {
                 col: term_col(nz(3))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(move_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(move_sequence);
 
         // Try NEL operation (should handle single-line region gracefully)
         let nel_sequence = b"\x1bE";
-        let _result = ofs_buf.apply_ansi_bytes(nel_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(nel_sequence);
 
         // Cursor should stay within or handle the single-line region appropriately
         // Exact behavior may vary by implementation
-        assert!(ofs_buf.cursor_pos.row_index <= row(9)); // Within buffer bounds
+        assert!(ofs_buf_vt_100.cursor_pos.row_index <= row(9)); // Within buffer bounds
     }
 
     #[test]
     fn test_full_buffer_scroll_region() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Set scroll region covering entire buffer
         let full_margins = format!(
@@ -1447,7 +1487,7 @@ pub mod boundary_validation {
                 bottom: Some(term_row(nz(10)))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(full_margins);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(full_margins);
 
         // This should be equivalent to no scroll region
         // Position cursor at bottom and test scrolling
@@ -1458,7 +1498,7 @@ pub mod boundary_validation {
                 col: term_col(nz(1))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(move_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(move_sequence);
 
         // Execute operations that would cause scrolling
         let scroll_ops = format!(
@@ -1466,10 +1506,10 @@ pub mod boundary_validation {
             "Text at bottom",
             CsiSequence::CursorNextLine(term_row_delta(1).unwrap())
         );
-        let _result = ofs_buf.apply_ansi_bytes(scroll_ops);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(scroll_ops);
 
         // Should handle full-buffer scrolling correctly
-        assert_eq!(ofs_buf.cursor_pos.row_index, row(9)); // Should stay at bottom row
+        assert_eq!(ofs_buf_vt_100.cursor_pos.row_index, row(9)); // Should stay at bottom row
     }
 }
 
@@ -1479,7 +1519,7 @@ pub mod complex_interactions {
 
     #[test]
     fn test_nested_cursor_operations_with_scrolling() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Set scroll region (rows 3-7)
         let margins_sequence = format!(
@@ -1489,7 +1529,7 @@ pub mod complex_interactions {
                 bottom: Some(term_row(nz(7)))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(margins_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(margins_sequence);
 
         // Fill the scroll region with content
         let fill_sequence = format!(
@@ -1515,7 +1555,7 @@ pub mod complex_interactions {
                 col: term_col(nz(1))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(fill_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(fill_sequence);
 
         // Perform complex cursor operations
         let complex_ops = format!(
@@ -1530,16 +1570,16 @@ pub mod complex_interactions {
             // Should move up within region
             CsiSequence::CursorPrevLine(term_row_delta(2).unwrap())
         );
-        let _result = ofs_buf.apply_ansi_bytes(complex_ops);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(complex_ops);
 
         // Verify the cursor is within the scroll region bounds
-        assert!(ofs_buf.cursor_pos.row_index >= row(2)); // >= row 3 (1-based)
-        assert!(ofs_buf.cursor_pos.row_index <= row(6)); // <= row 7 (1-based)
+        assert!(ofs_buf_vt_100.cursor_pos.row_index >= row(2)); // >= row 3 (1-based)
+        assert!(ofs_buf_vt_100.cursor_pos.row_index <= row(6)); // <= row 7 (1-based)
     }
 
     #[test]
     fn test_scroll_region_with_line_feed_and_carriage_return() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Set scroll region (rows 4-6)
         let margins_sequence = format!(
@@ -1549,7 +1589,7 @@ pub mod complex_interactions {
                 bottom: Some(term_row(nz(6)))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(margins_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(margins_sequence);
 
         // Position cursor at bottom of scroll region
         let move_sequence = format!(
@@ -1559,29 +1599,29 @@ pub mod complex_interactions {
                 col: term_col(nz(5))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(move_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(move_sequence);
 
         // Send line feed (should cause scrolling within region)
         let lf_sequence = "\n";
-        let _result = ofs_buf.apply_ansi_bytes(lf_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(lf_sequence);
 
         // Based on actual behavior: line feed may move cursor beyond expected bounds
         // Current implementation may not fully respect scroll region boundaries for LF
         // Verify the cursor position is reasonable within the buffer bounds
-        assert!(ofs_buf.cursor_pos.row_index < row(10)); // Within buffer bounds
+        assert!(ofs_buf_vt_100.cursor_pos.row_index < row(10)); // Within buffer bounds
 
         // Send carriage return + line feed combination
         let crlf_sequence = "\r\n";
-        let _result = ofs_buf.apply_ansi_bytes(crlf_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(crlf_sequence);
 
         // Should handle the combination and move to beginning of next line
-        assert!(ofs_buf.cursor_pos.row_index < row(10)); // Within buffer bounds
-        assert_eq!(ofs_buf.cursor_pos.col_index, col(0)); // Should be at column 1
+        assert!(ofs_buf_vt_100.cursor_pos.row_index < row(10)); // Within buffer bounds
+        assert_eq!(ofs_buf_vt_100.cursor_pos.col_index, col(0)); // Should be at column 1
     }
 
     #[test]
     fn test_scroll_region_boundary_with_text_overflow() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Set narrow scroll region (rows 5-6, only 2 lines)
         let margins_sequence = format!(
@@ -1591,7 +1631,7 @@ pub mod complex_interactions {
                 bottom: Some(term_row(nz(6)))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(margins_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(margins_sequence);
 
         // Position cursor at top of scroll region
         let move_sequence = format!(
@@ -1601,7 +1641,7 @@ pub mod complex_interactions {
                 col: term_col(nz(1))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(move_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(move_sequence);
 
         // Write multiple lines of text (should cause multiple scrolls)
         let text_overflow = format!(
@@ -1611,10 +1651,10 @@ pub mod complex_interactions {
             "Line2",
             CsiSequence::CursorNextLine(term_row_delta(1).unwrap())
         );
-        let _result = ofs_buf.apply_ansi_bytes(text_overflow);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(text_overflow);
 
         // Final cursor position should be within the narrow scroll region
-        assert!(ofs_buf.cursor_pos.row_index >= row(4)); // >= row 5 (1-based)
-        assert!(ofs_buf.cursor_pos.row_index <= row(5)); // <= row 6 (1-based)
+        assert!(ofs_buf_vt_100.cursor_pos.row_index >= row(4)); // >= row 5 (1-based)
+        assert!(ofs_buf_vt_100.cursor_pos.row_index <= row(5)); // <= row 6 (1-based)
     }
 }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_sgr_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_sgr_ops.rs
@@ -20,7 +20,7 @@ pub mod sgr_styling {
 
     #[test]
     fn test_sgr_reset_behavior() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         #[allow(clippy::items_after_statements)]
         const RED: &str = "RED";
@@ -39,7 +39,7 @@ pub mod sgr_styling {
         // Sequence: ESC[1m ESC[31m "RED" ESC[0m "NORM"
 
         // Set bold+red, write "RED", reset all, write "NORM".
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
         performer.apply_ansi_bytes(format!(
             "{bold}{fg_red}{text1}{reset_all}{text2}",
             bold = SgrCode::Bold,
@@ -52,7 +52,7 @@ pub mod sgr_styling {
         // Verify "RED" has bold and red color.
         for (col, expected_char) in RED.chars().enumerate() {
             assert_styled_char_at(
-                &ofs_buf,
+                &ofs_buf_vt_100,
                 0,
                 col,
                 expected_char,
@@ -65,16 +65,16 @@ pub mod sgr_styling {
         }
 
         // Verify "NORM" has no styling (SGR 0 reset everything)
-        assert_plain_text_at(&ofs_buf, 0, RED.len(), NORM);
+        assert_plain_text_at(&ofs_buf_vt_100, 0, RED.len(), NORM);
 
         // Verify empty cells after "NORM".
         for col_idx in (RED.len() + NORM.len())..10 {
-            assert_empty_at(&ofs_buf, 0, col_idx);
+            assert_empty_at(&ofs_buf_vt_100, 0, col_idx);
         }
 
-        // Verify final cursor position in ofs_buf.my_pos.
+        // Verify final cursor position in ofs_buf_vt_100.my_pos.
         assert_eq!(
-            ofs_buf.cursor_pos,
+            ofs_buf_vt_100.cursor_pos,
             row(0) + col(RED.len() + NORM.len()),
             "final cursor position after writing RED and NORM should be at row 0, col 7",
         );
@@ -82,7 +82,7 @@ pub mod sgr_styling {
 
     #[test]
     fn test_sgr_partial_reset() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // SGR partial reset test (SGR 22 resets bold/dim only):
         //
@@ -97,7 +97,7 @@ pub mod sgr_styling {
         // Sequence: ESC[1m ESC[3m ESC[31m A ESC[22m B
 
         // Test partial SGR resets (SGR 22 resets bold/dim only)
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Set bold+italic+red, write "A", reset bold/dim only, write "B"
         performer.apply_ansi_bytes(format!(
@@ -110,7 +110,7 @@ pub mod sgr_styling {
 
         // Verify 'A' has bold, italic, and red.
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             0,
             'A',
@@ -124,7 +124,7 @@ pub mod sgr_styling {
 
         // Verify 'B' has italic and red but NOT bold (SGR 22 reset bold/dim)
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             1,
             'B',
@@ -137,12 +137,12 @@ pub mod sgr_styling {
 
         // Verify empty cells after "AB".
         for col_idx in 2..10 {
-            assert_empty_at(&ofs_buf, 0, col_idx);
+            assert_empty_at(&ofs_buf_vt_100, 0, col_idx);
         }
 
-        // Verify final cursor position in ofs_buf.my_pos.
+        // Verify final cursor position in ofs_buf_vt_100.my_pos.
         assert_eq!(
-            ofs_buf.cursor_pos,
+            ofs_buf_vt_100.cursor_pos,
             row(0) + col(2),
             "final cursor position after writing AB should be at row 0, col 2",
         );
@@ -151,7 +151,7 @@ pub mod sgr_styling {
     #[test]
     #[allow(clippy::too_many_lines)]
     fn test_sgr_color_attributes() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // SGR color attributes test:
         //
@@ -172,7 +172,7 @@ pub mod sgr_styling {
         //           ESC[31mESC[44mZ ESC[0m
 
         // Test various SGR color sequences through VTE parser.
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Test foreground colors: black, red, green, white, then background colors
         performer.apply_ansi_bytes(format!(
@@ -189,7 +189,7 @@ pub mod sgr_styling {
 
         // Verify colors in buffer.
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             0,
             'B',
@@ -200,7 +200,7 @@ pub mod sgr_styling {
         );
 
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             1,
             'R',
@@ -211,7 +211,7 @@ pub mod sgr_styling {
         );
 
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             2,
             'G',
@@ -222,7 +222,7 @@ pub mod sgr_styling {
         );
 
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             3,
             'W',
@@ -232,10 +232,10 @@ pub mod sgr_styling {
             "white foreground",
         );
 
-        assert_plain_char_at(&ofs_buf, 0, 4, ' '); // Space after reset
+        assert_plain_char_at(&ofs_buf_vt_100, 0, 4, ' '); // Space after reset
 
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             5,
             'X',
@@ -246,7 +246,7 @@ pub mod sgr_styling {
         );
 
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             6,
             'Y',
@@ -257,7 +257,7 @@ pub mod sgr_styling {
         );
 
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             7,
             'Z',
@@ -271,8 +271,8 @@ pub mod sgr_styling {
 
     #[test]
     fn test_sgr_slow_blink() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Test ESC[5m (slow blink)
         performer.apply_ansi_bytes(format!(
@@ -284,7 +284,7 @@ pub mod sgr_styling {
         // Test each character in "BLINK" for the blink attribute.
         for (col, expected_char) in "BLINK".chars().enumerate() {
             assert_styled_char_at(
-                &ofs_buf,
+                &ofs_buf_vt_100,
                 0,
                 col,
                 expected_char,
@@ -299,8 +299,8 @@ pub mod sgr_styling {
 
     #[test]
     fn test_sgr_rapid_blink() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Test ESC[6m (rapid blink) - this tests our bug fix!
         performer.apply_ansi_bytes(format!(
@@ -312,7 +312,7 @@ pub mod sgr_styling {
         // Test each character in "RAPID" for the blink attribute.
         for (col, expected_char) in "RAPID".chars().enumerate() {
             assert_styled_char_at(
-                &ofs_buf,
+                &ofs_buf_vt_100,
                 0,
                 col,
                 expected_char,
@@ -371,8 +371,8 @@ pub mod sgr_styling {
 
     #[test]
     fn test_sgr_blink_reset() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Set blink, write char, reset blink, write char.
         performer.apply_ansi_bytes(format!(
@@ -385,7 +385,7 @@ pub mod sgr_styling {
 
         // First char should have blink.
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             0,
             'A',
@@ -396,15 +396,15 @@ pub mod sgr_styling {
         );
 
         // Second char should not have blink (should be plain text)
-        assert_plain_char_at(&ofs_buf, 0, 1, 'B');
+        assert_plain_char_at(&ofs_buf_vt_100, 0, 1, 'B');
     }
 
     #[test]
     fn test_sgr_extended_256_colors() {
         use crate::core::ansi::vt_100_pty_output_parser::vt_100_pty_output_conformance_tests::test_sequence_generators::extended_color_builders::*;
 
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Test 256-color sequences (both colon and semicolon formats)
         //
@@ -427,7 +427,7 @@ pub mod sgr_styling {
 
         // Verify 'F' has 256-color foreground (index 196)
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             0,
             'F',
@@ -440,7 +440,7 @@ pub mod sgr_styling {
 
         // Verify 'B' has 256-color background (index 196)
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             1,
             'B',
@@ -453,7 +453,7 @@ pub mod sgr_styling {
 
         // Verify 'M' has both 256-color foreground and background
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             2,
             'M',
@@ -468,8 +468,8 @@ pub mod sgr_styling {
     fn test_sgr_extended_rgb_colors() {
         use crate::core::ansi::vt_100_pty_output_parser::vt_100_pty_output_conformance_tests::test_sequence_generators::extended_color_builders::*;
 
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Test RGB color sequences (colon-separated format)
         //
@@ -492,7 +492,7 @@ pub mod sgr_styling {
 
         // Verify 'R' has RGB foreground
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             0,
             'R',
@@ -502,7 +502,7 @@ pub mod sgr_styling {
 
         // Verify 'G' has RGB background
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             1,
             'G',
@@ -512,7 +512,7 @@ pub mod sgr_styling {
 
         // Verify 'B' has both RGB foreground and background
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             2,
             'B',
@@ -527,8 +527,8 @@ pub mod sgr_styling {
     fn test_sgr_extended_colors_mixed() {
         use crate::core::ansi::vt_100_pty_output_parser::vt_100_pty_output_conformance_tests::test_sequence_generators::extended_color_builders::*;
 
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Test mixing basic ANSI, 256-color, and RGB sequences
         //
@@ -553,7 +553,7 @@ pub mod sgr_styling {
 
         // Verify 'A' has basic fg + 256-color bg
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             0,
             'A',
@@ -565,7 +565,7 @@ pub mod sgr_styling {
 
         // Verify 'B' has 256-color fg + basic bg
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             1,
             'B',
@@ -577,7 +577,7 @@ pub mod sgr_styling {
 
         // Verify 'C' has RGB fg + basic bg
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             2,
             'C',
@@ -595,8 +595,8 @@ pub mod sgr_styling {
     /// [196]]`.
     #[test]
     fn test_sgr_extended_256_colors_semicolon_format() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Test 256-color sequences with semicolon format (legacy)
         //
@@ -612,7 +612,7 @@ pub mod sgr_styling {
 
         // Verify 'F' has 256-color foreground.
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             0,
             'F',
@@ -622,7 +622,7 @@ pub mod sgr_styling {
 
         // Verify 'B' has 256-color background.
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             1,
             'B',
@@ -632,7 +632,7 @@ pub mod sgr_styling {
 
         // Verify 'M' has both 256-color fg and bg.
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             2,
             'M',
@@ -646,8 +646,8 @@ pub mod sgr_styling {
     /// Test semicolon-separated RGB color sequences (legacy format).
     #[test]
     fn test_sgr_extended_rgb_colors_semicolon_format() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Test RGB color sequences with semicolon format (legacy)
         //
@@ -663,7 +663,7 @@ pub mod sgr_styling {
 
         // Verify 'R' has RGB foreground.
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             0,
             'R',
@@ -673,7 +673,7 @@ pub mod sgr_styling {
 
         // Verify 'G' has RGB background.
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             1,
             'G',
@@ -683,7 +683,7 @@ pub mod sgr_styling {
 
         // Verify 'B' has both RGB fg and bg.
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             2,
             'B',
@@ -699,17 +699,17 @@ pub mod sgr_styling {
     /// [`SGR`]: crate::SgrCode
     #[test]
     fn test_sgr_semicolon_extended_colors_with_attributes() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Test: bold + semicolon 256-color fg
         // Sequence: ESC[1;38;5;196m (bold + fg index 196)
         {
-            let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+            let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
             performer.apply_ansi_bytes("\x1b[1;38;5;196mA\x1b[0m");
         }
 
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             0,
             'A',
@@ -722,12 +722,12 @@ pub mod sgr_styling {
         // Test: semicolon 256-color fg + bold (reversed order)
         // Sequence: ESC[38;5;196;1m (fg index 196 + bold)
         {
-            let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+            let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
             performer.apply_ansi_bytes("\x1b[38;5;196;1mB\x1b[0m");
         }
 
         assert_styled_char_at(
-            &ofs_buf,
+            &ofs_buf_vt_100,
             0,
             1,
             'B',
@@ -745,9 +745,9 @@ pub mod character_sets {
 
     #[test]
     fn test_esc_character_set_switching() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Start with ASCII mode and write 'q'.
         performer.apply_ansi_bytes(EscSequence::SelectAscii.to_string());
@@ -757,12 +757,12 @@ pub mod character_sets {
         performer.apply_ansi_bytes(EscSequence::SelectDECGraphics.to_string());
 
         assert_eq!(
-            ofs_buf.ansi_parser_support.character_set,
+            ofs_buf_vt_100.parser_global_state.character_set,
             CharacterSet::DECGraphics
         );
 
         // Currently in DEC graphics mode.
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
         // Write 'q' which should be translated to '─' (horizontal line)
         performer.print('q');
@@ -778,14 +778,14 @@ pub mod character_sets {
 
         // Verify character set state after performer is dropped.
         assert_eq!(
-            ofs_buf.ansi_parser_support.character_set,
+            ofs_buf_vt_100.parser_global_state.character_set,
             CharacterSet::Ascii
         );
 
         // Verify the characters.
-        assert_plain_char_at(&ofs_buf, 0, 0, 'q'); // ASCII 'q'
-        assert_plain_char_at(&ofs_buf, 0, 1, '─'); // DEC graphics 'q' -> horizontal line
-        assert_plain_char_at(&ofs_buf, 0, 2, '│'); // DEC graphics 'x' -> vertical line
-        assert_plain_char_at(&ofs_buf, 0, 3, 'q'); // ASCII 'q' again
+        assert_plain_char_at(&ofs_buf_vt_100, 0, 0, 'q'); // ASCII 'q'
+        assert_plain_char_at(&ofs_buf_vt_100, 0, 1, '─'); // DEC graphics 'q' -> horizontal line
+        assert_plain_char_at(&ofs_buf_vt_100, 0, 2, '│'); // DEC graphics 'x' -> vertical line
+        assert_plain_char_at(&ofs_buf_vt_100, 0, 3, 'q'); // ASCII 'q' again
     }
 }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_system_error_handling.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_system_error_handling.rs
@@ -54,7 +54,7 @@ pub mod malformed_csi_sequences {
     /// syntax.
     #[test]
     fn test_invalid_cursor_position_parameters() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Send CSI sequences with invalid parameters
         let malformed_sequences: Vec<&[u8]> = vec![
@@ -67,16 +67,16 @@ pub mod malformed_csi_sequences {
         ];
 
         for sequence in malformed_sequences {
-            let _unused = ofs_buf.apply_ansi_bytes(sequence);
+            let _unused = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
             // Cursor should remain within valid bounds
             assert!(
-                ofs_buf.cursor_pos.row_index < row(10),
+                ofs_buf_vt_100.cursor_pos.row_index < row(10),
                 "Cursor row out of bounds after sequence: {:?}",
                 std::str::from_utf8(sequence).unwrap_or("invalid UTF-8")
             );
             assert!(
-                ofs_buf.cursor_pos.col_index < col(10),
+                ofs_buf_vt_100.cursor_pos.col_index < col(10),
                 "Cursor column out of bounds after sequence: {:?}",
                 std::str::from_utf8(sequence).unwrap_or("invalid UTF-8")
             );
@@ -85,7 +85,7 @@ pub mod malformed_csi_sequences {
 
     #[test]
     fn test_invalid_sgr_parameters() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Test SGR sequences with invalid parameters
         let malformed_sgr: Vec<&[u8]> = vec![
@@ -98,11 +98,11 @@ pub mod malformed_csi_sequences {
         ];
 
         for sequence in malformed_sgr {
-            let _unused = ofs_buf.apply_ansi_bytes(sequence);
+            let _unused = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
             // Parser should handle gracefully - no crash expected
             // Style state should remain valid
-            let style = &ofs_buf.ansi_parser_support.current_style;
+            let style = &ofs_buf_vt_100.parser_global_state.current_style;
             // Basic validity check - style object should be accessible
             let _ = &style.attribs;
         }
@@ -110,7 +110,7 @@ pub mod malformed_csi_sequences {
 
     #[test]
     fn test_incomplete_csi_sequences() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Test incomplete sequences that might be split across buffer boundaries
         let incomplete_sequences: Vec<&[u8]> = vec![
@@ -122,30 +122,30 @@ pub mod malformed_csi_sequences {
         ];
 
         for sequence in incomplete_sequences {
-            let _unused = ofs_buf.apply_ansi_bytes(sequence);
+            let _unused = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
             // Should not crash - VTE parser handles incomplete sequences
             // Write some text after to verify parser recovery
-            let _unused = ofs_buf.apply_ansi_bytes("TEST");
+            let _unused = ofs_buf_vt_100.apply_ansi_bytes("TEST");
         }
     }
 
     #[test]
     fn test_csi_with_excessive_parameters() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // CSI sequence with many parameters (stress test parameter parsing)
         let excessive_params = b"\x1b[1;2;3;4;5;6;7;8;9;10;11;12;13;14;15H";
-        let _unused = ofs_buf.apply_ansi_bytes(excessive_params);
+        let _unused = ofs_buf_vt_100.apply_ansi_bytes(excessive_params);
 
         // Should not crash and cursor should remain in bounds
-        assert!(ofs_buf.cursor_pos.row_index < row(10));
-        assert!(ofs_buf.cursor_pos.col_index < col(10));
+        assert!(ofs_buf_vt_100.cursor_pos.row_index < row(10));
+        assert!(ofs_buf_vt_100.cursor_pos.col_index < col(10));
     }
 
     #[test]
     fn test_unknown_csi_commands() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Test unknown CSI command characters
         let unknown_commands: Vec<&[u8]> = vec![
@@ -156,10 +156,10 @@ pub mod malformed_csi_sequences {
         ];
 
         for sequence in unknown_commands {
-            let _unused = ofs_buf.apply_ansi_bytes(sequence);
+            let _unused = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
             // Should handle gracefully and allow continued operation
-            let _unused = ofs_buf.apply_ansi_bytes("OK");
+            let _unused = ofs_buf_vt_100.apply_ansi_bytes("OK");
         }
     }
 }
@@ -172,7 +172,7 @@ pub mod malformed_osc_sequences {
 
     #[test]
     fn test_incomplete_osc_sequences() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Test incomplete OSC sequences
         let incomplete_osc: Vec<&[u8]> = vec![
@@ -183,16 +183,16 @@ pub mod malformed_osc_sequences {
         ];
 
         for sequence in incomplete_osc {
-            let _unused = ofs_buf.apply_ansi_bytes(sequence);
+            let _unused = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
             // Should not crash
-            let _unused = ofs_buf.apply_ansi_bytes("RECOVERY");
+            let _unused = ofs_buf_vt_100.apply_ansi_bytes("RECOVERY");
         }
     }
 
     #[test]
     fn test_osc_with_invalid_codes() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Test OSC sequences with invalid codes
         let invalid_osc: Vec<&[u8]> = vec![
@@ -203,16 +203,16 @@ pub mod malformed_osc_sequences {
         ];
 
         for sequence in invalid_osc {
-            let _unused = ofs_buf.apply_ansi_bytes(sequence);
+            let _unused = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
             // Should handle gracefully
-            let _unused = ofs_buf.apply_ansi_bytes("CONTINUE");
+            let _unused = ofs_buf_vt_100.apply_ansi_bytes("CONTINUE");
         }
     }
 
     #[test]
     fn test_osc_with_malformed_parameters() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Test OSC hyperlinks with malformed parameters
         let malformed_hyperlinks: Vec<&[u8]> = vec![
@@ -223,10 +223,10 @@ pub mod malformed_osc_sequences {
         ];
 
         for sequence in malformed_hyperlinks {
-            let _unused = ofs_buf.apply_ansi_bytes(sequence);
+            let _unused = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
             // Should handle gracefully without corrupting state
-            let _unused = ofs_buf.apply_ansi_bytes("Link text");
+            let _unused = ofs_buf_vt_100.apply_ansi_bytes("Link text");
         }
     }
 }
@@ -239,7 +239,7 @@ pub mod invalid_character_handling {
 
     #[test]
     fn test_invalid_control_characters() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Test invalid or unsupported control characters
         let invalid_controls: Vec<&[u8]> = vec![
@@ -251,16 +251,16 @@ pub mod invalid_character_handling {
         ];
 
         for sequence in invalid_controls {
-            let _unused = ofs_buf.apply_ansi_bytes(sequence);
+            let _unused = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
             // Should not crash or corrupt state
-            let _unused = ofs_buf.apply_ansi_bytes("TEST");
+            let _unused = ofs_buf_vt_100.apply_ansi_bytes("TEST");
         }
     }
 
     #[test]
     fn test_mixed_valid_invalid_sequences() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Mix valid and invalid sequences
         let mixed_sequence = format!(
@@ -272,16 +272,16 @@ pub mod invalid_character_handling {
             "Text after invalid color"
         );
 
-        let _unused = ofs_buf.apply_ansi_bytes(mixed_sequence);
+        let _unused = ofs_buf_vt_100.apply_ansi_bytes(mixed_sequence);
 
         // Should handle mixture gracefully
-        assert!(ofs_buf.cursor_pos.row_index < row(10));
-        assert!(ofs_buf.cursor_pos.col_index < col(10));
+        assert!(ofs_buf_vt_100.cursor_pos.row_index < row(10));
+        assert!(ofs_buf_vt_100.cursor_pos.col_index < col(10));
     }
 
     #[test]
     fn test_rapid_malformed_sequence_stream() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Send many malformed sequences rapidly
         for _ in 0..50 {
@@ -292,15 +292,15 @@ pub mod invalid_character_handling {
                 "\x1b]999;x\x07", // Invalid OSC
                 "X"               // Valid character
             );
-            let _unused = ofs_buf.apply_ansi_bytes(malformed_batch);
+            let _unused = ofs_buf_vt_100.apply_ansi_bytes(malformed_batch);
         }
 
         // Should maintain stability under stress
-        assert!(ofs_buf.cursor_pos.row_index < row(10));
-        assert!(ofs_buf.cursor_pos.col_index < col(10));
+        assert!(ofs_buf_vt_100.cursor_pos.row_index < row(10));
+        assert!(ofs_buf_vt_100.cursor_pos.col_index < col(10));
 
         // Should still accept valid input
-        let _unused = ofs_buf.apply_ansi_bytes("FINAL");
+        let _unused = ofs_buf_vt_100.apply_ansi_bytes("FINAL");
     }
 }
 
@@ -318,7 +318,7 @@ pub mod boundary_edge_cases {
     /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
     #[test]
     fn test_zero_parameter_treated_as_one() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Test `VT-100`-compliant behavior: zero parameters are treated as 1
         // Using raw ANSI bytes since type-safe API prevents zero deltas
@@ -367,7 +367,7 @@ pub mod boundary_edge_cases {
         ) in test_cases
         {
             // Reset cursor to known position for each test
-            let _unused = ofs_buf.apply_ansi_bytes(format!(
+            let _unused = ofs_buf_vt_100.apply_ansi_bytes(format!(
                 "{}",
                 CsiSequence::CursorPosition {
                     row: start_row,
@@ -376,15 +376,15 @@ pub mod boundary_edge_cases {
             ));
 
             // Apply the zero-parameter movement command (raw ANSI bytes)
-            let _unused = ofs_buf.apply_ansi_bytes(movement_cmd_bytes);
+            let _unused = ofs_buf_vt_100.apply_ansi_bytes(movement_cmd_bytes);
 
             // Per `VT-100` spec: parameter 0 is treated as 1 (minimum movement)
             assert_eq!(
-                ofs_buf.cursor_pos.row_index, expected_row,
+                ofs_buf_vt_100.cursor_pos.row_index, expected_row,
                 "VT-100 spec: {description} should move by 1 (row)"
             );
             assert_eq!(
-                ofs_buf.cursor_pos.col_index, expected_col,
+                ofs_buf_vt_100.cursor_pos.col_index, expected_col,
                 "VT-100 spec: {description} should move by 1 (col)"
             );
         }
@@ -392,7 +392,7 @@ pub mod boundary_edge_cases {
 
     #[test]
     fn test_maximum_parameter_values() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Test with very large parameter values
         let large_params: Vec<&[u8]> = vec![
@@ -402,17 +402,17 @@ pub mod boundary_edge_cases {
         ];
 
         for sequence in large_params {
-            let _unused = ofs_buf.apply_ansi_bytes(sequence);
+            let _unused = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
             // Should clamp to valid ranges
-            assert!(ofs_buf.cursor_pos.row_index < row(10));
-            assert!(ofs_buf.cursor_pos.col_index < col(10));
+            assert!(ofs_buf_vt_100.cursor_pos.row_index < row(10));
+            assert!(ofs_buf_vt_100.cursor_pos.col_index < col(10));
         }
     }
 
     #[test]
     fn test_buffer_position_clamping() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Test positions beyond buffer boundaries
         let beyond_bounds = vec![
@@ -440,20 +440,20 @@ pub mod boundary_edge_cases {
         ];
 
         for sequence in beyond_bounds {
-            let _unused = ofs_buf.apply_ansi_bytes(sequence);
+            let _unused = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
             // Positions should be clamped to buffer bounds
             assert!(
-                ofs_buf.cursor_pos.row_index <= row(9), /* 0-based, so max is 9
-                                                         * for 10-row buffer */
+                ofs_buf_vt_100.cursor_pos.row_index <= row(9), /* 0-based, so max is 9
+                                                                * for 10-row buffer */
                 "Row not clamped properly: {:?}",
-                ofs_buf.cursor_pos
+                ofs_buf_vt_100.cursor_pos
             );
             assert!(
-                ofs_buf.cursor_pos.col_index <= col(9), /* 0-based, so max is 9
-                                                         * for 10-col buffer */
+                ofs_buf_vt_100.cursor_pos.col_index <= col(9), /* 0-based, so max is 9
+                                                                * for 10-col buffer */
                 "Column not clamped properly: {:?}",
-                ofs_buf.cursor_pos
+                ofs_buf_vt_100.cursor_pos
             );
         }
     }
@@ -465,7 +465,7 @@ pub mod parser_resilience {
 
     #[test]
     fn test_recovery_after_malformed_sequences() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Send malformed sequences followed by valid ones
         let recovery_test = format!(
@@ -480,19 +480,19 @@ pub mod parser_resilience {
             }
         );
 
-        let _unused = ofs_buf.apply_ansi_bytes(recovery_test);
+        let _unused = ofs_buf_vt_100.apply_ansi_bytes(recovery_test);
 
         // Should be able to continue processing after malformed input
-        let _unused = ofs_buf.apply_ansi_bytes("Final test");
+        let _unused = ofs_buf_vt_100.apply_ansi_bytes("Final test");
 
         // Parser should be in a valid state
-        assert!(ofs_buf.cursor_pos.row_index < row(10));
-        assert!(ofs_buf.cursor_pos.col_index < col(10));
+        assert!(ofs_buf_vt_100.cursor_pos.row_index < row(10));
+        assert!(ofs_buf_vt_100.cursor_pos.col_index < col(10));
     }
 
     #[test]
     fn test_partial_sequence_handling() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Simulate partial sequences arriving in separate chunks
         let partial_chunks: Vec<&[u8]> = vec![
@@ -507,17 +507,17 @@ pub mod parser_resilience {
 
         // Send chunks separately (simulating network/buffer splits)
         for chunk in partial_chunks {
-            let _unused = ofs_buf.apply_ansi_bytes(chunk);
+            let _unused = ofs_buf_vt_100.apply_ansi_bytes(chunk);
         }
 
         // Should eventually process complete sequence
-        assert!(ofs_buf.cursor_pos.row_index < row(10));
-        assert!(ofs_buf.cursor_pos.col_index < col(10));
+        assert!(ofs_buf_vt_100.cursor_pos.row_index < row(10));
+        assert!(ofs_buf_vt_100.cursor_pos.col_index < col(10));
     }
 
     #[test]
     fn test_state_corruption_prevention() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Try to corrupt parser state with adversarial input
         let adversarial_input = format!(
@@ -531,11 +531,11 @@ pub mod parser_resilience {
             "State check"        // Normal text
         );
 
-        let _unused = ofs_buf.apply_ansi_bytes(adversarial_input);
+        let _unused = ofs_buf_vt_100.apply_ansi_bytes(adversarial_input);
 
         // State should remain consistent
-        assert!(ofs_buf.cursor_pos.row_index < row(10));
-        assert!(ofs_buf.cursor_pos.col_index < col(10));
+        assert!(ofs_buf_vt_100.cursor_pos.row_index < row(10));
+        assert!(ofs_buf_vt_100.cursor_pos.col_index < col(10));
 
         // Should still respond to valid commands
         let move_sequence = format!(
@@ -545,10 +545,10 @@ pub mod parser_resilience {
                 col: term_col(nz(3))
             }
         );
-        let _unused = ofs_buf.apply_ansi_bytes(move_sequence);
+        let _unused = ofs_buf_vt_100.apply_ansi_bytes(move_sequence);
 
-        assert_eq!(ofs_buf.cursor_pos.row_index, row(2)); // 0-based
-        assert_eq!(ofs_buf.cursor_pos.col_index, col(2)); // 0-based
+        assert_eq!(ofs_buf_vt_100.cursor_pos.row_index, row(2)); // 0-based
+        assert_eq!(ofs_buf_vt_100.cursor_pos.col_index, col(2)); // 0-based
     }
 }
 
@@ -577,7 +577,7 @@ pub mod vte_parser_limit_exceeded {
 
     #[test]
     fn test_csi_excessive_parameters_ignored() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Set cursor to known position
         let initial_pos = format!(
@@ -587,25 +587,25 @@ pub mod vte_parser_limit_exceeded {
                 col: term_col(nz(5))
             }
         );
-        let _unused = ofs_buf.apply_ansi_bytes(initial_pos);
-        assert_eq!(ofs_buf.cursor_pos.row_index, row(4));
-        assert_eq!(ofs_buf.cursor_pos.col_index, col(4));
+        let _unused = ofs_buf_vt_100.apply_ansi_bytes(initial_pos);
+        assert_eq!(ofs_buf_vt_100.cursor_pos.row_index, row(4));
+        assert_eq!(ofs_buf_vt_100.cursor_pos.col_index, col(4));
 
         // Send CSI sequence with many parameters (exceeds VTE's internal limit)
         // VTE will collect up to its limit, set ignore=true, and call csi_dispatch()
         // Our implementation should discard this entirely
         // Note: Using 50 params to ensure we exceed whatever VTE's actual limit is
         let excessive_params = b"\x1b[1;2;3;4;5;6;7;8;9;10;11;12;13;14;15;16;17;18;19;20;21;22;23;24;25;26;27;28;29;30;31;32;33;34;35;36;37;38;39;40;41;42;43;44;45;46;47;48;49;50H";
-        let _unused = ofs_buf.apply_ansi_bytes(excessive_params);
+        let _unused = ofs_buf_vt_100.apply_ansi_bytes(excessive_params);
 
         // Cursor should NOT have moved - sequence was discarded
         assert_eq!(
-            ofs_buf.cursor_pos.row_index,
+            ofs_buf_vt_100.cursor_pos.row_index,
             row(4),
             "Cursor should not move when CSI sequence exceeds parameter limit"
         );
         assert_eq!(
-            ofs_buf.cursor_pos.col_index,
+            ofs_buf_vt_100.cursor_pos.col_index,
             col(4),
             "Cursor should not move when CSI sequence exceeds parameter limit"
         );
@@ -618,14 +618,14 @@ pub mod vte_parser_limit_exceeded {
                 col: term_col(nz(2))
             }
         );
-        let _unused = ofs_buf.apply_ansi_bytes(valid_move);
+        let _unused = ofs_buf_vt_100.apply_ansi_bytes(valid_move);
         assert_eq!(
-            ofs_buf.cursor_pos.row_index,
+            ofs_buf_vt_100.cursor_pos.row_index,
             row(1),
             "Parser should recover and process valid sequences"
         );
         assert_eq!(
-            ofs_buf.cursor_pos.col_index,
+            ofs_buf_vt_100.cursor_pos.col_index,
             col(1),
             "Parser should recover and process valid sequences"
         );
@@ -633,7 +633,7 @@ pub mod vte_parser_limit_exceeded {
 
     #[test]
     fn test_csi_excessive_intermediates_ignored() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Set cursor to known position
         let initial_pos = format!(
@@ -643,25 +643,25 @@ pub mod vte_parser_limit_exceeded {
                 col: term_col(nz(3))
             }
         );
-        let _unused = ofs_buf.apply_ansi_bytes(initial_pos);
-        assert_eq!(ofs_buf.cursor_pos.row_index, row(2));
-        assert_eq!(ofs_buf.cursor_pos.col_index, col(2));
+        let _unused = ofs_buf_vt_100.apply_ansi_bytes(initial_pos);
+        assert_eq!(ofs_buf_vt_100.cursor_pos.row_index, row(2));
+        assert_eq!(ofs_buf_vt_100.cursor_pos.col_index, col(2));
 
         // Send CSI sequence with too many intermediate bytes (>2)
         // Format: ESC [ intermediates... final_char
         // Using multiple '?' characters as intermediates (normally used for private
         // modes)
         let excessive_intermediates = b"\x1b[?>?>?>A"; // 4 intermediate bytes
-        let _unused = ofs_buf.apply_ansi_bytes(excessive_intermediates);
+        let _unused = ofs_buf_vt_100.apply_ansi_bytes(excessive_intermediates);
 
         // Cursor should NOT have moved - sequence was discarded
         assert_eq!(
-            ofs_buf.cursor_pos.row_index,
+            ofs_buf_vt_100.cursor_pos.row_index,
             row(2),
             "Cursor should not move when CSI has too many intermediates"
         );
         assert_eq!(
-            ofs_buf.cursor_pos.col_index,
+            ofs_buf_vt_100.cursor_pos.col_index,
             col(2),
             "Cursor should not move when CSI has too many intermediates"
         );
@@ -669,11 +669,11 @@ pub mod vte_parser_limit_exceeded {
 
     #[test]
     fn test_esc_excessive_intermediates_ignored() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Get initial character set state (should be ASCII by default)
         let initial_charset = matches!(
-            ofs_buf.ansi_parser_support.character_set,
+            ofs_buf_vt_100.parser_global_state.character_set,
             CharacterSet::Ascii
         );
 
@@ -681,11 +681,11 @@ pub mod vte_parser_limit_exceeded {
         // Normal: ESC ( 0 (select DEC graphics)
         // Excessive: ESC ( ( ( 0 (too many '(' intermediates)
         let excessive_intermediates = b"\x1b(((0";
-        let _unused = ofs_buf.apply_ansi_bytes(excessive_intermediates);
+        let _unused = ofs_buf_vt_100.apply_ansi_bytes(excessive_intermediates);
 
         // Character set should NOT have changed - sequence was discarded
         let charset_after = matches!(
-            ofs_buf.ansi_parser_support.character_set,
+            ofs_buf_vt_100.parser_global_state.character_set,
             CharacterSet::Ascii
         );
         assert_eq!(
@@ -696,7 +696,7 @@ pub mod vte_parser_limit_exceeded {
 
     #[test]
     fn test_dcs_ignored_regardless_of_limits() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // DCS sequences are not implemented in the multiplexer, so they're ignored
         // whether well-formed or malformed. This test verifies that excessive parameters
@@ -706,21 +706,21 @@ pub mod vte_parser_limit_exceeded {
         // Send DCS with excessive parameters: ESC P params... data ESC \
         let dcs_excessive_params =
             b"\x1bP1;2;3;4;5;6;7;8;9;10;11;12;13;14;15;16;17;18;19;20;data\x1b\\";
-        let _unused = ofs_buf.apply_ansi_bytes(dcs_excessive_params);
+        let _unused = ofs_buf_vt_100.apply_ansi_bytes(dcs_excessive_params);
 
         // Should not crash - verify by sending valid text
-        let _unused = ofs_buf.apply_ansi_bytes("TEXT");
+        let _unused = ofs_buf_vt_100.apply_ansi_bytes("TEXT");
 
         // Cursor should have advanced for the printable text
         assert!(
-            ofs_buf.cursor_pos.col_index >= col(4),
+            ofs_buf_vt_100.cursor_pos.col_index >= col(4),
             "Parser should continue working after ignored DCS"
         );
     }
 
     #[test]
     fn test_parser_recovery_after_ignore() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Send sequence that will be ignored, followed by valid sequences
         let mixed_sequence = format!(
@@ -733,16 +733,16 @@ pub mod vte_parser_limit_exceeded {
             }  // Should work
         );
 
-        let _unused = ofs_buf.apply_ansi_bytes(mixed_sequence);
+        let _unused = ofs_buf_vt_100.apply_ansi_bytes(mixed_sequence);
 
         // Parser should have recovered and processed the valid cursor position
         assert_eq!(
-            ofs_buf.cursor_pos.row_index,
+            ofs_buf_vt_100.cursor_pos.row_index,
             row(6),
             "Parser should recover and process valid sequences after ignored one"
         );
         assert_eq!(
-            ofs_buf.cursor_pos.col_index,
+            ofs_buf_vt_100.cursor_pos.col_index,
             col(2),
             "Parser should recover and process valid sequences after ignored one"
         );
@@ -750,7 +750,7 @@ pub mod vte_parser_limit_exceeded {
 
     #[test]
     fn test_mixed_valid_and_ignored_sequences() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Interleave valid and ignored sequences
         let sequence = format!(
@@ -768,18 +768,18 @@ pub mod vte_parser_limit_exceeded {
             }  // Valid - should execute
         );
 
-        let _unused = ofs_buf.apply_ansi_bytes(sequence);
+        let _unused = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
         // Only the valid sequences should have executed
         // Final position should be (5,5) from last valid cursor position
         // (TEXT would have moved cursor but then final position overrides)
         assert_eq!(
-            ofs_buf.cursor_pos.row_index,
+            ofs_buf_vt_100.cursor_pos.row_index,
             row(4),
             "Only valid sequences should execute, ignored ones discarded"
         );
         assert_eq!(
-            ofs_buf.cursor_pos.col_index,
+            ofs_buf_vt_100.cursor_pos.col_index,
             col(4),
             "Only valid sequences should execute, ignored ones discarded"
         );
@@ -787,7 +787,7 @@ pub mod vte_parser_limit_exceeded {
 
     #[test]
     fn test_excessive_params_different_csi_commands() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Test that ignore parameter works for different CSI command types
         // Using 50 params to ensure we exceed VTE's limit
@@ -812,7 +812,7 @@ pub mod vte_parser_limit_exceeded {
 
         for (sequence, description) in test_cases {
             // Reset to known position
-            let _unused = ofs_buf.apply_ansi_bytes(format!(
+            let _unused = ofs_buf_vt_100.apply_ansi_bytes(format!(
                 "{}",
                 CsiSequence::CursorPosition {
                     row: term_row(nz(5)),
@@ -821,18 +821,18 @@ pub mod vte_parser_limit_exceeded {
             ));
 
             // Send sequence with excessive parameters
-            let _unused = ofs_buf.apply_ansi_bytes(sequence);
+            let _unused = ofs_buf_vt_100.apply_ansi_bytes(sequence);
 
             // Position should remain unchanged for cursor commands
             // (For SGR/IL, we just verify no crash)
             if description.contains("Cursor") || description.contains("CUP") {
                 assert_eq!(
-                    ofs_buf.cursor_pos.row_index,
+                    ofs_buf_vt_100.cursor_pos.row_index,
                     row(4),
                     "{description} should be ignored when params exceed limit"
                 );
                 assert_eq!(
-                    ofs_buf.cursor_pos.col_index,
+                    ofs_buf_vt_100.cursor_pos.col_index,
                     col(4),
                     "{description} should be ignored when params exceed limit"
                 );

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_system_performer_lifecycle.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_system_performer_lifecycle.rs
@@ -8,23 +8,23 @@ use vte::Perform;
 
 #[test]
 fn test_performer_creation() {
-    let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+    let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
-    let performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+    let performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
     assert_eq!(
-        performer.ofs_buf.cursor_pos,
+        performer.ofs_buf_vt_100.cursor_pos,
         Pos::default(),
         "New performer should initialize cursor position to (0,0)"
     );
     assert_eq!(
-        performer.ofs_buf.ansi_parser_support.current_style,
+        performer.ofs_buf_vt_100.parser_global_state.current_style,
         TuiStyle::default(),
         "New performer should initialize current_style to default"
     );
     assert!(
         performer
-            .ofs_buf
-            .ansi_parser_support
+            .ofs_buf_vt_100
+            .parser_global_state
             .pending_osc_events
             .is_empty(),
         "New performer should initialize pending_osc_events to empty"
@@ -36,63 +36,63 @@ fn test_performer_creation() {
 /// changes are immediately visible and persistent in the buffer.
 #[test]
 fn test_state_persists_in_buffer_across_performer_lifecycles() {
-    let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+    let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
     // First performer session.
     {
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
-        performer.ofs_buf.cursor_pos = row(1) + col(5);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
+        performer.ofs_buf_vt_100.cursor_pos = row(1) + col(5);
         performer.print('A'); // Cursor advances to (r:1,c:6)
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(1) + col(6),
             "Cursor should advance after printing a character"
         );
     } // End of first performer scope - changes are already in buffer
 
     assert_eq!(
-        ofs_buf.cursor_pos,
+        ofs_buf_vt_100.cursor_pos,
         row(1) + col(6),
         "Buffer position should persist after performer goes out of scope"
     );
 
     // Second performer session - should start with buffer's current position.
     {
-        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
         // New performer should initialize with buffer's current cursor position.
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(1) + col(6),
             "New performer should start with buffer's current position"
         );
 
-        performer.ofs_buf.cursor_pos = row(4) + col(2);
+        performer.ofs_buf_vt_100.cursor_pos = row(4) + col(2);
         performer.print('B'); // Cursor advances to (r:4,c:3)
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(4) + col(3),
             "Cursor should advance after printing a character"
         );
     } // End of second performer scope - changes are already in buffer
 
     assert_eq!(
-        ofs_buf.cursor_pos,
+        ofs_buf_vt_100.cursor_pos,
         row(4) + col(3),
         "Buffer position should persist after second performer goes out of scope"
     );
 
     // Third performer session - should start with buffer's current position.
     {
-        let performer = AnsiToOfsBufPerformer::new(&mut ofs_buf);
+        let performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
         assert_eq!(
-            performer.ofs_buf.cursor_pos,
+            performer.ofs_buf_vt_100.cursor_pos,
             row(4) + col(3),
             "Third performer should start with previous session's final position"
         );
     } // End of third performer scope - no changes made
 
     assert_eq!(
-        ofs_buf.cursor_pos,
+        ofs_buf_vt_100.cursor_pos,
         row(4) + col(3),
         "Buffer position should persist across performer lifecycles"
     );

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_system_state_management.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_system_state_management.rs
@@ -11,8 +11,7 @@
 //! [`SGR`]: crate::SgrCode
 
 use super::super::test_fixtures_vt_100_ansi_conformance::*;
-use crate::AutoWrapState;
-use crate::{ANSIBasicColor, EraseDisplayMode, SgrCode, col,
+use crate::{ANSIBasicColor, AutoWrapState, EraseDisplayMode, SgrCode, col,
             core::ansi::vt_100_pty_output_parser::{CsiSequence, PrivateModeType},
             row, term_col, term_row};
 
@@ -24,7 +23,7 @@ pub mod cursor_save_restore_with_attributes {
 
     #[test]
     fn test_cursor_save_restore_preserves_position_only() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Move cursor to specific position
         let move_sequence = format!(
@@ -34,7 +33,7 @@ pub mod cursor_save_restore_with_attributes {
                 col: term_col(nz(5))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(move_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(move_sequence);
 
         // Set some SGR attributes
         let style_sequence = format!(
@@ -43,11 +42,11 @@ pub mod cursor_save_restore_with_attributes {
             SgrCode::ForegroundBasic(ANSIBasicColor::Red),
             SgrCode::BackgroundBasic(ANSIBasicColor::Blue)
         );
-        let _result = ofs_buf.apply_ansi_bytes(style_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(style_sequence);
 
         // Save cursor (should only save position, not attributes)
         let save_sequence = format!("{}", CsiSequence::SaveCursor);
-        let _result = ofs_buf.apply_ansi_bytes(save_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(save_sequence);
 
         // Move cursor and change attributes
         let move_sequence2 = format!(
@@ -57,35 +56,35 @@ pub mod cursor_save_restore_with_attributes {
                 col: term_col(nz(8))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(move_sequence2);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(move_sequence2);
 
         let style_sequence2 = format!(
             "{}{}",
             SgrCode::Reset,
             SgrCode::ForegroundBasic(ANSIBasicColor::Green)
         );
-        let _result = ofs_buf.apply_ansi_bytes(style_sequence2);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(style_sequence2);
 
         // Restore cursor
         let restore_sequence = format!("{}", CsiSequence::RestoreCursor);
-        let _result = ofs_buf.apply_ansi_bytes(restore_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(restore_sequence);
 
         // Position should be restored
-        assert_eq!(ofs_buf.cursor_pos, row(2) + col(4)); // 0-based
+        assert_eq!(ofs_buf_vt_100.cursor_pos, row(2) + col(4)); // 0-based
 
         // Attributes should remain as they were changed (not restored)
         // Current style should be green foreground from the change above
-        let current_style = ofs_buf.ansi_parser_support.current_style;
+        let current_style = ofs_buf_vt_100.parser_global_state.current_style;
         assert_eq!(current_style.color_fg, Some(ANSIBasicColor::Green.into()));
     }
 
     #[test]
     fn test_cursor_save_restore_multiple_times() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // First save at origin
         let save1_sequence = format!("{}", CsiSequence::SaveCursor);
-        let _result = ofs_buf.apply_ansi_bytes(save1_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(save1_sequence);
 
         // Move to position 1
         let move1_sequence = format!(
@@ -95,11 +94,11 @@ pub mod cursor_save_restore_with_attributes {
                 col: term_col(nz(3))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(move1_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(move1_sequence);
 
         // Second save at position 1
         let save2_sequence = format!("{}", CsiSequence::SaveCursor);
-        let _result = ofs_buf.apply_ansi_bytes(save2_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(save2_sequence);
 
         // Move to position 2
         let move2_sequence = format!(
@@ -109,18 +108,18 @@ pub mod cursor_save_restore_with_attributes {
                 col: term_col(nz(7))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(move2_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(move2_sequence);
 
         // Restore should go to most recently saved position (position 1)
         let restore_sequence = format!("{}", CsiSequence::RestoreCursor);
-        let _result = ofs_buf.apply_ansi_bytes(restore_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(restore_sequence);
 
-        assert_eq!(ofs_buf.cursor_pos, row(1) + col(2)); // 0-based position 1
+        assert_eq!(ofs_buf_vt_100.cursor_pos, row(1) + col(2)); // 0-based position 1
     }
 
     #[test]
     fn test_cursor_save_restore_with_styling_operations() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Position cursor and set initial style
         let move_sequence = format!(
@@ -130,14 +129,14 @@ pub mod cursor_save_restore_with_attributes {
                 col: term_col(nz(4))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(move_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(move_sequence);
 
         let initial_style = format!("{}", SgrCode::Bold);
-        let _result = ofs_buf.apply_ansi_bytes(initial_style);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(initial_style);
 
         // Save cursor
         let save_sequence = format!("{}", CsiSequence::SaveCursor);
-        let _result = ofs_buf.apply_ansi_bytes(save_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(save_sequence);
 
         // Move and do complex styling
         let move_and_style = format!(
@@ -150,20 +149,20 @@ pub mod cursor_save_restore_with_attributes {
             SgrCode::BackgroundBasic(ANSIBasicColor::Yellow),
             SgrCode::Underline
         );
-        let _result = ofs_buf.apply_ansi_bytes(move_and_style);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(move_and_style);
 
         // Restore cursor (position only)
         let restore_sequence = format!("{}", CsiSequence::RestoreCursor);
-        let _result = ofs_buf.apply_ansi_bytes(restore_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(restore_sequence);
 
         // Verify cursor position restored
-        assert_eq!(ofs_buf.cursor_pos, row(1) + col(3)); // 0-based
+        assert_eq!(ofs_buf_vt_100.cursor_pos, row(1) + col(3)); // 0-based
 
         // Write text to verify current attributes are maintained
-        let _result = ofs_buf.apply_ansi_bytes("Test");
+        let _result = ofs_buf_vt_100.apply_ansi_bytes("Test");
 
         // Should be written with the complex styling (red on yellow, underlined)
-        let char_at_restore_pos = &ofs_buf.buffer[1][3];
+        let char_at_restore_pos = &ofs_buf_vt_100.buffer[1][3];
         if let crate::PixelChar::PlainText { style, .. } = char_at_restore_pos {
             assert_eq!(style.color_fg, Some(ANSIBasicColor::Red.into()));
             assert_eq!(style.color_bg, Some(ANSIBasicColor::Yellow.into()));
@@ -180,15 +179,15 @@ pub mod character_set_state_management {
 
     #[test]
     fn test_character_set_persistence_across_cursor_operations() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Switch to DEC Graphics character set (ESC ( 0)
         let graphics_mode = b"\x1b(0";
-        let _result = ofs_buf.apply_ansi_bytes(graphics_mode);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(graphics_mode);
 
         // Verify DEC Graphics mode is active
         assert_eq!(
-            ofs_buf.ansi_parser_support.character_set,
+            ofs_buf_vt_100.parser_global_state.character_set,
             crate::CharacterSet::DECGraphics
         );
 
@@ -202,19 +201,19 @@ pub mod character_set_state_management {
             },
             CsiSequence::RestoreCursor
         );
-        let _result = ofs_buf.apply_ansi_bytes(cursor_ops);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(cursor_ops);
 
         // Character set should persist
         assert_eq!(
-            ofs_buf.ansi_parser_support.character_set,
+            ofs_buf_vt_100.parser_global_state.character_set,
             crate::CharacterSet::DECGraphics
         );
 
         // Print a character that gets translated in DEC Graphics mode
-        let _result = ofs_buf.apply_ansi_bytes("q"); // Should become horizontal line
+        let _result = ofs_buf_vt_100.apply_ansi_bytes("q"); // Should become horizontal line
 
         // Verify the character was translated
-        let char_at_cursor = &ofs_buf.buffer[0][0];
+        let char_at_cursor = &ofs_buf_vt_100.buffer[0][0];
         if let crate::PixelChar::PlainText { display_char, .. } = char_at_cursor {
             assert_eq!(*display_char, '─'); // DEC Graphics 'q' → horizontal line
         } else {
@@ -224,11 +223,11 @@ pub mod character_set_state_management {
 
     #[test]
     fn test_character_set_switching_with_mode_changes() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Start in ASCII mode (default)
         assert_eq!(
-            ofs_buf.ansi_parser_support.character_set,
+            ofs_buf_vt_100.parser_global_state.character_set,
             crate::CharacterSet::Ascii
         );
 
@@ -238,35 +237,41 @@ pub mod character_set_state_management {
             "\x1b(0", // DEC Graphics
             CsiSequence::DisablePrivateMode(PrivateModeType::AutoWrap)
         );
-        let _result = ofs_buf.apply_ansi_bytes(combined_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(combined_sequence);
 
         // Both states should be active
         assert_eq!(
-            ofs_buf.ansi_parser_support.character_set,
+            ofs_buf_vt_100.parser_global_state.character_set,
             crate::CharacterSet::DECGraphics
         );
-        assert_eq!(ofs_buf.ansi_parser_support.auto_wrap_mode, AutoWrapState::Disabled);
+        assert_eq!(
+            ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Disabled
+        );
 
         // Change modes but keep character set
         let mode_change = format!(
             "{}",
             CsiSequence::EnablePrivateMode(PrivateModeType::AutoWrap)
         );
-        let _result = ofs_buf.apply_ansi_bytes(mode_change);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(mode_change);
 
         // Auto-wrap should change but character set should persist
-        assert_eq!(ofs_buf.ansi_parser_support.auto_wrap_mode, AutoWrapState::Enabled);
         assert_eq!(
-            ofs_buf.ansi_parser_support.character_set,
+            ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Enabled
+        );
+        assert_eq!(
+            ofs_buf_vt_100.parser_global_state.character_set,
             crate::CharacterSet::DECGraphics
         );
 
         // Switch back to ASCII
         let ascii_mode = b"\x1b(B";
-        let _result = ofs_buf.apply_ansi_bytes(ascii_mode);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(ascii_mode);
 
         assert_eq!(
-            ofs_buf.ansi_parser_support.character_set,
+            ofs_buf_vt_100.parser_global_state.character_set,
             crate::CharacterSet::Ascii
         );
     }
@@ -278,7 +283,7 @@ pub mod scroll_region_state_interactions {
 
     #[test]
     fn test_cursor_save_restore_with_scroll_regions() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Set scroll region (rows 3-7)
         let margins_sequence = format!(
@@ -288,7 +293,7 @@ pub mod scroll_region_state_interactions {
                 bottom: Some(term_row(nz(7)))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(margins_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(margins_sequence);
 
         // Position cursor within scroll region
         let move_sequence = format!(
@@ -298,11 +303,11 @@ pub mod scroll_region_state_interactions {
                 col: term_col(nz(6))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(move_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(move_sequence);
 
         // Save cursor
         let save_sequence = format!("{}", CsiSequence::SaveCursor);
-        let _result = ofs_buf.apply_ansi_bytes(save_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(save_sequence);
 
         // Move outside scroll region
         let move_outside = format!(
@@ -312,7 +317,7 @@ pub mod scroll_region_state_interactions {
                 col: term_col(nz(2))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(move_outside);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(move_outside);
 
         // Change scroll region
         let new_margins = format!(
@@ -322,29 +327,29 @@ pub mod scroll_region_state_interactions {
                 bottom: Some(term_row(nz(8)))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(new_margins);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(new_margins);
 
         // Restore cursor (should restore to absolute position)
         let restore_sequence = format!("{}", CsiSequence::RestoreCursor);
-        let _result = ofs_buf.apply_ansi_bytes(restore_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(restore_sequence);
 
         // Should restore to original absolute position (5,6)
-        assert_eq!(ofs_buf.cursor_pos, row(4) + col(5)); // 0-based
+        assert_eq!(ofs_buf_vt_100.cursor_pos, row(4) + col(5)); // 0-based
 
         // Verify scroll region changed
         assert_eq!(
-            ofs_buf.ansi_parser_support.scroll_region_top,
+            ofs_buf_vt_100.parser_global_state.scroll_region_top,
             Some(term_row(nz(2)))
         );
         assert_eq!(
-            ofs_buf.ansi_parser_support.scroll_region_bottom,
+            ofs_buf_vt_100.parser_global_state.scroll_region_bottom,
             Some(term_row(nz(8)))
         );
     }
 
     #[test]
     fn test_scroll_region_reset_with_saved_cursor() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Set initial scroll region and position cursor
         let setup_sequence = format!(
@@ -359,7 +364,7 @@ pub mod scroll_region_state_interactions {
             },
             CsiSequence::SaveCursor
         );
-        let _result = ofs_buf.apply_ansi_bytes(setup_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(setup_sequence);
 
         // Reset scroll region (ESC [ r with no parameters)
         let reset_margins = format!(
@@ -369,11 +374,14 @@ pub mod scroll_region_state_interactions {
                 bottom: None
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(reset_margins);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(reset_margins);
 
         // Verify scroll region reset
-        assert_eq!(ofs_buf.ansi_parser_support.scroll_region_top, None);
-        assert_eq!(ofs_buf.ansi_parser_support.scroll_region_bottom, None);
+        assert_eq!(ofs_buf_vt_100.parser_global_state.scroll_region_top, None);
+        assert_eq!(
+            ofs_buf_vt_100.parser_global_state.scroll_region_bottom,
+            None
+        );
 
         // Move cursor somewhere else
         let move_sequence = format!(
@@ -383,26 +391,25 @@ pub mod scroll_region_state_interactions {
                 col: term_col(nz(8))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(move_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(move_sequence);
 
         // Restore cursor (should still work with reset scroll region)
         let restore_sequence = format!("{}", CsiSequence::RestoreCursor);
-        let _result = ofs_buf.apply_ansi_bytes(restore_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(restore_sequence);
 
         // Should restore to saved position (6,3)
-        assert_eq!(ofs_buf.cursor_pos, row(5) + col(2)); // 0-based
+        assert_eq!(ofs_buf_vt_100.cursor_pos, row(5) + col(2)); // 0-based
     }
 }
 
 /// Tests for complex state combinations and edge cases.
 pub mod complex_state_combinations {
+    use super::*;
     use crate::AutoWrapState;
-
-use super::*;
 
     #[test]
     fn test_full_state_combination() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Set up complex state: scroll region + DEC graphics + auto-wrap off + styling
         let complex_setup = format!(
@@ -420,11 +427,11 @@ use super::*;
                 col: term_col(nz(4))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(complex_setup);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(complex_setup);
 
         // Save cursor
         let save_sequence = format!("{}", CsiSequence::SaveCursor);
-        let _result = ofs_buf.apply_ansi_bytes(save_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(save_sequence);
 
         // Modify all states
         let state_changes = format!(
@@ -441,30 +448,33 @@ use super::*;
                 col: term_col(nz(1))
             }
         );
-        let _result = ofs_buf.apply_ansi_bytes(state_changes);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(state_changes);
 
         // Restore cursor (position only)
         let restore_sequence = format!("{}", CsiSequence::RestoreCursor);
-        let _result = ofs_buf.apply_ansi_bytes(restore_sequence);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(restore_sequence);
 
         // Verify cursor position restored
-        assert_eq!(ofs_buf.cursor_pos, row(4) + col(3)); // 0-based
+        assert_eq!(ofs_buf_vt_100.cursor_pos, row(4) + col(3)); // 0-based
 
         // Verify other states changed (not restored)
         assert_eq!(
-            ofs_buf.ansi_parser_support.scroll_region_top,
+            ofs_buf_vt_100.parser_global_state.scroll_region_top,
             Some(term_row(nz(1)))
         );
         assert_eq!(
-            ofs_buf.ansi_parser_support.character_set,
+            ofs_buf_vt_100.parser_global_state.character_set,
             crate::CharacterSet::Ascii
         );
-        assert_eq!(ofs_buf.ansi_parser_support.auto_wrap_mode, AutoWrapState::Enabled);
+        assert_eq!(
+            ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Enabled
+        );
     }
 
     #[test]
     fn test_state_persistence_across_buffer_operations() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Set up initial state
         let initial_state = format!(
@@ -473,7 +483,7 @@ use super::*;
             CsiSequence::DisablePrivateMode(PrivateModeType::AutoWrap),
             SgrCode::Bold
         );
-        let _result = ofs_buf.apply_ansi_bytes(initial_state);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(initial_state);
 
         // Perform various buffer operations
         let buffer_ops = format!(
@@ -487,19 +497,22 @@ use super::*;
             CsiSequence::EraseDisplay(EraseDisplayMode::FromCursorToEnd), /* Clear from cursor to end */
             "Text3"
         );
-        let _result = ofs_buf.apply_ansi_bytes(buffer_ops);
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(buffer_ops);
 
         // States should persist through buffer operations
         assert_eq!(
-            ofs_buf.ansi_parser_support.character_set,
+            ofs_buf_vt_100.parser_global_state.character_set,
             crate::CharacterSet::DECGraphics
         );
-        assert_eq!(ofs_buf.ansi_parser_support.auto_wrap_mode, AutoWrapState::Disabled);
+        assert_eq!(
+            ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
+            AutoWrapState::Disabled
+        );
 
         // Current style should still have bold
         assert!(
-            ofs_buf
-                .ansi_parser_support
+            ofs_buf_vt_100
+                .parser_global_state
                 .current_style
                 .attribs
                 .bold

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_terminal_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_terminal_ops.rs
@@ -4,7 +4,7 @@
 //!
 //! This module tests terminal control operations including:
 //! - RIS (Reset to Initial State) - [`ESC`] c
-//! - Character set selection - [`ESC`] ( B, [`ESC`] ( 0
+//! - Character set selection - `ESC ( B`, `ESC ( 0`
 //! - Terminal state reset and initialization
 //! - Character set switching and translation
 //!
@@ -19,68 +19,70 @@ pub mod reset_initial_state {
 
     #[test]
     fn test_ris_resets_cursor_position() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Move cursor to non-origin position
-        ofs_buf.cursor_pos = Pos::new((RowIndex::new(ch(5)), ColIndex::new(ch(3))));
+        ofs_buf_vt_100.cursor_pos =
+            Pos::new((RowIndex::new(ch(5)), ColIndex::new(ch(3))));
 
         // Send RIS sequence
         let ris_sequence = format!("{}", EscSequence::ResetTerminal);
-        let _result = ofs_buf.apply_ansi_bytes(ris_sequence.as_bytes());
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(ris_sequence.as_bytes());
 
         // Cursor should be reset to origin
-        assert_eq!(ofs_buf.cursor_pos, Pos::default());
+        assert_eq!(ofs_buf_vt_100.cursor_pos, Pos::default());
     }
 
     #[test]
     fn test_ris_resets_style() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Set non-default style (simplified for test)
-        ofs_buf.ansi_parser_support.current_style = TuiStyle::default();
+        ofs_buf_vt_100.parser_global_state.current_style = TuiStyle::default();
 
         // Send RIS sequence
         let ris_sequence = format!("{}", EscSequence::ResetTerminal);
-        let _result = ofs_buf.apply_ansi_bytes(ris_sequence.as_bytes());
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(ris_sequence.as_bytes());
 
         // Style should be reset to default
         assert_eq!(
-            ofs_buf.ansi_parser_support.current_style,
+            ofs_buf_vt_100.parser_global_state.current_style,
             TuiStyle::default()
         );
     }
 
     #[test]
     fn test_ris_resets_character_set() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Set DEC graphics character set
-        ofs_buf.ansi_parser_support.character_set = CharacterSet::DECGraphics;
+        ofs_buf_vt_100.parser_global_state.character_set = CharacterSet::DECGraphics;
 
         // Send RIS sequence
         let ris_sequence = format!("{}", EscSequence::ResetTerminal);
-        let _result = ofs_buf.apply_ansi_bytes(ris_sequence.as_bytes());
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(ris_sequence.as_bytes());
 
         // Character set should be reset to ASCII
         assert_eq!(
-            ofs_buf.ansi_parser_support.character_set,
+            ofs_buf_vt_100.parser_global_state.character_set,
             CharacterSet::Ascii
         );
     }
 
     #[test]
     fn test_ris_basic_functionality() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Move cursor away from origin
-        ofs_buf.cursor_pos = Pos::new((RowIndex::new(ch(3)), ColIndex::new(ch(5))));
+        ofs_buf_vt_100.cursor_pos =
+            Pos::new((RowIndex::new(ch(3)), ColIndex::new(ch(5))));
 
         // Send RIS sequence
         let ris_sequence = format!("{}", EscSequence::ResetTerminal);
-        let _result = ofs_buf.apply_ansi_bytes(ris_sequence.as_bytes());
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(ris_sequence.as_bytes());
 
         // Verify basic reset occurred
-        assert_eq!(ofs_buf.cursor_pos, Pos::default());
+        assert_eq!(ofs_buf_vt_100.cursor_pos, Pos::default());
     }
 }
 
@@ -90,61 +92,61 @@ pub mod character_set_selection {
 
     #[test]
     fn test_select_ascii_character_set() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Start with DEC graphics
-        ofs_buf.ansi_parser_support.character_set = CharacterSet::DECGraphics;
+        ofs_buf_vt_100.parser_global_state.character_set = CharacterSet::DECGraphics;
 
         // Select ASCII character set (ESC ( B)
         let ascii_sequence = format!("{}", EscSequence::SelectAscii);
-        let _result = ofs_buf.apply_ansi_bytes(ascii_sequence.as_bytes());
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(ascii_sequence.as_bytes());
 
         // Character set should be ASCII
         assert_eq!(
-            ofs_buf.ansi_parser_support.character_set,
+            ofs_buf_vt_100.parser_global_state.character_set,
             CharacterSet::Ascii
         );
     }
 
     #[test]
     fn test_select_dec_graphics_character_set() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Start with ASCII
-        ofs_buf.ansi_parser_support.character_set = CharacterSet::Ascii;
+        ofs_buf_vt_100.parser_global_state.character_set = CharacterSet::Ascii;
 
         // Select DEC graphics character set (ESC ( 0)
         let graphics_sequence = format!("{}", EscSequence::SelectDECGraphics);
-        let _result = ofs_buf.apply_ansi_bytes(graphics_sequence.as_bytes());
+        let _result = ofs_buf_vt_100.apply_ansi_bytes(graphics_sequence.as_bytes());
 
         // Character set should be DEC graphics
         assert_eq!(
-            ofs_buf.ansi_parser_support.character_set,
+            ofs_buf_vt_100.parser_global_state.character_set,
             CharacterSet::DECGraphics
         );
     }
 
     #[test]
     fn test_basic_character_set_functionality() {
-        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+        let mut ofs_buf_vt_100 = create_test_offscreen_buffer_10r_by_10c();
 
         // Verify default character set
         assert_eq!(
-            ofs_buf.ansi_parser_support.character_set,
+            ofs_buf_vt_100.parser_global_state.character_set,
             CharacterSet::Ascii
         );
 
         // Switch to DEC graphics
-        ofs_buf.ansi_parser_support.character_set = CharacterSet::DECGraphics;
+        ofs_buf_vt_100.parser_global_state.character_set = CharacterSet::DECGraphics;
         assert_eq!(
-            ofs_buf.ansi_parser_support.character_set,
+            ofs_buf_vt_100.parser_global_state.character_set,
             CharacterSet::DECGraphics
         );
 
         // Switch back to ASCII
-        ofs_buf.ansi_parser_support.character_set = CharacterSet::Ascii;
+        ofs_buf_vt_100.parser_global_state.character_set = CharacterSet::Ascii;
         assert_eq!(
-            ofs_buf.ansi_parser_support.character_set,
+            ofs_buf_vt_100.parser_global_state.character_set,
             CharacterSet::Ascii
         );
     }

--- a/tui/src/core/common/get_mem_size.rs
+++ b/tui/src/core/common/get_mem_size.rs
@@ -40,7 +40,7 @@ pub fn ring_buffer_size<T: GetMemSize, const N: usize>(
 /// This struct wraps a memory size value and provides a `Display` implementation
 /// that shows the size in kilobytes with commas for readability, or "?" if the
 /// size is not available.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MemorySize {
     inner: Option<usize>,
 }

--- a/tui/src/core/coordinates/bounds_check/range_convert_ext.rs
+++ b/tui/src/core/coordinates/bounds_check/range_convert_ext.rs
@@ -240,7 +240,7 @@ use std::ops::{Add, Range, RangeInclusive};
 /// [`RangeInclusive`]: std::ops::RangeInclusive
 /// [`to_exclusive()`]: RangeConvertExt::to_exclusive
 /// [`VT-100`]:
-///     mod@crate::vt_100_pty_output_parser::operations::vt_100_shim_scroll_ops
+///     mod@crate::core::ansi::vt_100_pty_output_parser::ops::vt_100_shim_scroll_ops
 /// [Interval Notation]: mod@crate::bounds_check#interval-notation
 /// [Module documentation]: mod@crate::bounds_check
 pub trait RangeConvertExt {
@@ -257,7 +257,7 @@ pub trait RangeConvertExt {
     ///
     /// [`Range`]: std::ops::Range
     /// [`VT-100`]:
-    ///     mod@crate::vt_100_pty_output_parser::operations::vt_100_shim_scroll_ops
+    ///     mod@crate::core::ansi::vt_100_pty_output_parser::ops::vt_100_shim_scroll_ops
     /// [trait documentation]: Self
     #[must_use]
     fn to_exclusive(self) -> Range<Self::IndexType>;
@@ -270,7 +270,7 @@ pub trait RangeConvertExt {
 /// use with iteration and slice operations.
 ///
 /// [`VT-100`]:
-///     mod@crate::vt_100_pty_output_parser::operations::vt_100_shim_scroll_ops
+///     mod@crate::core::ansi::vt_100_pty_output_parser::ops::vt_100_shim_scroll_ops
 impl<I> RangeConvertExt for RangeInclusive<I>
 where
     I: IndexOps + Add<Output = I>,

--- a/tui/src/core/pty/pty_mux/input_router.rs
+++ b/tui/src/core/pty/pty_mux/input_router.rs
@@ -8,7 +8,10 @@
 //! [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
 
 use super::{ProcessManager, show_notification_non_blocking};
-use crate::{Continuation, InputEvent, Key, KeyPress, KeyState, ModifierKeysMask, PtyInputEvent, Size, core::{osc::OscController, terminal_io::OutputDevice}, ok};
+use crate::{Continuation, InputEvent, Key, KeyPress, KeyState, ModifierKeysMask,
+            PtyInputEvent, Size,
+            core::{osc::OscController, terminal_io::OutputDevice},
+            ok};
 
 /// Routes input events to appropriate handlers and manages dynamic keyboard shortcuts.
 #[derive(Debug)]
@@ -74,7 +77,7 @@ impl InputRouter {
                                     &format!("Switching to {process_name}"),
                                 );
 
-                                 process_manager.switch_to(process_index);
+                                process_manager.switch_to(process_index);
                                 Self::update_terminal_title(process_manager, osc)?;
                                 tracing::debug!("Process switch completed successfully");
                             }

--- a/tui/src/core/pty/pty_mux/mod.rs
+++ b/tui/src/core/pty/pty_mux/mod.rs
@@ -76,21 +76,21 @@
 //!
 //! - [`vt_100_pty_output_parser`]: The [`ANSI`] parser module that processes escape
 //!   sequences from child processes. The [`ProcessManager`] uses this via
-//!   [`OffscreenBuffer::apply_ansi_bytes`]
+//!   [`OfsBufVT100::apply_ansi_bytes`]
 //! - [`core::ansi`]: Parent module containing all [`ANSI`]/[`VT-100`] protocol handling
 //!
 //! [`ANSI Parser`]: crate::AnsiToOfsBufPerformer
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 //! [`core::ansi`]: mod@crate::core::ansi
-//! [`OffscreenBuffer::apply_ansi_bytes`]: crate::OffscreenBuffer::apply_ansi_bytes
 //! [`OffscreenBuffer`]: crate::OffscreenBuffer
+//! [`OfsBufVT100::apply_ansi_bytes`]: crate::OfsBufVT100::apply_ansi_bytes
 //! [`OSC`]: crate::osc_codes::OscSequence
 //! [`PTY Session`]: crate::PtySession
 //! [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
 //! [`readline_async`]: crate::readline_async::ReadlineAsyncContext::try_new
 //! [`TUI`]: crate::tui::TerminalWindow::main_event_loop
 //! [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
-//! [`vt_100_pty_output_parser`]: mod@crate::vt_100_pty_output_parser
+//! [`vt_100_pty_output_parser`]: mod@crate::core::ansi::vt_100_pty_output_parser
 
 // Attach.
 mod input_router;

--- a/tui/src/core/pty/pty_mux/mux.rs
+++ b/tui/src/core/pty/pty_mux/mux.rs
@@ -11,8 +11,8 @@
 
 use super::{InputRouter, OutputRenderer, Process, ProcessManager, output_renderer,
             show_notification_non_blocking};
-use crate::{AnsiSequenceGenerator, Continuation, PaintMode, DEBUG_TUI_PTY_MUX, InputEvent, RawMode,
-            Size, TerminalInteractiveStatus, TuiAvailability, col,
+use crate::{AnsiSequenceGenerator, Continuation, DEBUG_TUI_PTY_MUX, InputEvent,
+            PaintMode, RawMode, Size, TerminalInteractiveStatus, TuiAvailability, col,
             core::{check_is_terminal_interactive, emit_stderr_redirection_disclaimer,
                    get_size,
                    osc::OscController,

--- a/tui/src/core/pty/pty_mux/output_renderer.rs
+++ b/tui/src/core/pty/pty_mux/output_renderer.rs
@@ -10,16 +10,16 @@
 //! [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
 
 use super::ProcessManager;
-use crate::{ArrayBoundsCheck, PaintMode, ArrayOverflowResult, FlushKind, GCStringOwned, IndexOps,
-            OffscreenBuffer, OutputDevice, PixelChar, RangeExt, RenderOpsLocalData,
-            RenderOpCommon,
-            SPACE_CHAR, Size, TuiStyle, col,
+use crate::{ArrayBoundsCheck, ArrayOverflowResult, FlushKind, GCStringOwned, IndexOps,
+            OffscreenBuffer, OutputDevice, PaintMode, PixelChar, RangeExt,
+            RenderOpCommon, RenderOpsLocalData, SPACE_CHAR, Size, TuiStyle, col,
             core::coordinates::{idx, len},
             ok, print_text_with_attributes, row,
             tui::{DEBUG_TUI_PTY_MUX,
-                  terminal_lib_backends::{CursorVisibilityState, OffscreenBufferPaint,
+                  terminal_lib_backends::{OffscreenBufferPaint,
                                           OffscreenBufferPaintImpl}},
             tui_color,
+            CursorVisibilityState,
             tui_style_attrib::{self, Bold},
             tui_style_attribs, width};
 
@@ -90,12 +90,14 @@ impl OutputRenderer {
             }
         }
 
-        // Inherit the cursor and ANSI parser state.
+        // Inherit the cursor.
         composite_buffer.cursor_pos = active_buffer.cursor_pos;
-        composite_buffer.ansi_parser_support = active_buffer.ansi_parser_support.clone();
 
         // 1. Composite PTY virtual cursor if it's visible.
-        Self::composite_virtual_cursor_into_buffer(&mut composite_buffer);
+        Self::composite_virtual_cursor_into_buffer(
+            &mut composite_buffer,
+            active_buffer.parser_global_state.cursor_visibility,
+        );
 
         // 2. Composite status bar into the last row.
         self.composite_status_bar_into_buffer(&mut composite_buffer, process_manager);
@@ -117,10 +119,12 @@ impl OutputRenderer {
     /// [`Reverse`]: crate::tui_style_attrib::Reverse
     /// [display widths]: unicode-width
     /// [segmentation]: crate::graphemes
-    fn composite_virtual_cursor_into_buffer(ofs_buf: &mut OffscreenBuffer) {
+    pub fn composite_virtual_cursor_into_buffer(
+        ofs_buf: &mut OffscreenBuffer,
+        cursor_visibility: CursorVisibilityState,
+    ) {
         // Only do something if the child process requested a visible cursor.
-        if ofs_buf.ansi_parser_support.cursor_visibility == CursorVisibilityState::Hidden
-        {
+        if cursor_visibility == CursorVisibilityState::Hidden {
             return;
         }
 
@@ -354,12 +358,12 @@ impl OutputRenderer {
 /// # Note on Side Effects
 ///
 /// We explicitly push [`RenderOpCommon::HideCursor`] here instead of passing the parsed
-/// visibility state. This permanently suppresses the terminal emulator cursor when the multiplexer
-/// is active, preventing flickering and cursor parking issues.
+/// visibility state. This permanently suppresses the terminal emulator cursor when the
+/// multiplexer is active, preventing flickering and cursor parking issues.
 ///
 /// There is no danger of this messing up the chrome UI since it doesn't natively require
-/// a terminal emulator cursor. If interactive regions (like a find feature) are added to the
-/// chrome in the future, they will be handled by compositing another virtual caret.
+/// a terminal emulator cursor. If interactive regions (like a find feature) are added to
+/// the chrome in the future, they will be handled by compositing another virtual caret.
 fn paint_buffer(ofs_buf: &OffscreenBuffer, output_device: &OutputDevice) {
     let mut ofs_buf_paint_impl = OffscreenBufferPaintImpl {};
     let mut render_ops = ofs_buf_paint_impl.render(ofs_buf);

--- a/tui/src/core/pty/pty_mux/output_renderer.rs
+++ b/tui/src/core/pty/pty_mux/output_renderer.rs
@@ -12,6 +12,7 @@
 use super::ProcessManager;
 use crate::{ArrayBoundsCheck, PaintMode, ArrayOverflowResult, FlushKind, GCStringOwned, IndexOps,
             OffscreenBuffer, OutputDevice, PixelChar, RangeExt, RenderOpsLocalData,
+            RenderOpCommon,
             SPACE_CHAR, Size, TuiStyle, col,
             core::coordinates::{idx, len},
             ok, print_text_with_attributes, row,
@@ -352,7 +353,7 @@ impl OutputRenderer {
 ///
 /// # Note on Side Effects
 ///
-/// We explicitly pass [`CursorVisibilityState::Hidden`] here instead of the parsed
+/// We explicitly push [`RenderOpCommon::HideCursor`] here instead of passing the parsed
 /// visibility state. This permanently suppresses the terminal emulator cursor when the multiplexer
 /// is active, preventing flickering and cursor parking issues.
 ///
@@ -361,7 +362,8 @@ impl OutputRenderer {
 /// chrome in the future, they will be handled by compositing another virtual caret.
 fn paint_buffer(ofs_buf: &OffscreenBuffer, output_device: &OutputDevice) {
     let mut ofs_buf_paint_impl = OffscreenBufferPaintImpl {};
-    let render_ops = ofs_buf_paint_impl.render(ofs_buf);
+    let mut render_ops = ofs_buf_paint_impl.render(ofs_buf);
+    render_ops.push(RenderOpCommon::HideCursor);
     output_device.write(|out| {
         ofs_buf_paint_impl.paint(
             render_ops,
@@ -369,7 +371,6 @@ fn paint_buffer(ofs_buf: &OffscreenBuffer, output_device: &OutputDevice) {
             ofs_buf.window_size,
             out,
             PaintMode::Real,
-            CursorVisibilityState::Hidden, // Always hide the terminal emulator cursor
         );
     });
 }

--- a/tui/src/core/pty/pty_mux/process_manager.rs
+++ b/tui/src/core/pty/pty_mux/process_manager.rs
@@ -7,11 +7,12 @@
 //! parser]. Process switching is instant - just display a different buffer.
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
+//! [`OffscreenBuffer`]: crate::OffscreenBuffer
 //! [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
 //! [ANSI parser]: crate::AnsiToOfsBufPerformer
 
 use super::output_renderer::STATUS_BAR_HEIGHT;
-use crate::{OffscreenBuffer, Size,
+use crate::{OfsBufVT100, Size,
             core::{osc::OscEvent,
                    pty::{PtyInputEvent, PtyOutputEvent, PtySession, PtySessionBuilder}},
             height, ok};
@@ -29,7 +30,7 @@ pub struct ProcessManager {
 
 /// Represents a single process that can be managed by the multiplexer.
 ///
-/// Each process maintains its own virtual terminal state through an [`OffscreenBuffer`]
+/// Each process maintains its own virtual terminal state through a [`OfsBufVT100`]
 /// and [`ANSI parser`], enabling true terminal multiplexing where switching between
 /// processes is instant and preserves the complete terminal state.
 ///
@@ -48,7 +49,7 @@ pub struct Process {
     /// Whether the process is currently running
     is_running: bool,
     /// Virtual terminal buffer for this process (per-process buffer architecture)
-    ofs_buf: OffscreenBuffer,
+    pub terminal_state: OfsBufVT100,
 
     /// Tracks if this process has unrendered output since last render
     has_unrendered_output: bool,
@@ -83,7 +84,7 @@ impl Process {
             args,
             session: None,
             is_running: false,
-            ofs_buf: OffscreenBuffer::new_empty(buffer_size),
+            terminal_state: OfsBufVT100::new_empty(buffer_size),
 
             has_unrendered_output: false,
             terminal_title: None,
@@ -97,7 +98,7 @@ impl Process {
     /// Updates the process's virtual terminal buffer with new [`PTY`] output.
     ///
     /// This is the core of the per-process virtual terminal architecture: Each process
-    /// maintains its own complete terminal state through an [`OffscreenBuffer`]. Raw
+    /// maintains its own complete terminal state through a [`OfsBufVT100`]. Raw
     /// [`PTY`] bytes are processed through the [`ANSI`] parser and converted into
     /// [`PixelChar`] updates in the virtual terminal buffer.
     ///
@@ -110,7 +111,8 @@ impl Process {
     pub fn process_pty_output_and_update_buffer(&mut self, output: Vec<u8>) {
         if !output.is_empty() {
             // Process bytes and extract any OSC and DSR events.
-            let (osc_events, dsr_requests) = self.ofs_buf.apply_ansi_bytes(&output);
+            let (osc_events, dsr_requests) =
+                self.terminal_state.apply_ansi_bytes(&output);
 
             // Handle any OSC events that were detected.
             for event in osc_events {
@@ -152,7 +154,7 @@ impl Process {
                 "Process '{}' updated buffer with {} bytes, cursor at {:?}",
                 self.name,
                 output.len(),
-                self.ofs_buf.cursor_pos
+                self.terminal_state.cursor_pos
             );
         }
     }
@@ -202,7 +204,7 @@ impl Debug for Process {
             .field("args", &self.args)
             .field("session", &self.session)
             .field("is_running", &self.is_running)
-            .field("offscreen_buffer", &self.ofs_buf)
+            .field("terminal_state", &self.terminal_state)
             .field("has_unrendered_output", &self.has_unrendered_output)
             .field("terminal_title", &self.terminal_title)
             .finish()
@@ -258,7 +260,7 @@ impl ProcessManager {
     /// 3. The next render will display the target process's virtual terminal
     ///
     /// **Why this works universally**:
-    /// - TUI apps: Their complete screen state is preserved in the [`OffscreenBuffer`]
+    /// - TUI apps: Their complete screen state is preserved in the [`OfsBufVT100`]
     /// - bash: Your command history and current prompt state remain intact
     /// - CLI tools: All their output is preserved exactly as they generated it
     pub fn switch_to(&mut self, index: usize) -> Option<usize> {
@@ -315,7 +317,7 @@ impl ProcessManager {
     ///
     /// **Key Innovation**: ALL processes are polled continuously, not just the active
     /// one. Each process maintains its own complete virtual terminal state through its
-    /// [`OffscreenBuffer`]. When you switch between processes, you're instantly seeing
+    /// [`OfsBufVT100`]. When you switch between processes, you're instantly seeing
     /// their maintained terminal state - no delays, no fake resize tricks needed.
     ///
     /// **How it works**:
@@ -390,8 +392,8 @@ impl ProcessManager {
 
     /// Gets read-only access to the active process's virtual terminal buffer.
     #[must_use]
-    pub fn get_active_buffer(&self) -> &OffscreenBuffer {
-        &self.processes[self.active_index].ofs_buf
+    pub fn get_active_buffer(&self) -> &OfsBufVT100 {
+        &self.processes[self.active_index].terminal_state
     }
 
     /// Marks the active process as having been rendered.
@@ -424,7 +426,7 @@ impl ProcessManager {
         // Update all processes with new buffers and parsers.
         for (i, process) in self.processes.iter_mut().enumerate() {
             // Create fresh buffer at new size.
-            process.ofs_buf = OffscreenBuffer::new_empty(pty_size);
+            process.terminal_state = OfsBufVT100::new_empty(pty_size);
 
             // Clear unrendered output flag since we're starting fresh.
             process.has_unrendered_output = false;

--- a/tui/src/core/terminal_io/backend_compat_tests/backend_compat_input_test.rs
+++ b/tui/src/core/terminal_io/backend_compat_tests/backend_compat_input_test.rs
@@ -61,8 +61,18 @@
 //! [`terminal_raw_mode::raw_mode_unix::enable_raw_mode`]:
 //!     crate::terminal_raw_mode::raw_mode_unix::enable_raw_mode
 
-use crate::{ARROW_DOWN_FINAL, ARROW_LEFT_FINAL, ARROW_RIGHT_FINAL, ARROW_UP_FINAL, ASCII_DEL, CONTROL_C, CONTROL_ENTER, CONTROL_TAB, CrosstermInputDevice, EIO, FUNCTION_F5_CODE, GLYPH_CONTROLLED, GLYPH_FAILURE, GLYPH_SUCCESS, GLYPH_WAITING, MODIFIER_ALT, MODIFIER_CTRL, MODIFIER_CTRL_SHIFT, MODIFIER_SHIFT, MSG_CONTROLLED_READY, PtyPair, PtyTestChild, SPECIAL_DELETE_CODE, SPECIAL_END_FINAL, SPECIAL_HOME_FINAL, SPECIAL_INSERT_CODE, SPECIAL_PAGE_DOWN_CODE, SPECIAL_PAGE_UP_CODE, SS3_F1_FINAL, SS3_F2_FINAL, SS3_F3_FINAL, SS3_F4_FINAL, core::ansi::{generator::{csi, csi_modified, csi_tilde, ss3},
-                         terminal_raw_mode}, ok, retry_until_success_test, spawn_controlled_in_pty, tui::terminal_lib_backends::direct_to_ansi::DirectToAnsiInputDevice};
+use crate::{ARROW_DOWN_FINAL, ARROW_LEFT_FINAL, ARROW_RIGHT_FINAL, ARROW_UP_FINAL,
+            ASCII_DEL, CONTROL_C, CONTROL_ENTER, CONTROL_TAB, CrosstermInputDevice, EIO,
+            FUNCTION_F5_CODE, GLYPH_CONTROLLED, GLYPH_FAILURE, GLYPH_SUCCESS,
+            GLYPH_WAITING, MODIFIER_ALT, MODIFIER_CTRL, MODIFIER_CTRL_SHIFT,
+            MODIFIER_SHIFT, MSG_CONTROLLED_READY, PtyPair, PtyTestChild,
+            SPECIAL_DELETE_CODE, SPECIAL_END_FINAL, SPECIAL_HOME_FINAL,
+            SPECIAL_INSERT_CODE, SPECIAL_PAGE_DOWN_CODE, SPECIAL_PAGE_UP_CODE,
+            SS3_F1_FINAL, SS3_F2_FINAL, SS3_F3_FINAL, SS3_F4_FINAL,
+            core::ansi::{generator::{csi, csi_modified, csi_tilde, ss3},
+                         terminal_raw_mode},
+            ok, retry_until_success_test, spawn_controlled_in_pty,
+            tui::terminal_lib_backends::direct_to_ansi::DirectToAnsiInputDevice};
 use std::{collections::HashMap,
           fmt::Write as _,
           io::{BufRead, Write}};

--- a/tui/src/core/terminal_io/backend_compat_tests/backend_compat_output_test.rs
+++ b/tui/src/core/terminal_io/backend_compat_tests/backend_compat_output_test.rs
@@ -47,10 +47,10 @@
 //!           ┌──────────────────────────────────────────────────────────────┐
 //!           │                  SNAPSHOT COMPARISON TEST                    │
 //!           │ Raw ANSI byte sequences may DIFFER between backends, but     │
-//!           │ resulting terminal STATE (OffscreenBuffer) must be IDENTICAL │
+//!           │ resulting terminal STATE (OfsBufVT100) must be IDENTICAL     │
 //!           │                                                              │
 //!           │   ┌─────────────────┐         ┌─────────────────┐            │
-//!           │   │ OffscreenBuffer │   ==    │ OffscreenBuffer │            │
+//!           │   │ OfsBufVT100     │   ==    │ OfsBufVT100     │            │
 //!           │   │    (direct)     │─────────│   (crossterm)   │            │
 //!           │   └────────▲────────┘         └───▲─────────────┘            │
 //!           │            │                      │                          │
@@ -91,11 +91,11 @@
 //!  └───────────────────────────────────┘   └───────────────────────────────────┘
 //! ```
 //!
-//! # Why `OffscreenBuffer` Comparison?
+//! # Why [`OfsBufVT100`] Comparison?
 //!
 //! The raw [`ANSI`] bytes from each backend may differ in encoding (e.g., crossterm might
 //! use different [`CSI`] parameter formats), but they should produce **identical terminal
-//! state**. By applying bytes to [`OffscreenBuffer`]s and comparing those, we test
+//! state**. By applying bytes to [`OfsBufVT100`]s and comparing those, we test
 //! semantic equivalence rather than byte-for-byte equality. This is a rendered output
 //! snapshot test that confirms that both backends "look the same" at the end, regardless
 //! what [`ANSI`] escape code encoded byte sequences they used to get there.
@@ -112,7 +112,7 @@
 //! [`Crossterm`]: crate::TerminalLibBackend::Crossterm
 //! [`CSI`]: crate::CsiSequence
 //! [`DirectToAnsi`]: crate::TerminalLibBackend::DirectToAnsi
-//! [`OffscreenBuffer`]: crate::OffscreenBuffer
+//! [`OfsBufVT100`]: crate::OfsBufVT100
 //! [`PaintRenderOpImplCrossterm`]: crate::crossterm_backend::PaintRenderOpImplCrossterm
 //! [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
 //! [`RenderOpOutput`]: crate::RenderOpOutput
@@ -124,12 +124,13 @@
 //! [`terminal_raw_mode::raw_mode_unix::enable_raw_mode()`]:
 //!     crate::terminal_raw_mode::raw_mode_unix::enable_raw_mode
 
-use crate::{ColorSupport, EIO, InlineString, MSG_CONTROLLED_READY, OffscreenBuffer,
+use crate::{ColorSupport, EIO, InlineString, MSG_CONTROLLED_READY, OfsBufVT100,
             OutputDevice, PtyPair, PtyTestChild, RenderOpOutput, RenderOpPaint,
             RenderOpsLocalData, Size, TuiStyle, TuiStyleAttribs, col,
-            core::ansi::terminal_raw_mode, global_color_support, height, ok, pos,
-            render_op::RenderOpCommon, retry_until_success_test, row,
-            spawn_controlled_in_pty,
+            core::ansi::terminal_raw_mode,
+            global_color_support, height, ok, pos,
+            render_op::RenderOpCommon,
+            retry_until_success_test, row, spawn_controlled_in_pty,
             terminal_lib_backends::{crossterm_backend::PaintRenderOpImplCrossterm,
                                     direct_to_ansi::RenderOpPaintImplDirectToAnsi},
             tui_color, tui_style_attrib, width};
@@ -152,7 +153,7 @@ const OUTPUT_TEST_ENV_VAR: &str = "R3BL_PTY_OUTPUT_TEST_CONTROLLED";
 /// Runs both backend tests and compares their rendered outputs.
 ///
 /// Creates [`PTY`] pairs directly (no subprocess indirection), captures raw [`ANSI`]
-/// output from each backend, applies to [`OffscreenBuffer`]s, and compares.
+/// output from each backend, applies to [`OfsBufVT100`]s, and compares.
 ///
 /// # Panics
 ///
@@ -207,8 +208,8 @@ fn run_single_test_attempt() -> Result<(), String> {
 
     // Create OffscreenBuffers and apply the captured ANSI bytes.
     let buffer_size = height(TEST_HEIGHT) + width(TEST_WIDTH);
-    let mut buffer_direct = OffscreenBuffer::new_empty(buffer_size);
-    let mut buffer_crossterm = OffscreenBuffer::new_empty(buffer_size);
+    let mut buffer_direct = OfsBufVT100::new_empty(buffer_size);
+    let mut buffer_crossterm = OfsBufVT100::new_empty(buffer_size);
 
     drop(buffer_direct.apply_ansi_bytes(&direct_bytes));
     drop(buffer_crossterm.apply_ansi_bytes(&crossterm_bytes));
@@ -279,7 +280,9 @@ pub mod controller {
     ///
     /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
     /// [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
-    pub fn run((backend_name, pty_pair, child): (&str, PtyPair, &PtyTestChild)) -> Result<Vec<u8>, String> {
+    pub fn run(
+        (backend_name, pty_pair, child): (&str, PtyPair, &PtyTestChild),
+    ) -> Result<Vec<u8>, String> {
         eprintln!("{backend_name} Controller: Starting...");
 
         let reader = pty_pair
@@ -482,7 +485,7 @@ pub mod generate_test_render_ops {
     /// All test render operation sequences for backend compatibility testing.
     ///
     /// Returns render ops that will be executed by both backends for comparison. The
-    /// resulting terminal state (`OffscreenBuffer`) should be identical.
+    /// resulting terminal state (`OfsBufVT100`) should be identical.
     #[must_use]
     #[allow(clippy::too_many_lines, clippy::vec_init_then_push)]
     pub fn all() -> Vec<RenderOpOutput> {

--- a/tui/src/core/terminal_io/backend_compat_tests/mod.rs
+++ b/tui/src/core/terminal_io/backend_compat_tests/mod.rs
@@ -28,7 +28,7 @@
 //!
 //! - A controlled process executes [`RenderOpOutput`] via the specific backend
 //! - [`ANSI`] output is captured and written to stdout ([`PTY`] controlled side)
-//! - The main test applies both outputs to [`OffscreenBuffer`] and compares
+//! - The main test applies both outputs to [`OfsBufVT100`] and compares
 //!
 //! # Platform Support
 //!
@@ -36,19 +36,19 @@
 //! both [`DirectToAnsiInputDevice`] and the `DirectToAnsi` output backend, which are
 //! only available on Linux.
 //!
-//! | Test                                   | Linux   | macOS   | Windows   |
-//! | :------------------------------------- | :------ | :------ | :-------- |
-//! | [`test_pty_backend_direct_to_ansi`]    | ✅      | ❌      | ❌        |
-//! | [`test_pty_backend_crossterm`]         | ✅      | ❌      | ❌        |
-//! | [`test_backend_compat_input_compare`]  | ✅      | ❌      | ❌        |
-//! | [`test_backend_compat_output_compare`] | ✅      | ❌      | ❌        |
+//! | Test                                   | Linux | macOS | Windows |
+//! | :------------------------------------- | :---- | :---- | :------ |
+//! | [`test_pty_backend_direct_to_ansi`]    | ✅    | ❌    | ❌      |
+//! | [`test_pty_backend_crossterm`]         | ✅    | ❌    | ❌      |
+//! | [`test_backend_compat_input_compare`]  | ✅    | ❌    | ❌      |
+//! | [`test_backend_compat_output_compare`] | ✅    | ❌    | ❌      |
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 //! [`CrosstermInputDevice`]: crate::CrosstermInputDevice
 //! [`DirectToAnsiInputDevice`]: crate::direct_to_ansi::DirectToAnsiInputDevice
 //! [`InputDevice`]: crate::InputDevice
 //! [`InputEvent`]: crate::InputEvent
-//! [`OffscreenBuffer`]: crate::OffscreenBuffer
+//! [`OfsBufVT100`]: crate::OfsBufVT100
 //! [`PaintRenderOpImplCrossterm`]: crate::crossterm_backend::PaintRenderOpImplCrossterm
 //! [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
 //! [`RenderOpOutput`]: crate::RenderOpOutput

--- a/tui/src/lib.rs
+++ b/tui/src/lib.rs
@@ -2002,7 +2002,7 @@
 //! pty_mux (receives child process output)
 //!      │
 //!      ▼
-//! OffscreenBuffer::apply_ansi_bytes()
+//! OfsBufVT100::apply_ansi_bytes()
 //!      │
 //!      │ Uses VTE state machine
 //!      ▼
@@ -2018,7 +2018,7 @@
 //! ## In-memory terminal emulation
 //!
 //! [`OffscreenBuffer`] can function as a **standalone in-memory terminal emulator**. By
-//! calling [`OffscreenBuffer::apply_ansi_bytes()`], you can feed raw `VT-100` ANSI escape
+//! calling [`OfsBufVT100::apply_ansi_bytes()`], you can feed raw `VT-100` ANSI escape
 //! sequences directly into the buffer — no real terminal or PTY required:
 //!
 //! <!-- It is ok to use ignore here - demonstrates API usage with types not importable
@@ -2518,7 +2518,7 @@
 //! **Three-layer architecture** for maintainability:
 //! ```text
 //! Layer 1: SHIM           → Protocol delegation (vt_100_shim_char_ops)
-//! Layer 2: IMPLEMENTATION → Business logic (vt_100_impl_char_ops)
+//! Layer 2: IMPLEMENTATION → Business logic (impl_char_ops)
 //! Layer 3: TESTS          → Conformance validation (vt_100_test_char_ops)
 //! ```
 //!
@@ -2785,7 +2785,7 @@
 //! [CsiSequence]: crate::CsiSequence
 //! [EscSequence]: crate::EscSequence
 //! [SgrCode]: crate::SgrCode
-//! [`vt_100_pty_output_parser`]: mod@crate::vt_100_pty_output_parser
+//! [`vt_100_pty_output_parser`]: mod@crate::core::ansi::vt_100_pty_output_parser
 //! [RowIndex]: crate::RowIndex
 //! [ColIndex]: crate::ColIndex
 //! [ColWidth]: crate::ColWidth
@@ -2845,7 +2845,7 @@
 //! [`RawModeGuard`]: crate::RawModeGuard
 //! [`terminal_raw_mode`]: crate::terminal_raw_mode
 //! [`raw_mode_unix`]: crate::terminal_raw_mode::raw_mode_unix
-//! [`OffscreenBuffer::apply_ansi_bytes()`]: crate::OffscreenBuffer::apply_ansi_bytes
+//! [`OfsBufVT100::apply_ansi_bytes()`]: crate::OfsBufVT100::apply_ansi_bytes
 //! [`RRT`]: crate::RRT
 //! [`SubscriberGuard`]: crate::SubscriberGuard
 //! [`RRTWorker`]: crate::RRTWorker

--- a/tui/src/readline_async/readline_async_impl/readline_async_integration_tests/pty_multiline_output_test.rs
+++ b/tui/src/readline_async/readline_async_impl/readline_async_integration_tests/pty_multiline_output_test.rs
@@ -104,7 +104,7 @@
 //!   │  │                                                 │                  │  │
 //!   │  │                                                 ▼                  │  │
 //!   │  │                                         ┌─────────────────┐        │  │
-//!   │  │                                         │ OffscreenBuffer │        │  │
+//!   │  │                                         │ OfsBufVT100     │        │  │
 //!   │  │                                         │ .apply_ansi     │        │  │
 //!   │  │                                         │ _bytes()        │        │  │
 //!   │  │                                         │                 │        │  │
@@ -130,7 +130,7 @@
 //! A simple [`Write`] implementation that captures raw bytes (including [`ANSI`] escape
 //! sequences) for later processing. See the [blank line test] for detailed docs.
 //!
-//! ## [`OffscreenBuffer::apply_ansi_bytes`]
+//! ## [`OfsBufVT100::apply_ansi_bytes`]
 //!
 //! Parses [`ANSI`] escape sequences and renders them to a virtual terminal buffer. This
 //! gives us the **exact visual output** a user would see, allowing us to verify column
@@ -163,12 +163,15 @@
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 //! [`CHA(1)`]: crate::CsiSequence::CursorHorizontalAbsolute
-//! [`OffscreenBuffer::apply_ansi_bytes`]: crate::OffscreenBuffer::apply_ansi_bytes
+//! [`OfsBufVT100::apply_ansi_bytes`]: crate::OfsBufVT100::apply_ansi_bytes
 //! [`PTY`]: crate::core::pty
 //! [`SharedWriter`]: crate::SharedWriter
 //! [blank line test]: super::pty_shared_writer_no_blank_line_test
 
-use crate::{GLYPH_CONTROLLED, GLYPH_CONTROLLER, GLYPH_SUCCESS, LineStateControlSignal, MSG_CONTROLLED_STARTING, MSG_TEST_RUNNING, OffscreenBuffer, PtyTestContext, PtyTestMode, SharedWriter, Size, generate_pty_test, height, ok, readline_async::readline_async_impl::LineState, width};
+use crate::{GLYPH_CONTROLLED, GLYPH_CONTROLLER, GLYPH_SUCCESS, LineStateControlSignal,
+            MSG_CONTROLLED_STARTING, MSG_TEST_RUNNING, OfsBufVT100, PtyTestContext,
+            PtyTestMode, SharedWriter, Size, generate_pty_test, height, ok,
+            readline_async::readline_async_impl::LineState, width};
 use std::io::Write;
 
 generate_pty_test! {
@@ -265,11 +268,11 @@ fn controller(context: PtyTestContext) {
 }
 
 /// Captures raw [`ANSI`] bytes for later processing with
-/// [`OffscreenBuffer::apply_ansi_bytes`].
+/// [`OfsBufVT100::apply_ansi_bytes`].
 ///
 /// This struct implements [`Write`] to collect terminal output bytes (including escape
 /// sequences) that would normally go to stdout. The captured bytes can then be fed to
-/// [`OffscreenBuffer::apply_ansi_bytes`] to render them in a virtual terminal buffer,
+/// [`OfsBufVT100::apply_ansi_bytes`] to render them in a virtual terminal buffer,
 /// allowing inspection of the exact visual output.
 ///
 /// # Example Flow
@@ -284,13 +287,13 @@ fn controller(context: PtyTestContext) {
 ///           │ take_bytes()
 ///           ▼
 /// ┌─────────────────────┐
-/// │ OffscreenBuffer     │  ← Renders to virtual 2D grid
+/// │ OfsBufVT100         │  ← Renders to virtual 2D grid
 /// │ .apply_ansi_bytes() │
 /// └─────────────────────┘
 /// ```
 ///
 /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
-/// [`OffscreenBuffer::apply_ansi_bytes`]: crate::OffscreenBuffer::apply_ansi_bytes
+/// [`OfsBufVT100::apply_ansi_bytes`]: crate::OfsBufVT100::apply_ansi_bytes
 struct CaptureOutputBytes(Vec<u8>);
 
 impl CaptureOutputBytes {
@@ -306,10 +309,10 @@ impl Write for CaptureOutputBytes {
     fn flush(&mut self) -> std::io::Result<()> { ok!() }
 }
 
-/// Extracts text content from an [`OffscreenBuffer`] row for verification.
+/// Extracts text content from an [`OfsBufVT100`] row for verification.
 ///
-/// [`OffscreenBuffer`]: crate::OffscreenBuffer
-fn get_line_content(buf: &crate::OffscreenBuffer, row: usize, max_cols: usize) -> String {
+/// [`OfsBufVT100`]: crate::OfsBufVT100
+fn get_line_content(buf: &crate::OfsBufVT100, row: usize, max_cols: usize) -> String {
     buf.buffer[row]
         .iter()
         .take(max_cols)
@@ -323,13 +326,13 @@ fn get_line_content(buf: &crate::OffscreenBuffer, row: usize, max_cols: usize) -
 }
 
 /// [`PTY`] controlled process: simulates multi-line [`SharedWriter`] output and verifies
-/// column alignment via [`OffscreenBuffer::apply_ansi_bytes`].
+/// column alignment via [`OfsBufVT100::apply_ansi_bytes`].
 ///
 /// See the [module docs] for the full test architecture.
 ///
 /// The harness performs [`std::process::exit(0)`] after this function returns.
 ///
-/// [`OffscreenBuffer::apply_ansi_bytes`]: crate::OffscreenBuffer::apply_ansi_bytes
+/// [`OfsBufVT100::apply_ansi_bytes`]: crate::OfsBufVT100::apply_ansi_bytes
 /// [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
 /// [`SharedWriter`]: crate::SharedWriter
 /// [module docs]: self
@@ -371,9 +374,9 @@ fn controlled() {
         }
     });
 
-    // Now apply the captured ANSI bytes to an OffscreenBuffer to see the actual
+    // Now apply the captured ANSI bytes to an OfsBufVT100 to see the actual
     // rendered output - this is what the user would see in the terminal.
-    let mut ofs_buf = OffscreenBuffer::new_empty(height(24) + width(80));
+    let mut ofs_buf = OfsBufVT100::new_empty(height(24) + width(80));
     let captured_bytes = capture_output_bytes.take_bytes();
     let _events = ofs_buf.apply_ansi_bytes(&captured_bytes);
 

--- a/tui/src/readline_async/readline_async_impl/readline_async_integration_tests/pty_shared_writer_no_blank_line_test.rs
+++ b/tui/src/readline_async/readline_async_impl/readline_async_integration_tests/pty_shared_writer_no_blank_line_test.rs
@@ -85,7 +85,7 @@
 //!   │  │                                                 │                  │  │
 //!   │  │                                                 ▼                  │  │
 //!   │  │                                         ┌────────────────┐         │  │
-//!   │  │                                         │ OffscreenBuffer│         │  │
+//!   │  │                                         │ OfsBufVT100    │         │  │
 //!   │  │                                         │ .apply_ansi    │         │  │
 //!   │  │                                         │ _bytes()       │         │  │
 //!   │  │                                         │                │         │  │
@@ -127,7 +127,7 @@
 //! └─────────────────────────────────────────────────────────────────────────────┘
 //! ```
 //!
-//! ## [`OffscreenBuffer::apply_ansi_bytes`]
+//! ## [`OfsBufVT100::apply_ansi_bytes`]
 //!
 //! Parses [`ANSI`] escape sequences and renders them to a virtual terminal buffer, giving
 //! us the **exact visual output** a user would see:
@@ -154,7 +154,7 @@
 //! │                     │                                                       │
 //! │                     ▼                                                       │
 //! │   ┌─────────────────────────────────────────────────────────────────────┐   │
-//! │   │ OffscreenBuffer (2D grid of PixelChars)                             │   │
+//! │   │ OfsBufVT100 (2D grid of PixelChars)                                 │   │
 //! │   │                                                                     │   │
 //! │   │   Col:  0   1   2   3   4                                           │   │
 //! │   │       ┌───┬───┬───┬───┬───┐                                         │   │
@@ -190,11 +190,15 @@
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 //! [`CHA(1)`]: crate::CsiSequence::CursorHorizontalAbsolute
-//! [`OffscreenBuffer::apply_ansi_bytes`]: crate::OffscreenBuffer::apply_ansi_bytes
+//! [`OfsBufVT100::apply_ansi_bytes`]: crate::OfsBufVT100::apply_ansi_bytes
 //! [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
 //! [`SharedWriter`]: crate::SharedWriter
 
-use crate::{GLYPH_CONTROLLED, GLYPH_CONTROLLER, GLYPH_SUCCESS, GLYPH_WARNING, LineStateControlSignal, MSG_CONTROLLED_STARTING, MSG_TEST_RUNNING, OffscreenBuffer, PtyTestContext, PtyTestMode, SharedWriter, Size, generate_pty_test, height, ok, readline_async::readline_async_impl::LineState, width};
+use crate::{GLYPH_CONTROLLED, GLYPH_CONTROLLER, GLYPH_SUCCESS, GLYPH_WARNING,
+            LineStateControlSignal, MSG_CONTROLLED_STARTING, MSG_TEST_RUNNING,
+            OfsBufVT100, PtyTestContext, PtyTestMode, SharedWriter, Size,
+            generate_pty_test, height, ok,
+            readline_async::readline_async_impl::LineState, width};
 use std::io::Write;
 
 generate_pty_test! {
@@ -274,11 +278,11 @@ fn controller(context: PtyTestContext) {
 }
 
 /// Captures raw [`ANSI`] bytes for later processing with
-/// [`OffscreenBuffer::apply_ansi_bytes`].
+/// [`OfsBufVT100::apply_ansi_bytes`].
 ///
 /// This struct implements [`Write`] to collect terminal output bytes (including escape
 /// sequences) that would normally go to stdout. The captured bytes can then be fed to
-/// [`OffscreenBuffer::apply_ansi_bytes`] to render them in a virtual terminal buffer,
+/// [`OfsBufVT100::apply_ansi_bytes`] to render them in a virtual terminal buffer,
 /// allowing inspection of the exact visual output.
 ///
 /// # Example Flow
@@ -293,13 +297,13 @@ fn controller(context: PtyTestContext) {
 ///           │ take_bytes()
 ///           ▼
 /// ┌─────────────────────┐
-/// │ OffscreenBuffer     │  ← Renders to virtual 2D grid
+/// │ OfsBufVT100         │  ← Renders to virtual 2D grid
 /// │ .apply_ansi_bytes() │
 /// └─────────────────────┘
 /// ```
 ///
 /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
-/// [`OffscreenBuffer::apply_ansi_bytes`]: crate::OffscreenBuffer::apply_ansi_bytes
+/// [`OfsBufVT100::apply_ansi_bytes`]: crate::OfsBufVT100::apply_ansi_bytes
 struct CaptureOutputBytes(Vec<u8>);
 
 impl CaptureOutputBytes {
@@ -315,10 +319,10 @@ impl Write for CaptureOutputBytes {
     fn flush(&mut self) -> std::io::Result<()> { ok!() }
 }
 
-/// Extracts text content from an [`OffscreenBuffer`] row for verification.
+/// Extracts text content from an [`OfsBufVT100`] row for verification.
 ///
-/// [`OffscreenBuffer`]: crate::OffscreenBuffer
-fn get_line_content(buf: &crate::OffscreenBuffer, row: usize, max_cols: usize) -> String {
+/// [`OfsBufVT100`]: crate::OfsBufVT100
+fn get_line_content(buf: &crate::OfsBufVT100, row: usize, max_cols: usize) -> String {
     buf.buffer[row]
         .iter()
         .take(max_cols)
@@ -332,13 +336,13 @@ fn get_line_content(buf: &crate::OffscreenBuffer, row: usize, max_cols: usize) -
 }
 
 /// [`PTY`] controlled process: simulates [`SharedWriter`] output and checks for blank
-/// lines before the prompt via [`OffscreenBuffer::apply_ansi_bytes`].
+/// lines before the prompt via [`OfsBufVT100::apply_ansi_bytes`].
 ///
 /// See the [module docs] for the full test architecture.
 ///
 /// The harness performs [`std::process::exit(0)`] after this function returns.
 ///
-/// [`OffscreenBuffer::apply_ansi_bytes`]: crate::OffscreenBuffer::apply_ansi_bytes
+/// [`OfsBufVT100::apply_ansi_bytes`]: crate::OfsBufVT100::apply_ansi_bytes
 /// [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
 /// [`SharedWriter`]: crate::SharedWriter
 /// [module docs]: self
@@ -377,9 +381,9 @@ fn controlled() {
         }
     });
 
-    // Apply the captured ANSI bytes to an OffscreenBuffer to see the actual
+    // Apply the captured ANSI bytes to an OfsBufVT100 to see the actual
     // rendered output - this is what the user would see in the terminal.
-    let mut ofs_buf = OffscreenBuffer::new_empty(height(24) + width(80));
+    let mut ofs_buf = OfsBufVT100::new_empty(height(24) + width(80));
     let captured_bytes = capture_output_bytes.take_bytes();
     let _events = ofs_buf.apply_ansi_bytes(&captured_bytes);
 

--- a/tui/src/tui/terminal_lib_backends/compositor_render_ops_to_ofs_buf.rs
+++ b/tui/src/tui/terminal_lib_backends/compositor_render_ops_to_ofs_buf.rs
@@ -70,8 +70,7 @@
 //! [`render_pipeline`]: mod@crate::render_pipeline
 //! [rendering pipeline overview]: mod@crate::terminal_lib_backends#rendering-pipeline-architecture
 
-use super::{AlternateScreenState, BracketedPasteState, MouseTrackingState,
-            OffscreenBuffer, RawModeState, RenderOpCommon, RenderOpIR, RenderPipeline,
+use super::{OffscreenBuffer, RenderOpCommon, RenderOpIR, RenderPipeline,
             sanitize_and_save_abs_pos};
 use crate::{ColWidth, CommonError, CommonErrorType, CommonResult, DEBUG_TUI_COMPOSITOR,
             GCStringOwned, MemoizedLenMap, PixelChar, PixelCharLine, Pos,
@@ -169,32 +168,10 @@ fn process_common_render_op(
 ) {
     match common_op {
         // ===== Terminal Mode State Operations =====
-        // These operations update the OffscreenBuffer's terminal mode state while also
-        // being executed by the terminal backend to affect actual terminal behavior.
-        RenderOpCommon::EnterRawMode => {
-            ofs_buf.terminal_mode.raw_mode = RawModeState::Enabled;
-        }
-        RenderOpCommon::ExitRawMode => {
-            ofs_buf.terminal_mode.raw_mode = RawModeState::Disabled;
-        }
-        RenderOpCommon::EnterAlternateScreen => {
-            ofs_buf.terminal_mode.alternate_screen = AlternateScreenState::Active;
-        }
-        RenderOpCommon::ExitAlternateScreen => {
-            ofs_buf.terminal_mode.alternate_screen = AlternateScreenState::Inactive;
-        }
-        RenderOpCommon::EnableMouseTracking => {
-            ofs_buf.terminal_mode.mouse_tracking = MouseTrackingState::Enabled;
-        }
-        RenderOpCommon::DisableMouseTracking => {
-            ofs_buf.terminal_mode.mouse_tracking = MouseTrackingState::Disabled;
-        }
-        RenderOpCommon::EnableBracketedPaste => {
-            ofs_buf.terminal_mode.bracketed_paste = BracketedPasteState::Enabled;
-        }
-        RenderOpCommon::DisableBracketedPaste => {
-            ofs_buf.terminal_mode.bracketed_paste = BracketedPasteState::Disabled;
-        }
+        // These operations update the terminal mode state in the backend, but the
+        // OffscreenBuffer no longer tracks terminal mode state (since the refactor to OfsBufVT100).
+        // They are just passed through here to the backend during diffing.
+
         // ===== Incremental Rendering Operations - Complete implementation
         // These operations are executed both by the backend AND need to
         // update buffer state for consistency and future extensibility (e.g., if
@@ -270,7 +247,15 @@ fn process_common_render_op(
         | RenderOpCommon::ShowCursor
         | RenderOpCommon::HideCursor
         | RenderOpCommon::SaveCursorPosition
-        | RenderOpCommon::RestoreCursorPosition => {}
+        | RenderOpCommon::RestoreCursorPosition
+        | RenderOpCommon::EnterRawMode
+        | RenderOpCommon::ExitRawMode
+        | RenderOpCommon::EnterAlternateScreen
+        | RenderOpCommon::ExitAlternateScreen
+        | RenderOpCommon::EnableMouseTracking
+        | RenderOpCommon::DisableMouseTracking
+        | RenderOpCommon::EnableBracketedPaste
+        | RenderOpCommon::DisableBracketedPaste => {}
         // Do process these.
         RenderOpCommon::ClearScreen => {
             ofs_buf.clear();

--- a/tui/src/tui/terminal_lib_backends/crossterm_backend/crossterm_paint_render_op_impl.rs
+++ b/tui/src/tui/terminal_lib_backends/crossterm_backend/crossterm_paint_render_op_impl.rs
@@ -707,10 +707,11 @@ impl PaintRenderOpImplCrossterm {
     }
 
     /// Save cursor position to be restored later.
-    /// Maps to [`CSI`] `s` [`ANSI`] sequence (DECSC - save cursor).
+    /// Maps to [`CSI`] `s` [`ANSI`] sequence ([`DECSC`] - save cursor).
     ///
     /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
     /// [`CSI`]: crate::CsiSequence
+    /// [`DECSC`]: https://vt100.net/docs/vt510-rm/DECSC.html
     pub fn save_cursor_position(locked_output_device: LockedOutputDevice<'_>) {
         // crossterm doesn't have a direct SaveCursorPosition command,
         // so we write the ANSI sequence directly.
@@ -720,10 +721,11 @@ impl PaintRenderOpImplCrossterm {
     }
 
     /// Restore cursor position previously saved with [`SaveCursorPosition`].
-    /// Maps to [`CSI`] `u` [`ANSI`] sequence (DECRC - restore cursor).
+    /// Maps to [`CSI`] `u` [`ANSI`] sequence ([`DECRC`] - restore cursor).
     ///
     /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
     /// [`CSI`]: crate::CsiSequence
+    /// [`DECRC`]: https://vt100.net/docs/vt510-rm/DECRC.html
     /// [`SaveCursorPosition`]: PaintRenderOpImplCrossterm::save_cursor_position
     pub fn restore_cursor_position(locked_output_device: LockedOutputDevice<'_>) {
         // crossterm doesn't have a direct RestoreCursorPosition command,

--- a/tui/src/tui/terminal_lib_backends/direct_to_ansi/output/direct_to_ansi_output_integration_tests/cursor_movement_rendered.rs
+++ b/tui/src/tui/terminal_lib_backends/direct_to_ansi/output/direct_to_ansi_output_integration_tests/cursor_movement_rendered.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2025 R3BL LLC. Licensed under Apache License, Version 2.0.
 
-//! Behavioral tests for cursor movement operations via [`OffscreenBuffer`] rendering.
+//! Behavioral tests for cursor movement operations via [`OfsBufVT100`] rendering.
 //!
 //! These tests complement the byte-level tests in [`cursor_movement`] by verifying
 //! that cursor positioning produces the correct **visual result** when [`ANSI`] sequences
@@ -14,7 +14,7 @@
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 //! [`cursor_movement`]: super::cursor_movement
-//! [`OffscreenBuffer`]: crate::OffscreenBuffer
+//! [`OfsBufVT100`]: crate::OfsBufVT100
 
 use super::test_helpers_rendered::*;
 use crate::{col, offscreen_buffer::test_fixtures_ofs_buf::*, pos,

--- a/tui/src/tui/terminal_lib_backends/direct_to_ansi/output/direct_to_ansi_output_integration_tests/mod.rs
+++ b/tui/src/tui/terminal_lib_backends/direct_to_ansi/output/direct_to_ansi_output_integration_tests/mod.rs
@@ -13,10 +13,10 @@
 //!
 //! This module uses **two testing layers** that verify complementary properties:
 //!
-//! | Layer                              | Tests                        | Catches                    |
-//! | ---------------------------------- | ---------------------------- | -------------------------- |
-//! | **[`StdoutMock`]** (byte-level)    | "Did we emit correct bytes?" | Typos, wrong [`SGR`] codes |
-//! | **[`OffscreenBuffer`]** (rendered) | "Did it render correctly?"   | Off-by-one, semantic bugs  |
+//! | Layer                           | Tests                        | Catches                    |
+//! | ------------------------------- | ---------------------------- | -------------------------- |
+//! | **[`StdoutMock`]** (byte-level) | "Did we emit correct bytes?" | Typos, wrong [`SGR`] codes |
+//! | **[`OfsBufVT100`]** (rendered)  | "Did it render correctly?"   | Off-by-one, semantic bugs  |
 //!
 //! ## Byte-Level Tests ([`StdoutMock`])
 //!
@@ -24,14 +24,14 @@
 //! - `color_operations`, `cursor_movement`, `screen_operations`, `text_operations`
 //! - `state_optimization` (tracks operation counts)
 //!
-//! ## Rendered Tests ([`OffscreenBuffer`])
+//! ## Rendered Tests ([`OfsBufVT100`])
 //!
-//! Verify **behavioral correctness** by applying [`ANSI`] output to [`OffscreenBuffer`]:
-//! - `cursor_movement_rendered`: Cursor positions characters correctly
+//! Verify **behavioral correctness** by applying [`ANSI`] output to [`OfsBufVT100`]:
 //! - `text_operations_rendered`: Styled text renders with correct colors/attributes
 //! - `screen_operations_rendered`: Clear operations affect correct regions
+//! - `cursor_movement_rendered`: Cursor positions characters correctly
 //!
-//! The rendered tests use [`OffscreenBuffer::apply_ansi_bytes`] to parse the [`ANSI`]
+//! The rendered tests use [`OfsBufVT100::apply_ansi_bytes`] to parse the [`ANSI`]
 //! output and verify the visual result.
 //!
 //!
@@ -92,8 +92,8 @@
 //! [`input::integration_tests_stub`]: mod@crate::terminal_lib_backends::direct_to_ansi::input::integration_tests_stub
 //! [`MoveCursorPositionAbs`]: crate::render_op::RenderOpCommon::MoveCursorPositionAbs
 //! [`MoveCursorPositionRelTo`]: crate::render_op::RenderOpCommon::MoveCursorPositionRelTo
-//! [`OffscreenBuffer::apply_ansi_bytes`]: crate::OffscreenBuffer::apply_ansi_bytes
-//! [`OffscreenBuffer`]: crate::OffscreenBuffer
+//! [`OfsBufVT100::apply_ansi_bytes`]: crate::OfsBufVT100::apply_ansi_bytes
+//! [`OfsBufVT100`]: crate::OfsBufVT100
 //! [`OutputDevice`]: crate::OutputDevice
 //! [`Pos`]: crate::Pos
 //! [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
@@ -124,7 +124,7 @@ mod state_optimization;
 #[cfg(test)]
 mod text_operations;
 
-// Rendered tests (OffscreenBuffer).
+// Rendered tests (OfsBufVT100).
 #[cfg(test)]
 mod cursor_movement_rendered;
 #[cfg(test)]

--- a/tui/src/tui/terminal_lib_backends/direct_to_ansi/output/direct_to_ansi_output_integration_tests/screen_operations_rendered.rs
+++ b/tui/src/tui/terminal_lib_backends/direct_to_ansi/output/direct_to_ansi_output_integration_tests/screen_operations_rendered.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2025 R3BL LLC. Licensed under Apache License, Version 2.0.
 
-//! Behavioral tests for screen operations via [`OffscreenBuffer`] rendering.
+//! Behavioral tests for screen operations via [`OfsBufVT100`] rendering.
 //!
 //! These tests complement the byte-level tests in [`screen_operations`] by verifying
 //! that clear operations produce the correct **visual result** when [`ANSI`] sequences
@@ -8,18 +8,19 @@
 //!
 //! # Important Design Note
 //!
-//! The [`OffscreenBuffer`] [`ANSI`] parser fully supports and applies clear operations
-//! (ED/EL sequences) to the visual buffer. 
+//! The [`OfsBufVT100`] [`ANSI`] parser fully supports and applies clear operations
+//! (ED/EL sequences) to the visual buffer.
 //!
 //! As a result, these tests verify:
 //! - Clear [`ANSI`] sequences are **generated correctly** (verified by byte-level tests)
-//! - Clear operations correctly update the visual buffer (replacing characters with spaces)
+//! - Clear operations correctly update the visual buffer (replacing characters with
+//!   spaces)
 //! - Text painting **after** clear operations works correctly (cursor positioning)
 //! - Buffer state is correct for content that **isn't** cleared
 //!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
-//! [`OffscreenBuffer`]: crate::OffscreenBuffer
-//! [`performer.rs`]: crate::vt_100_pty_output_parser::performer
+//! [`OfsBufVT100`]: crate::OfsBufVT100
+//! [`performer.rs`]: crate::core::ansi::vt_100_pty_output_parser::performer
 //! [`screen_operations`]: super::screen_operations
 
 use super::test_helpers_rendered::*;
@@ -29,7 +30,8 @@ use crate::{offscreen_buffer::test_fixtures_ofs_buf::*, render_op::RenderOpCommo
 ///
 /// NOTE: Previously, Clear operations (`ClearScreen`, `ClearLine`, etc.) were
 /// intentionally ignored. They are now fully supported, so this test verifies
-/// that the screen is actually cleared and subsequent text painting still works correctly.
+/// that the screen is actually cleared and subsequent text painting still works
+/// correctly.
 ///
 /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 #[test]

--- a/tui/src/tui/terminal_lib_backends/direct_to_ansi/output/direct_to_ansi_output_integration_tests/test_helpers_rendered.rs
+++ b/tui/src/tui/terminal_lib_backends/direct_to_ansi/output/direct_to_ansi_output_integration_tests/test_helpers_rendered.rs
@@ -3,14 +3,15 @@
 //! Test helpers for rendered output integration tests.
 //!
 //! These helpers execute render operations via [`StdoutMock`], capture the [`ANSI`]
-//! output, then apply those bytes to an [`OffscreenBuffer`] for behavioral verification.
+//! output, then apply those bytes to an [`OfsBufVT100`] for behavioral
+//! verification.
 //!
 //! # Testing Pattern
 //!
 //! ```text
 //! RenderOpOutput → RenderOpPaintImplDirectToAnsi → StdoutMock (ANSI bytes)
 //!                                                       ↓
-//!                                    OffscreenBuffer::apply_ansi_bytes()
+//!                                    OfsBufVT100::apply_ansi_bytes()
 //!                                                       ↓
 //!                                    Assert buffer state (chars, colors, positions)
 //! ```
@@ -28,10 +29,10 @@
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 //! [`ColorSupport::Truecolor`]: crate::ColorSupport::Truecolor
 //! [`global_color_support::set_override`]: crate::global_color_support::set_override
-//! [`OffscreenBuffer`]: crate::OffscreenBuffer
+//! [`OfsBufVT100`]: crate::OfsBufVT100
 //! [`StdoutMock`]: crate::StdoutMock
 
-use crate::{OffscreenBuffer, OutputDevice, RenderOpOutput, RenderOpPaint,
+use crate::{OfsBufVT100, OutputDevice, RenderOpOutput, RenderOpPaint,
             RenderOpsLocalData, Size, col, height, pos, render_op::RenderOpCommon, row,
             terminal_lib_backends::direct_to_ansi::RenderOpPaintImplDirectToAnsi,
             test_fixtures::output_device_fixtures::OutputDeviceExt, width};
@@ -48,20 +49,21 @@ pub fn create_rendered_test_state() -> RenderOpsLocalData {
     }
 }
 
-/// Execute render operations via [`StdoutMock`] and render result to [`OffscreenBuffer`].
+/// Execute render operations via [`StdoutMock`] and render result to
+/// [`OfsBufVT100`].
 ///
 /// This is the core helper for behavioral testing. It:
 /// 1. Creates a [`StdoutMock`] output device
 /// 2. Executes render operations via [`RenderOpPaintImplDirectToAnsi`]
 /// 3. Captures the [`ANSI`] byte output
-/// 4. Creates an [`OffscreenBuffer`] and applies the captured bytes
+/// 4. Creates an [`OfsBufVT100`] and applies the captured bytes
 /// 5. Returns the buffer for assertions
 ///
 /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
-/// [`OffscreenBuffer`]: crate::OffscreenBuffer
+/// [`OfsBufVT100`]: crate::OfsBufVT100
 /// [`RenderOpPaintImplDirectToAnsi`]: crate::RenderOpPaintImplDirectToAnsi
 /// [`StdoutMock`]: crate::StdoutMock
-pub fn execute_and_render_to_buffer(ops: Vec<RenderOpOutput>) -> OffscreenBuffer {
+pub fn execute_and_render_to_buffer(ops: Vec<RenderOpOutput>) -> OfsBufVT100 {
     let buffer_size = rendered_test_buffer_size();
     execute_and_render_to_buffer_with_size(ops, buffer_size)
 }
@@ -80,7 +82,7 @@ pub fn execute_and_render_to_buffer(ops: Vec<RenderOpOutput>) -> OffscreenBuffer
 pub fn execute_and_render_to_buffer_with_size(
     ops: Vec<RenderOpOutput>,
     buffer_size: Size,
-) -> OffscreenBuffer {
+) -> OfsBufVT100 {
     // Step 1: Create mock output device.
     let (output_device, stdout_mock) = OutputDevice::new_mock();
 
@@ -105,9 +107,9 @@ pub fn execute_and_render_to_buffer_with_size(
     // Step 3: Get captured ANSI bytes.
     let ansi_bytes = stdout_mock.get_copy_of_buffer_as_string();
 
-    // Step 4: Create OffscreenBuffer and apply bytes.
+    // Step 4: Create OfsBufVT100 and apply bytes.
     let mut ofs_buf =
-        OffscreenBuffer::new_empty(buffer_size.row_height + buffer_size.col_width);
+        OfsBufVT100::new_empty(buffer_size.row_height + buffer_size.col_width);
     let (_osc_events, _dsr_responses) = ofs_buf.apply_ansi_bytes(ansi_bytes);
 
     ofs_buf
@@ -116,7 +118,7 @@ pub fn execute_and_render_to_buffer_with_size(
 /// Execute a sequence of operations including cursor movement and text paint.
 ///
 /// This is useful for tests that need to position cursor before painting text.
-pub fn execute_ops_and_render(ops: Vec<RenderOpOutput>) -> OffscreenBuffer {
+pub fn execute_ops_and_render(ops: Vec<RenderOpOutput>) -> OfsBufVT100 {
     execute_and_render_to_buffer(ops)
 }
 

--- a/tui/src/tui/terminal_lib_backends/direct_to_ansi/output/direct_to_ansi_output_integration_tests/text_operations_rendered.rs
+++ b/tui/src/tui/terminal_lib_backends/direct_to_ansi/output/direct_to_ansi_output_integration_tests/text_operations_rendered.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2025 R3BL LLC. Licensed under Apache License, Version 2.0.
 
-//! Behavioral tests for text painting operations via [`OffscreenBuffer`] rendering.
+//! Behavioral tests for text painting operations via [`OfsBufVT100`] rendering.
 //!
 //! These tests complement the byte-level tests in [`text_operations`] by verifying that
 //! styled text produces the correct **visual result** when [`ANSI`] sequences are
@@ -32,7 +32,7 @@
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 //! [`ColorSupport::Truecolor`]: crate::ColorSupport::Truecolor
 //! [`global_color_support::set_override`]: crate::global_color_support::set_override
-//! [`OffscreenBuffer`]: crate::OffscreenBuffer
+//! [`OfsBufVT100`]: crate::OfsBufVT100
 //! [`text_operations`]: super::text_operations
 
 use super::test_helpers_rendered::*;
@@ -187,7 +187,7 @@ fn test_paint_unicode_text_rendered() {
 
     // Verify each Unicode character.
     // Note: These are full-width characters, so they may occupy 2 columns each.
-    // The exact behavior depends on OffscreenBuffer's Unicode handling.
+    // The exact behavior depends on OfsBufVT100's Unicode handling.
     // For now, just verify the first character exists.
     let pos = crate::row(0) + crate::col(0);
     let pixel_char = buffer.get_char(pos);

--- a/tui/src/tui/terminal_lib_backends/direct_to_ansi/output/pixel_char_renderer.rs
+++ b/tui/src/tui/terminal_lib_backends/direct_to_ansi/output/pixel_char_renderer.rs
@@ -21,7 +21,7 @@ use crate::{FastStringify, PixelChar, SGR_RESET_BYTES, SgrCode, TuiColor, TuiSty
 /// ## Architecture Overview
 ///
 /// ```text
-/// PixelChar[] (from OffscreenBuffer)
+/// PixelChar[] (from OfsBufVT100)
 ///     │
 /// ┌───▼──────────────────────────────┐
 /// │  PixelCharRenderer               │
@@ -66,7 +66,7 @@ use crate::{FastStringify, PixelChar, SGR_RESET_BYTES, SgrCode, TuiColor, TuiSty
 ///
 /// ## Integration Points
 ///
-/// - `OffscreenBuffer::render_to_ansi()` will call this renderer
+/// - `OfsBufVT100::render_to_ansi()` will call this renderer
 /// - `CliTextInline::Display` will use this renderer
 /// - `choose()` and `readline_async` will use this renderer
 /// - [`RenderOpOutput`] variant `CompositorNoClipTruncPaintTextWithAttributes` will use

--- a/tui/src/tui/terminal_lib_backends/direct_to_ansi/output/render_to_ansi.rs
+++ b/tui/src/tui/terminal_lib_backends/direct_to_ansi/output/render_to_ansi.rs
@@ -6,7 +6,7 @@
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 
 use super::PixelCharRenderer;
-use crate::{CRLF_BYTES, OffscreenBuffer, SGR_RESET_BYTES};
+use crate::{CRLF_BYTES, OfsBufVT100, SGR_RESET_BYTES};
 
 /// Trait for rendering content to [`ANSI`] escape sequences.
 ///
@@ -17,7 +17,7 @@ use crate::{CRLF_BYTES, OffscreenBuffer, SGR_RESET_BYTES};
 /// ## Architecture
 ///
 /// ```text
-/// OffscreenBuffer (full TUI)
+/// OfsBufVT100 (full TUI)
 ///        │
 ///        ├─────────────────┐
 ///        │                 │
@@ -36,7 +36,7 @@ use crate::{CRLF_BYTES, OffscreenBuffer, SGR_RESET_BYTES};
 /// Unified interface for rendering content to [`ANSI`] escape sequences.
 ///
 /// This trait defines a contract for any buffer-like type to render itself as
-/// [`ANSI`]-encoded bytes. Both full TUI (via [`OffscreenBuffer`]) and lightweight modes
+/// [`ANSI`]-encoded bytes. Both full TUI (via [`OfsBufVT100`]) and lightweight modes
 /// (via alternative buffer types) can implement this to provide consistent [`ANSI`]
 /// generation.
 ///
@@ -51,7 +51,7 @@ use crate::{CRLF_BYTES, OffscreenBuffer, SGR_RESET_BYTES};
 ///
 /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 /// [`choose()`]: crate::choose
-/// [`OffscreenBuffer`]: crate::OffscreenBuffer
+/// [`OfsBufVT100`]: crate::OfsBufVT100
 pub trait RenderToAnsi {
     /// Render this buffer to [`ANSI`] escape sequence bytes.
     ///
@@ -84,7 +84,7 @@ pub trait RenderToAnsi {
     fn render_to_ansi(&self) -> Vec<u8>;
 }
 
-impl RenderToAnsi for OffscreenBuffer {
+impl RenderToAnsi for OfsBufVT100 {
     fn render_to_ansi(&self) -> Vec<u8> {
         let mut output = Vec::new();
         let mut renderer = PixelCharRenderer::new();
@@ -118,7 +118,7 @@ mod tests {
 
     #[test]
     fn test_render_to_ansi_empty_buffer() {
-        let buffer = OffscreenBuffer::new_empty(height(2) + width(3));
+        let buffer = OfsBufVT100::new_empty(height(2) + width(3));
         let ansi = buffer.render_to_ansi();
 
         // Empty buffer (all spacers) should still produce output (spaces + line separator
@@ -134,7 +134,7 @@ mod tests {
 
     #[test]
     fn test_render_to_ansi_single_line() {
-        let mut buffer = OffscreenBuffer::new_empty(height(1) + width(5));
+        let mut buffer = OfsBufVT100::new_empty(height(1) + width(5));
 
         // Add some plain text
         if let Some(first_line) = buffer.buffer.first_mut() {
@@ -160,7 +160,7 @@ mod tests {
 
     #[test]
     fn test_render_to_ansi_multi_line() {
-        let mut buffer = OffscreenBuffer::new_empty(height(2) + width(3));
+        let mut buffer = OfsBufVT100::new_empty(height(2) + width(3));
 
         // Populate two lines
         if buffer.buffer.len() >= 2 {
@@ -196,7 +196,7 @@ mod tests {
 
     #[test]
     fn test_render_to_ansi_with_spacers() {
-        let mut buffer = OffscreenBuffer::new_empty(height(1) + width(5));
+        let mut buffer = OfsBufVT100::new_empty(height(1) + width(5));
 
         if let Some(first_line) = buffer.buffer.first_mut() {
             first_line.pixel_chars.clear();
@@ -220,7 +220,7 @@ mod tests {
 
     #[test]
     fn test_render_to_ansi_with_void() {
-        let mut buffer = OffscreenBuffer::new_empty(height(1) + width(5));
+        let mut buffer = OfsBufVT100::new_empty(height(1) + width(5));
 
         if let Some(first_line) = buffer.buffer.first_mut() {
             first_line.pixel_chars.clear();

--- a/tui/src/tui/terminal_lib_backends/offscreen_buffer/mod.rs
+++ b/tui/src/tui/terminal_lib_backends/offscreen_buffer/mod.rs
@@ -67,7 +67,7 @@
 //!
 //! ## 1. [`ANSI`]/VT100 Terminal Emulation
 //!
-//! - **Parser Integration**: Processes escape sequences via [`vt_100_ansi_impl`]
+//! - **Parser Integration**: Processes escape sequences via [`ofs_buf_vt_100`]
 //!   implementations
 //! - **State Management**: Maintains cursor position, character sets, scrolling regions
 //! - **Protocol Compliance**: Full VT100 specification compliance with conformance tests
@@ -111,14 +111,14 @@
 //! mapping:
 //!
 //! ```text
-//! vt_100_pty_output_parser/operations/   offscreen_buffer/vt_100_ansi_impl/
-//! ├── vt_100_shim_char_ops            →  ├── vt_100_impl_char_ops    (print_char, ICH, DCH, ECH)
-//! ├── vt_100_shim_control_ops         →  ├── vt_100_impl_control_ops (BS, TAB, LF, CR)
-//! ├── vt_100_shim_cursor_ops          →  ├── vt_100_impl_cursor_ops  (movement, positioning)
-//! ├── vt_100_shim_line_ops            →  ├── vt_100_impl_line_ops    (insert/delete lines)
-//! ├── vt_100_shim_scroll_ops          →  ├── vt_100_impl_scroll_ops  (scrolling, regions)
-//! ├── vt_100_shim_terminal_ops        →  ├── vt_100_impl_terminal_ops(reset, clear, charset)
-//! └── bounds_check.rs                 →  └── vt_100_impl_ansi_scroll_helper (scroll region utilities)
+//! vt_100_pty_output_parser/ops/   offscreen_buffer/ofs_buf_vt_100/
+//! ├── vt_100_shim_char_ops      → ├── impl_char_ops    (print_char, ICH, DCH, ECH)
+//! ├── vt_100_shim_control_ops   → ├── impl_control_ops (BS, TAB, LF, CR)
+//! ├── vt_100_shim_cursor_ops    → ├── impl_cursor_ops  (movement, positioning)
+//! ├── vt_100_shim_line_ops      → ├── impl_line_ops    (insert/delete lines)
+//! ├── vt_100_shim_scroll_ops    → ├── impl_scroll_ops  (scrolling, regions)
+//! ├── vt_100_shim_terminal_ops  → ├── impl_terminal_ops(reset, clear, charset)
+//! └── bounds_check.rs           → └── impl_ansi_scroll_helper (scroll region utilities)
 //! ```
 //!
 //! This 1:1 mapping provides:
@@ -209,11 +209,11 @@
 //! Debug assertions catch issues during development:
 //! ```rust
 //! # use r3bl_tui::*;
-//! # let mut buffer = OffscreenBuffer::new_empty(Size { col_width: width(10), row_height: height(5) });
-//! # buffer.cursor_pos = Pos { row_index: row(1), col_index: col(1) };
+//! # let mut vt100 = OfsBufVT100::new_empty(Size { col_width: width(10), row_height: height(5) });
+//! # vt100.ofs_buf.cursor_pos = Pos { row_index: row(1), col_index: col(1) };
 //! # let count = Length::from(1);
 //! // In parser operations
-//! let success = buffer.delete_chars_at_cursor(count);
+//! let success = vt100.delete_chars_at_cursor(count);
 //! debug_assert!(success.is_ok(), "Failed to delete {:?} chars at cursor", count);
 //!
 //! # let row = RowIndex::from(1);
@@ -221,7 +221,7 @@
 //! # let end = ColIndex::from(1);
 //! # let dest = ColIndex::from(2);
 //! // In internal operations with edge case awareness
-//! let success = buffer.copy_chars_within_line(row, source..end, dest);
+//! let success = vt100.ofs_buf.copy_chars_within_line(row, source..end, dest);
 //! debug_assert!(success.is_ok() || source >= end,
 //!     "Failed to copy chars, range: {:?}..{:?}", source, end);
 //! ```
@@ -281,25 +281,26 @@
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 //! [`ASCII`]: https://en.wikipedia.org/wiki/ASCII
 //! [`bounds_check`]: crate::bounds_check
-//! [`clear_line()`]: crate::OffscreenBuffer::clear_line
+//! [`clear_line()`]: crate::OfsBufVT100::clear_line
 //! [`copy_chars_within_line()`]: crate::OffscreenBuffer::copy_chars_within_line
-//! [`cursor_backward()`]: crate::OffscreenBuffer::cursor_backward
-//! [`cursor_down()`]: crate::OffscreenBuffer::cursor_down
-//! [`cursor_forward()`]: crate::OffscreenBuffer::cursor_forward
-//! [`cursor_up()`]: crate::OffscreenBuffer::cursor_up
+//! [`cursor_backward()`]: crate::OfsBufVT100::cursor_backward
+//! [`cursor_down()`]: crate::OfsBufVT100::cursor_down
+//! [`cursor_forward()`]: crate::OfsBufVT100::cursor_forward
+//! [`cursor_up()`]: crate::OfsBufVT100::cursor_up
 //! [`DEC`]: https://en.wikipedia.org/wiki/Digital_Equipment_Corporation
-//! [`delete_chars_at_cursor()`]: crate::OffscreenBuffer::delete_chars_at_cursor
+//! [`delete_chars_at_cursor()`]: crate::OfsBufVT100::delete_chars_at_cursor
 //! [`diff()`]: crate::OffscreenBuffer::diff
 //! [`fill_char_range()`]: crate::OffscreenBuffer::fill_char_range
 //! [`get_char()`]: crate::OffscreenBuffer::get_char
 //! [`get_line()`]: crate::OffscreenBuffer::get_line
-//! [`handle_backspace()`]: crate::OffscreenBuffer::handle_backspace
-//! [`handle_line_feed()`]: crate::OffscreenBuffer::handle_line_feed
-//! [`handle_tab()`]: crate::OffscreenBuffer::handle_tab
+//! [`handle_backspace()`]: crate::OfsBufVT100::handle_backspace
+//! [`handle_line_feed()`]: crate::OfsBufVT100::handle_line_feed
+//! [`handle_tab()`]: crate::OfsBufVT100::handle_tab
 //! [`IndexOps`]: crate::bounds_check::IndexOps
-//! [`insert_chars_at_cursor()`]: crate::OffscreenBuffer::insert_chars_at_cursor
+//! [`insert_chars_at_cursor()`]: crate::OfsBufVT100::insert_chars_at_cursor
 //! [`LengthOps`]: crate::bounds_check::LengthOps
 //! [`ofs_buf_range_validation`]: mod@crate::offscreen_buffer::ofs_buf_range_validation
+//! [`ofs_buf_vt_100`]: crate::core::ansi::vt_100_pty_output_parser::ops_impl_ofs_buf
 //! [`Option<&PixelCharLine>`]: std::option::Option
 //! [`Option<PixelChar>`]: std::option::Option
 //! [`Option<PixelCharDiffChunks>`]: std::option::Option
@@ -308,11 +309,11 @@
 //! [`Pos`]: crate::Pos
 //! [`RangeBoundsExt`]: crate::bounds_check::RangeBoundsExt
 //! [`RenderPipeline::paint()`]: crate::RenderPipeline::paint
-//! [`reset_all_style_attributes()`]: crate::OffscreenBuffer::reset_all_style_attributes
+//! [`reset_all_style_attributes()`]: crate::OfsBufVT100::reset_all_style_attributes
 //! [`set_char()`]: crate::OffscreenBuffer::set_char
-//! [`set_foreground_color()`]: crate::OffscreenBuffer::set_foreground_color
-//! [`shift_lines_down()`]: crate::OffscreenBuffer::shift_lines_down
-//! [`shift_lines_up()`]: crate::OffscreenBuffer::shift_lines_up
+//! [`set_foreground_color()`]: crate::OfsBufVT100::set_foreground_color
+//! [`shift_lines_down()`]: crate::OfsBufVT100::shift_lines_down
+//! [`shift_lines_up()`]: crate::OfsBufVT100::shift_lines_up
 //! [`TuiStyle`]: crate::TuiStyle
 //! [`validate_col_range_mut()`]: crate::OffscreenBuffer::validate_col_range_mut
 //! [`validate_row_range_mut()`]: crate::OffscreenBuffer::validate_row_range_mut
@@ -349,11 +350,6 @@ mod pixel_char;
 mod pixel_char_line;
 mod pixel_char_lines;
 
-#[cfg(any(test, doc))]
-pub mod vt_100_ansi_impl;
-#[cfg(not(any(test, doc)))]
-mod vt_100_ansi_impl;
-
 // Re-export public API (flat, ergonomic surface).
 pub use diff_chunks::*;
 pub use ofs_buf_core::*;
@@ -361,7 +357,5 @@ pub use paint_impl::*;
 pub use pixel_char::*;
 pub use pixel_char_line::*;
 pub use pixel_char_lines::*;
-
-// Test fixtures (only available during testing).
 #[cfg(any(test, doc))]
 pub mod test_fixtures_ofs_buf;

--- a/tui/src/tui/terminal_lib_backends/offscreen_buffer/ofs_buf_bulk_ops.rs
+++ b/tui/src/tui/terminal_lib_backends/offscreen_buffer/ofs_buf_bulk_ops.rs
@@ -28,11 +28,11 @@ impl OffscreenBuffer {
 #[cfg(test)]
 mod tests_bulk_ops {
     use super::*;
-    use crate::{TuiStyle, col, height, row, width};
+    use crate::{OfsBufVT100, TuiStyle, col, height, row, width};
 
-    fn create_test_buffer() -> OffscreenBuffer {
+    fn create_test_buffer() -> OfsBufVT100 {
         let size = width(4) + height(4);
-        OffscreenBuffer::new_empty(size)
+        OfsBufVT100::new_empty(size)
     }
 
     fn create_test_char(ch: char) -> PixelChar {

--- a/tui/src/tui/terminal_lib_backends/offscreen_buffer/ofs_buf_char_ops.rs
+++ b/tui/src/tui/terminal_lib_backends/offscreen_buffer/ofs_buf_char_ops.rs
@@ -112,11 +112,11 @@ impl OffscreenBuffer {
 #[cfg(test)]
 mod tests_char_ops {
     use super::*;
-    use crate::{TuiStyle, col, height, width};
+    use crate::{OfsBufVT100, TuiStyle, col, height, width};
 
-    fn create_test_buffer() -> OffscreenBuffer {
+    fn create_test_buffer() -> OfsBufVT100 {
         let size = width(5) + height(3);
-        OffscreenBuffer::new_empty(size)
+        OfsBufVT100::new_empty(size)
     }
 
     fn create_test_char(ch: char) -> PixelChar {

--- a/tui/src/tui/terminal_lib_backends/offscreen_buffer/ofs_buf_core.rs
+++ b/tui/src/tui/terminal_lib_backends/offscreen_buffer/ofs_buf_core.rs
@@ -611,7 +611,6 @@ pub trait OffscreenBufferPaint {
         window_size: Size,
         locked_output_device: LockedOutputDevice<'_>,
         paint_mode: PaintMode,
-        cursor_visibility: CursorVisibilityState,
     );
 
     /// Execute diff operations on the display (selective redraw).
@@ -628,7 +627,6 @@ pub trait OffscreenBufferPaint {
         window_size: Size,
         locked_output_device: LockedOutputDevice<'_>,
         paint_mode: PaintMode,
-        cursor_visibility: CursorVisibilityState,
     );
 }
 

--- a/tui/src/tui/terminal_lib_backends/offscreen_buffer/ofs_buf_core.rs
+++ b/tui/src/tui/terminal_lib_backends/offscreen_buffer/ofs_buf_core.rs
@@ -1,471 +1,14 @@
 // Copyright (c) 2022-2025 R3BL LLC. Licensed under Apache License, Version 2.0.
 
-use super::super::{FlushKind, RenderOpOutputVec};
-use crate::{DsrRequestFromPtyEvent, GetMemSize, LockedOutputDevice, MemorySize,
-            PaintMode, Pos, Size, TermRow, TuiStyle, inline_string, ok, osc::OscEvent};
-use std::{fmt::Debug, mem::size_of};
-
-/// Character set modes for terminal emulation.
-///
-/// Used by [`AnsiToOfsBufPerformer`] to handle [`ESC`] ( sequences that switch between
-/// [`ASCII`] and [`DEC`] line-drawing graphics.
-///
-/// [`AnsiToOfsBufPerformer`]: crate::AnsiToOfsBufPerformer
-/// [`ASCII`]: https://en.wikipedia.org/wiki/ASCII
-/// [`DEC`]: https://en.wikipedia.org/wiki/Digital_Equipment_Corporation
-/// [`ESC`]: crate::EscSequence
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum CharacterSet {
-    /// Normal [`ASCII`] character set ([`ESC`] ( B).
-    ///
-    /// [`ASCII`]: https://en.wikipedia.org/wiki/ASCII
-    /// [`ESC`]: crate::EscSequence
-    #[default]
-    Ascii,
-    /// [`DEC`] Special Graphics character set for line drawing ([`ESC`] ( 0). Maps
-    /// [`ASCII`] characters to box-drawing Unicode characters.
-    ///
-    /// [`ASCII`]: https://en.wikipedia.org/wiki/ASCII
-    /// [`DEC`]: https://en.wikipedia.org/wiki/Digital_Equipment_Corporation
-    /// [`ESC`]: crate::EscSequence
-    DECGraphics,
-}
-
-/// Encapsulated state representing the alternate screen support and its independent
-/// cursor positions.
-///
-/// # [`SGR`] Style Inheritance & [`BCE`] (Background Color Erase) Compliance
-///
-/// Under VT100, [`xterm`], and standard [`ANSI`] specifications, graphic rendition states
-/// (foreground/background colors, bold, italic) are globally shared and preserved across
-/// screen buffer switches.
-///
-/// This struct implements this specification by separating the alternate buffer
-/// ([`alt_buffer`]) from the overall parser emulation state. When entering the alternate
-/// screen:
-/// - The alternate buffer inherits the active graphic style from the main buffer.
-/// - The buffer is cleared utilizing [`create_empty_pixel_char()`] to ensure that erased
-///   cells carry the active background color and attributes, fully complying with
-///   Background Color Erase ([`BCE`]) rules.
-///
-/// [`alt_buffer`]: AltScreenSupport::alt_buffer
-/// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
-/// [`BCE`]: https://invisible-island.net/xterm/xterm.faq.html#what_is_bce
-/// [`create_empty_pixel_char()`]: crate::OffscreenBuffer::create_empty_pixel_char
-/// [`SGR`]: crate::SgrCode
-/// [`xterm`]: https://en.wikipedia.org/wiki/Xterm
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct AltScreenSupport {
-    /// The secondary buffer grid representing the alternate screen. Always allocated at
-    /// buffer creation time to avoid having to use [`Option`] which adds needless
-    /// complexity for a very small cost in terms of memory.
-    pub alt_buffer: PixelCharLines,
-
-    /// Saved cursor position for the primary buffer.
-    pub cursor_pos_primary: Pos,
-
-    /// Saved cursor position for the alternate buffer.
-    pub cursor_pos_alt: Pos,
-}
-
-impl AltScreenSupport {
-    #[must_use]
-    pub fn new_empty(window_size: Size) -> Self {
-        Self {
-            alt_buffer: PixelCharLines::new_empty(window_size),
-            cursor_pos_primary: Pos::default(),
-            cursor_pos_alt: Pos::default(),
-        }
-    }
-}
-
-/// Support structure for [`ANSI`] escape sequence parsing and terminal state management.
-///
-/// This struct groups together all fields related to [`ANSI parser performer`]
-/// functionality that need to be maintained by the [`OffscreenBuffer`] for proper
-/// terminal emulation.
-///
-/// One field missing from here is [`OffscreenBuffer::cursor_pos`] which tracks the
-/// current cursor position. This is because `cursor_pos` is used by multiple subsystems
-/// and is the primary cursor position tracker for the entire offscreen buffer system.
-///
-/// [`ANSI parser performer`]: crate::AnsiToOfsBufPerformer
-/// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
-/// [`OffscreenBuffer::cursor_pos`]: OffscreenBuffer::cursor_pos
-#[derive(Debug, Clone, PartialEq)]
-pub struct AnsiParserSupport {
-    /// Temporary cursor position storage for DECSC/DECRC escape sequences only.
-    ///
-    /// This field is ONLY used for [`ESC`] 7 (DECSC) save and [`ESC`] 8 (DECRC) restore
-    /// operations, as well as their [`CSI`] equivalents ([`CSI`] s and [`CSI`] u). It
-    /// does NOT track the current cursor position - that's stored in
-    /// [`OffscreenBuffer::cursor_pos`].
-    ///
-    /// Used by [`AnsiToOfsBufPerformer`] to implement the DECSC ([`ESC`] 7) and DECRC
-    /// ([`ESC`] 8) escape sequences for saving and restoring cursor position.
-    ///
-    /// ## Data Flow:
-    /// ```text
-    /// 1. Child process (e.g., vim) sends ESC 7 to save cursor
-    ///                             ↓
-    /// 2. AnsiToOfsBufPerformer::esc_dispatch() handles ESC 7
-    ///                             ↓
-    /// 3. Saves current cursor_pos to buffer.ansi_parser_support.cursor_pos_for_esc_save_and_restore
-    ///                             ↓
-    /// 4. Later, child sends ESC 8 to restore cursor
-    ///                             ↓
-    /// 5. AnsiToOfsBufPerformer::esc_dispatch() handles ESC 8
-    ///                             ↓
-    /// 6. Restores cursor_pos from buffer.ansi_parser_support.cursor_pos_for_esc_save_and_restore
-    /// ```
-    ///
-    /// [`AnsiToOfsBufPerformer`]: crate::AnsiToOfsBufPerformer
-    /// [`CSI`]: crate::CsiSequence
-    /// [`ESC`]: crate::EscSequence
-    pub cursor_pos_for_esc_save_and_restore: Option<Pos>,
-
-    /// Active character set for [`ANSI`] escape sequence support.
-    ///
-    /// Used by [`AnsiToOfsBufPerformer`] to implement character set switching via [`ESC`]
-    /// ( B ([`ASCII`]) and [`ESC`] ( 0 ([`DEC`] graphics). When in Graphics mode,
-    /// characters like 'q' are translated to box-drawing characters like '─' during the
-    /// `print()` operation.
-    ///
-    /// ## Character Set Usage:
-    /// ```text
-    /// ASCII Mode (ESC ( B):   'q' → 'q' (literal)
-    /// Graphics Mode (ESC ( 0): 'q' → '─' (horizontal line)
-    /// ```
-    ///
-    /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
-    /// [`AnsiToOfsBufPerformer`]: crate::AnsiToOfsBufPerformer
-    /// [`ASCII`]: https://en.wikipedia.org/wiki/ASCII
-    /// [`DEC`]: https://en.wikipedia.org/wiki/Digital_Equipment_Corporation
-    /// [`ESC`]: crate::EscSequence
-    pub character_set: CharacterSet,
-
-    /// Auto-wrap mode ([`DECAWM`]) for [`ANSI`] escape sequence support.
-    ///
-    /// Used by [`AnsiToOfsBufPerformer`] to control line wrapping behavior when printing
-    /// characters. This implements the [`VT-100`] [`DECAWM`] (Auto Wrap Mode)
-    /// specification.
-    ///
-    /// ## [`DECAWM`] Control:
-    ///
-    /// ```text
-    /// ESC[?7h: Enable auto-wrap (default)  - Characters wrap to next line
-    /// ESC[?7l: Disable auto-wrap           - Characters overwrite at right margin
-    /// ```
-    ///
-    /// When enabled (default), characters that would exceed the right margin
-    /// automatically wrap to the beginning of the next line. When disabled, the cursor
-    /// stays at the right margin and subsequent characters overwrite.
-    ///
-    /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
-    /// [`AnsiToOfsBufPerformer`]: crate::AnsiToOfsBufPerformer
-    /// [`DECAWM`]: https://vt100.net/docs/vt510-rm/DECAWM.html
-    /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
-    pub auto_wrap_mode: AutoWrapState,
-
-    /// Complete computed style combining attributes and colors for efficient rendering.
-    pub current_style: TuiStyle,
-
-    /// [`OSC`] events (hyperlinks, titles, etc.) accumulated during processing.
-    ///
-    /// [`OSC`]: crate::osc_codes::OscSequence
-    pub pending_osc_events: Vec<OscEvent>,
-
-    /// [`DSR`] response events accumulated during processing - need to be sent back to
-    /// [`PTY`].
-    ///
-    /// [`DSR`]: crate::DsrSequence
-    /// [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
-    pub pending_dsr_responses: Vec<DsrRequestFromPtyEvent>,
-
-    /// Top margin for the **scrollable region** ([`DECSTBM`]) - 1-based row number.
-    ///
-    /// This variable defines the **upper boundary** of the area where scrolling occurs.
-    /// Rows above this boundary are part of the **static top region** and do not scroll.
-    ///
-    /// Used by [`AnsiToOfsBufPerformer`] to implement [`DECSTBM`] (Set Top and Bottom
-    /// Margins) functionality via [`ESC`] [ top ; bottom r.
-    ///
-    /// When `None`, the default top margin is row 1 (first row), making the entire
-    /// terminal screen the scrollable region. When `Some(n)`, scrolling operations only
-    /// affect rows from n to `scroll_region_bottom`.
-    ///
-    /// ## [`DECSTBM`] Usage:
-    /// ```text
-    /// ESC [ 5 ; 20 r   - Set scrolling region from row 5 to row 20
-    /// ESC [ r          - Reset to full screen (clears both margins)
-    /// ```
-    ///
-    /// [`AnsiToOfsBufPerformer`]: crate::AnsiToOfsBufPerformer
-    /// [`DECSTBM`]: https://vt100.net/docs/vt510-rm/DECSTBM.html
-    /// [`ESC`]: crate::EscSequence
-    pub scroll_region_top: Option<TermRow>,
-
-    /// Bottom margin for the **scrollable region** ([`DECSTBM`]) - 1-based row number.
-    ///
-    /// This variable defines the **lower boundary** of the area where scrolling occurs.
-    /// Rows below this boundary are part of the **static bottom region** and do not
-    /// scroll.
-    ///
-    /// Used by [`AnsiToOfsBufPerformer`] to implement [`DECSTBM`] (Set Top and Bottom
-    /// Margins) functionality via [`ESC`] [ top ; bottom r.
-    ///
-    /// When `None`, the default bottom margin is the last row of the terminal, making the
-    /// entire terminal screen the scrollable region. When `Some(n)`, scrolling operations
-    /// only affect rows from `scroll_region_top` to n.
-    ///
-    /// ## [`DECSTBM`] Behavior:
-    /// - Scrolling commands ([`ESC`] D, [`ESC`] M, [`CSI`] S, [`CSI`] T) only affect the
-    ///   region
-    /// - Cursor movement is constrained to the region boundaries
-    /// - Content outside the region remains unchanged during scrolling
-    ///
-    /// [`AnsiToOfsBufPerformer`]: crate::AnsiToOfsBufPerformer
-    /// [`CSI`]: crate::CsiSequence
-    /// [`DECSTBM`]: https://vt100.net/docs/vt510-rm/DECSTBM.html
-    /// [`ESC`]: crate::EscSequence
-    pub scroll_region_bottom: Option<TermRow>,
-
-    /// Controls whether the terminal cursor is visible.
-    ///
-    /// Corresponds to the [`DECTCEM`] (`?25`) private mode.
-    ///
-    /// [`DECTCEM`]: https://vt100.net/docs/vt510-rm/DECTCEM.html
-    pub cursor_visibility: CursorVisibilityState,
-}
-
-impl Default for AnsiParserSupport {
-    /// Creates a new [`AnsiParserSupport`] with [`VT-100`] compliant defaults.
-    ///
-    /// [`AnsiParserSupport`]: crate::AnsiParserSupport
-    /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
-    fn default() -> Self {
-        Self {
-            cursor_pos_for_esc_save_and_restore: None,
-            character_set: CharacterSet::default(),
-            auto_wrap_mode: AutoWrapState::Enabled, // DECAWM default: Enabled
-            current_style: TuiStyle::default(),
-            pending_osc_events: Vec::new(),
-            pending_dsr_responses: Vec::new(),
-            scroll_region_top: None, // Default: no top margin (uses row 1)
-            scroll_region_bottom: None, // Default: no bottom margin (uses last row)
-            cursor_visibility: CursorVisibilityState::Visible, // DECTCEM default: visible
-        }
-    }
-}
-
-/// Auto-wrap mode ([`DECAWM`]) state.
-///
-/// Controls line wrapping behavior when text reaches the right margin.
-///
-/// [`DECAWM`]: https://vt100.net/docs/vt510-rm/DECAWM.html
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum AutoWrapState {
-    /// Characters automatically wrap to the next line (DECAWM `?7h`)
-    #[default]
-    Enabled,
-    /// Characters overwrite at the right margin (DECAWM `?7l`)
-    Disabled,
-}
-
-/// Terminal cursor visibility state.
-///
-/// Controls whether the terminal cursor is displayed or hidden. Corresponds to the
-/// [`DECTCEM`] (`?25`) private mode.
-///
-/// # Dual Usage Architecture
-///
-/// This enum serves two distinct roles in the rendering pipeline depending on the
-/// context:
-///
-/// 1. **Parsing & Virtual Composition ([`PTY Mux`])**: When used inside
-///    [`AnsiParserSupport::cursor_visibility`], it stores the *requested* visibility
-///    state of the child process. The [`PTY Mux`] compositor
-///    (`OutputRenderer::composite_virtual_cursor_into_buffer`) reads this to determine if
-///    it needs to paint a simulated, virtual block cursor into the grid.
-///
-/// 2. **Terminal Emulator Cursor Rendering (Backend)**: When passed as an argument to
-///    backend executor traits (e.g., [`OffscreenBufferPaintImpl::paint`]), it pushes
-///    either a [`RenderOpCommon::ShowCursor`] or [`RenderOpCommon::HideCursor`] operation
-///    to command the terminal emulator to display or hide its terminal emulator cursor.
-///
-///    > Note: The [`PTY Mux`] explicitly passes [`CursorVisibilityState::Hidden`] to the
-///    > backend to suppress the terminal emulator's cursor.
-///
-/// [`AnsiParserSupport::cursor_visibility`]: crate::AnsiParserSupport::cursor_visibility
-/// [`CursorVisibilityState::Hidden`]:
-///     crate::tui::terminal_lib_backends::CursorVisibilityState::Hidden
-/// [`DECTCEM`]: https://vt100.net/docs/vt510-rm/DECTCEM.html
-/// [`OffscreenBufferPaintImpl::paint`]:
-///     crate::tui::terminal_lib_backends::OffscreenBufferPaintImpl::paint
-/// [`OutputRenderer`]: crate::core::pty::OutputRenderer
-/// [`PTY Mux`]: crate::PTYMux
-/// [`RenderOpCommon::HideCursor`]: crate::RenderOpCommon::HideCursor
-/// [`RenderOpCommon::ShowCursor`]: crate::RenderOpCommon::ShowCursor
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum CursorVisibilityState {
-    /// Cursor is visible ([`DECTCEM`] `ESC [ ? 25 h`)
-    ///
-    /// [`DECTCEM`]: https://vt100.net/docs/vt510-rm/DECTCEM.html
-    #[default]
-    Visible,
-    /// Cursor is hidden ([`DECTCEM`] `ESC [ ? 25 l`)
-    ///
-    /// [`DECTCEM`]: https://vt100.net/docs/vt510-rm/DECTCEM.html
-    Hidden,
-}
-
-/// Raw mode state for terminal input processing.
-///
-/// Raw mode (POSIX non-canonical mode) controls whether terminal input is processed
-/// character-by-character without line buffering. This is essential for interactive TUI
-/// applications that need immediate character feedback.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RawModeState {
-    /// Raw mode enabled - input processed character-by-character
-    Enabled,
-    /// Raw mode disabled - input processed line-by-line with buffering
-    Disabled,
-}
-
-/// Alternate screen buffer state.
-///
-/// Controls whether terminal output is redirected to an alternate screen buffer,
-/// preserving the original screen content. This is used by full-screen applications (vim,
-/// less, etc.) to avoid cluttering the shell history.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AlternateScreenState {
-    /// Alternate screen buffer active
-    Active,
-    /// Alternate screen buffer inactive, using primary screen
-    Inactive,
-}
-
-/// The requested screen buffer mode.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RequestedScreenMode {
-    Primary,
-    Alternate,
-}
-
-/// Mouse event tracking state.
-///
-/// Controls whether the terminal captures mouse click, movement, and scroll events. This
-/// enables interactive mouse support in TUI applications.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum MouseTrackingState {
-    /// Mouse tracking enabled - terminal sends mouse events
-    Enabled,
-    /// Mouse tracking disabled
-    Disabled,
-}
-
-/// Bracketed paste mode state.
-///
-/// Controls whether text pasted from clipboard is wrapped with special escape sequences
-/// ([`OSC`] 52), allowing applications to distinguish pasted text from keyboard input.
-/// This prevents misinterpretation of pasted content.
-///
-/// [`OSC`]: crate::osc_codes::OscSequence
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BracketedPasteState {
-    /// Bracketed paste mode enabled
-    Enabled,
-    /// Bracketed paste mode disabled
-    Disabled,
-}
-
-/// Terminal mode state tracking for terminal control sequences.
-///
-/// This struct groups together all terminal mode flags that track the state of various
-/// terminal features that can be controlled via escape sequences. These modes affect how
-/// the terminal processes and displays output.
-///
-/// ## Terminal Modes
-///
-/// - **Raw Mode**: Direct input/output without line buffering (POSIX raw mode)
-/// - **Alternate Screen**: Secondary screen buffer for full-screen applications
-/// - **Mouse Tracking**: Capability to capture mouse events
-/// - **Bracketed Paste**: Ability to distinguish pasted text from keyboard input
-///
-/// Used by render pipeline and [`ANSI`] parser performer to maintain complete terminal
-/// state information.
-///
-/// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
-/// [`RenderOpCommon`]: enum@crate::RenderOpCommon
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TerminalModeState {
-    /// Raw mode status (POSIX non-canonical mode).
-    ///
-    /// When enabled, terminal input is processed character-by-character without line
-    /// buffering. This is essential for interactive TUI applications that need immediate
-    /// character feedback.
-    ///
-    /// Set via:
-    /// - [`RenderOpCommon`] variant `EnterRawMode` (enables)
-    /// - [`RenderOpCommon`] variant `ExitRawMode` (disables)
-    ///
-    /// [`RenderOpCommon`]: enum@crate::RenderOpCommon
-    pub raw_mode: RawModeState,
-
-    /// Alternate screen buffer status.
-    ///
-    /// When active, terminal output is redirected to an alternate screen buffer,
-    /// preserving the original screen content. This is used by full-screen applications
-    /// (vim, less, etc.) to avoid cluttering the shell history.
-    ///
-    /// Set via:
-    /// - [`RenderOpCommon`] variant `EnterAlternateScreen` (activates)
-    /// - [`RenderOpCommon`] variant `ExitAlternateScreen` (deactivates)
-    ///
-    /// [`RenderOpCommon`]: enum@crate::RenderOpCommon
-    pub alternate_screen: AlternateScreenState,
-
-    /// Mouse event tracking status.
-    ///
-    /// When enabled, terminal sends mouse click, movement, and scroll events. This
-    /// enables interactive mouse support in TUI applications.
-    ///
-    /// Set via:
-    /// - [`RenderOpCommon`] variant `EnableMouseTracking` (enables)
-    /// - [`RenderOpCommon`] variant `DisableMouseTracking` (disables)
-    ///
-    /// [`RenderOpCommon`]: enum@crate::RenderOpCommon
-    pub mouse_tracking: MouseTrackingState,
-
-    /// Bracketed paste mode status.
-    ///
-    /// When enabled, text pasted from clipboard is wrapped with special escape sequences
-    /// ([`OSC`] 52), allowing applications to distinguish pasted text from keyboard
-    /// input. This prevents misinterpretation of pasted content.
-    ///
-    /// Set via:
-    /// - [`RenderOpCommon`] variant `EnableBracketedPaste` (enables)
-    /// - [`RenderOpCommon`] variant `DisableBracketedPaste` (disables)
-    ///
-    /// [`OSC`]: crate::osc_codes::OscSequence
-    /// [`RenderOpCommon`]: enum@crate::RenderOpCommon
-    pub bracketed_paste: BracketedPasteState,
-}
-
-impl Default for TerminalModeState {
-    /// Creates a new `TerminalModeState` with VT100-compliant defaults.
-    ///
-    /// All modes are disabled by default, representing a standard terminal state before
-    /// any special features are activated.
-    fn default() -> Self {
-        Self {
-            raw_mode: RawModeState::Disabled,
-            alternate_screen: AlternateScreenState::Inactive,
-            mouse_tracking: MouseTrackingState::Disabled,
-            bracketed_paste: BracketedPasteState::Disabled,
-        }
-    }
-}
+use super::{super::{FlushKind, RenderOpOutputVec},
+            PixelCharDiffChunks,
+            pixel_char::PixelChar,
+            pixel_char_lines::PixelCharLines};
+use crate::{GetMemSize, List, LockedOutputDevice, MemorySize, PaintMode, Pos, Size, col,
+            fg_green, inline_string, ok, row};
+use std::{fmt::{Debug, {self}},
+          mem::size_of,
+          ops::{Deref, DerefMut}};
 
 /// Core terminal screen buffer structure with VT100/[`ANSI`] support.
 ///
@@ -488,24 +31,22 @@ impl Default for TerminalModeState {
 /// The struct is organized into logical groups:
 /// - **Core Buffer**: The 2D grid and window dimensions
 /// - **Cursor Management**: Primary cursor position for all subsystems
-/// - **Terminal Mode State**: Tracking of terminal control modes (raw, alternate screen,
-///   etc.)
-/// - **[`ANSI`] Support**: Terminal state for escape sequence processing
 /// - **Performance**: Pre-calculated memory usage tracking
 ///
 /// ## Underlying protocol parser
 ///
 /// - [`vt_100_pty_output_parser`]: The [`ANSI`] parser that processes [`PTY`] output and
-///   updates this buffer's state via [`apply_ansi_bytes`]
+///   updates the higher-level [`OfsBufVT100`] via [`apply_ansi_bytes`]
 /// - [`AnsiToOfsBufPerformer`]: The VTE `Perform` implementation that translates [`ANSI`]
-///   sequences into buffer operations
+///   sequences into terminal state operations
 ///
 /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 /// [`AnsiToOfsBufPerformer`]: crate::AnsiToOfsBufPerformer
-/// [`apply_ansi_bytes`]: OffscreenBuffer::apply_ansi_bytes
+/// [`apply_ansi_bytes`]: crate::OfsBufVT100::apply_ansi_bytes
+/// [`OfsBufVT100`]: crate::OfsBufVT100
 /// [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
 /// [`RenderOpCommon`]: enum@crate::RenderOpCommon
-/// [`vt_100_pty_output_parser`]: mod@crate::vt_100_pty_output_parser
+/// [`vt_100_pty_output_parser`]: mod@crate::core::ansi::vt_100_pty_output_parser
 /// [module documentation]: super
 #[derive(Clone, PartialEq)]
 pub struct OffscreenBuffer {
@@ -520,60 +61,52 @@ pub struct OffscreenBuffer {
     /// This is the primary cursor position tracker for the entire offscreen buffer
     /// system, used by multiple subsystems:
     /// - **Render pipeline**: Updated when processing [`RenderOpCommon`] variants
-    ///   `MoveCursorPositionAbs` and `MoveCursorPositionRelTo`
-    /// - **Text rendering**: Starting position for `print_text_with_attributes()`
+    ///   [`MoveCursorPositionAbs`] and [`MoveCursorPositionRelTo`]
+    /// - **Text rendering**: Starting position for [`print_text_with_attributes()`]
     /// - **[`ANSI`] parser**: Directly reads from and writes to this position during
     ///   sequence processing
     /// - **Terminal emulation**: Tracks where the next character should be rendered
     ///
-    /// Note: This is different from [`cursor_pos_for_esc_save_and_restore`] which is only
-    /// used for DECSC/DECRC ([`ESC`] 7/8) save/restore operations.
+    /// Note: This is different from [`cursor_pos_for_esc_save_and_restore`] which is
+    /// only used for [`DECSC`]/[`DECRC`] (`ESC 7` / `ESC 8`) save/restore operations.
     ///
     /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
     /// [`cursor_pos_for_esc_save_and_restore`]:
-    ///     AnsiParserSupport::cursor_pos_for_esc_save_and_restore
-    /// [`ESC`]: crate::EscSequence
-    /// [`RenderOpCommon`]: enum@crate::RenderOpCommon
+    ///     crate::ParserGlobalState::cursor_pos_for_esc_save_and_restore
+    /// [`DECRC`]: https://vt100.net/docs/vt510-rm/contents.html
+    /// [`DECSC`]: https://vt100.net/docs/vt510-rm/contents.html
+    /// [`MoveCursorPositionAbs`]: crate::RenderOpCommon::MoveCursorPositionAbs
+    /// [`MoveCursorPositionRelTo`]: crate::RenderOpCommon::MoveCursorPositionRelTo
+    /// [`print_text_with_attributes()`]: crate::print_text_with_attributes
+    /// [`RenderOpCommon`]: crate::RenderOpCommon
     pub cursor_pos: Pos,
 
-    /// Terminal mode state tracking (raw mode, alternate screen, mouse tracking, etc.).
+    /// Cached memory size of this buffer to provide O(1) retrieval.
     ///
-    /// This field tracks the state of various terminal control modes that affect how the
-    /// terminal processes input and displays output. These modes are set via control
-    /// escape sequences or render operations.
-    pub terminal_mode: TerminalModeState,
-
-    /// Pre-calculated memory size of this buffer. Since the buffer has fixed dimensions
-    /// and each cell is a fixed-size enum, this value is calculated once at creation and
-    /// never changes.
+    /// Because the buffer grid dimensions are strictly fixed upon creation (resizing the
+    /// terminal creates a brand new buffer), we can safely calculate its total memory
+    /// cost exactly once during [`new_empty()`] and cache it here. This avoids expensive
+    /// O(N) traversal recalculations later.
     ///
     /// Used in [`log_telemetry_info`] which is called in a hot loop on every render.
     ///
     /// [`log_telemetry_info`]:
     ///     crate::main_event_loop::EventLoopState::log_telemetry_info()
-    memory_size: MemorySize,
-
-    /// [`ANSI`] parser support fields grouped together for better organization.
-    ///
-    /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
-    pub ansi_parser_support: AnsiParserSupport,
-
-    /// Support for the [`VT-100`] alternate screen buffer (`?1049` mode) and independent
-    /// cursor state.
-    ///
-    /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
-    pub alt_screen_support: AltScreenSupport,
+    /// [`new_empty()`]: Self::new_empty()
+    pub cached_memory_size: MemorySize,
 }
 
 impl GetMemSize for OffscreenBuffer {
-    /// Returns the pre-calculated memory size of this buffer. Since buffer dimensions are
-    /// fixed and cells are fixed-size enums, this value was calculated once at creation
-    /// and never changes.
-    fn get_mem_size(&self) -> usize { self.memory_size.size().unwrap_or(0) }
+    /// Acts as a fast O(1) getter for the cached memory size.
+    ///
+    /// Instead of iterating through all internal vectors and states on the fly, this
+    /// method returns the value that was pre-calculated during [`new_empty()`]. This
+    /// caching pattern is an optimization for performance, as this method is called
+    /// frequently during hot-loop render cycles.
+    ///
+    /// [`new_empty()`]: Self::new_empty()
+    fn get_mem_size(&self) -> usize { self.cached_memory_size.size().unwrap_or(0) }
 }
-
-// Forward declarations for types defined in their own modules, just for this file.
-use super::{pixel_char::PixelChar, pixel_char_lines::PixelCharLines};
 
 /// Trait for painting offscreen buffer content to terminal output.
 ///
@@ -583,9 +116,11 @@ use super::{pixel_char::PixelChar, pixel_char_lines::PixelCharLines};
 ///
 /// # Type Safety Note
 ///
-/// This trait works with `RenderOpOutputVec` (post-Compositor operations), not
-/// `RenderOpIRVec`. The Compositor has already applied all necessary transformations
+/// This trait works with [`RenderOpOutputVec`] (post-Compositor operations), not
+/// [`RenderOpIRVec`]. The Compositor has already applied all necessary transformations
 /// (clipping, Unicode handling, etc.) when these methods are called.
+///
+/// [`RenderOpIRVec`]: crate::RenderOpIRVec
 pub trait OffscreenBufferPaint {
     /// Converts offscreen buffer to terminal operations.
     fn render(&mut self, offscreen_buffer: &OffscreenBuffer) -> RenderOpOutputVec;
@@ -597,13 +132,6 @@ pub trait OffscreenBufferPaint {
     ) -> RenderOpOutputVec;
 
     /// Execute terminal operations on the display.
-    ///
-    /// The `cursor_visibility` parameter ensures that the terminal emulator's cursor
-    /// state perfectly matches the emulator's parsed state ([`DECTCEM`] `ESC [ ? 25 h` /
-    /// `ESC [ ? 25 l`). This decouples the parsing of the state from its actual
-    /// execution, which happens right before flush.
-    ///
-    /// [`DECTCEM`]: https://vt100.net/docs/vt510-rm/DECTCEM.html
     fn paint(
         &mut self,
         render_ops: RenderOpOutputVec,
@@ -614,13 +142,6 @@ pub trait OffscreenBufferPaint {
     );
 
     /// Execute diff operations on the display (selective redraw).
-    ///
-    /// The `cursor_visibility` parameter ensures that the terminal emulator's cursor
-    /// state perfectly matches the emulator's parsed state ([`DECTCEM`] `ESC [ ? 25 h` /
-    /// `ESC [ ? 25 l`). This decouples the parsing of the state from its actual
-    /// execution, which happens right before flush.
-    ///
-    /// [`DECTCEM`]: https://vt100.net/docs/vt510-rm/DECTCEM.html
     fn paint_diff(
         &mut self,
         render_ops: RenderOpOutputVec,
@@ -629,13 +150,6 @@ pub trait OffscreenBufferPaint {
         paint_mode: PaintMode,
     );
 }
-
-// Core implementations moved from ofs_buf_core_impl.rs.
-
-use super::PixelCharDiffChunks;
-use crate::{List, col, fg_green, row};
-use std::{fmt::{self},
-          ops::{Deref, DerefMut}};
 
 impl Debug for PixelCharDiffChunks {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -717,24 +231,26 @@ impl OffscreenBuffer {
     }
 
     /// Creates a new buffer and fills it with empty chars.
+    ///
+    /// This constructor also pre-calculates the exact memory footprint of the buffer
+    /// and caches it in [`cached_memory_size`]. Because the buffer's grid dimensions
+    /// are fixed at creation time, calculating this upfront provides an O(1) getter
+    /// for memory metrics without requiring expensive recursive traversals later.
+    ///
+    /// [`cached_memory_size`]: Self::cached_memory_size
     #[must_use]
     pub fn new_empty(arg_window_size: impl Into<Size>) -> Self {
         let window_size = arg_window_size.into();
         let buffer = PixelCharLines::new_empty(window_size);
 
-        let memory_size = {
+        let cached_memory_size = {
             // Calculate memory size once - it will never change since buffer dimensions
-            // are fixed. Account for both the primary and alternate screen buffers, as
-            // well as all cursor states.
+            // are fixed.
             let primary_buffer_mem = buffer.get_mem_size();
-            let alt_buffer_mem = primary_buffer_mem;
             MemorySize::new(
                 primary_buffer_mem
-                + alt_buffer_mem
                 + size_of::<Size>() // window_size
-                + size_of::<Pos>()  // cursor_pos
-                + size_of::<Pos>()  // cursor_pos_primary
-                + size_of::<Pos>(), // cursor_pos_alt
+                + size_of::<Pos>(), // cursor_pos
             )
         };
 
@@ -742,10 +258,7 @@ impl OffscreenBuffer {
             buffer,
             window_size,
             cursor_pos: Pos::default(),
-            terminal_mode: TerminalModeState::default(),
-            memory_size,
-            ansi_parser_support: super::AnsiParserSupport::default(),
-            alt_screen_support: AltScreenSupport::new_empty(window_size),
+            cached_memory_size,
         }
     }
 
@@ -764,7 +277,7 @@ impl OffscreenBuffer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{height, width};
+    use crate::{TuiStyle, height, width};
 
     fn create_test_buffer() -> OffscreenBuffer {
         let size = height(3) + width(4);
@@ -776,18 +289,6 @@ mod tests {
             display_char: ch,
             style: TuiStyle::default(),
         }
-    }
-
-    #[test]
-    fn test_character_set_default() {
-        let charset = CharacterSet::default();
-        assert!(matches!(charset, CharacterSet::Ascii));
-    }
-
-    #[test]
-    fn test_ansi_parser_support_default() {
-        let support = AnsiParserSupport::default();
-        assert!(matches!(support.character_set, CharacterSet::Ascii));
     }
 
     #[test]
@@ -805,12 +306,6 @@ mod tests {
                 assert!(matches!(pixel_char, PixelChar::Spacer));
             }
         }
-
-        // Check ANSI parser support is initialized.
-        assert!(matches!(
-            buffer.ansi_parser_support.character_set,
-            CharacterSet::Ascii
-        ));
     }
 
     #[test]
@@ -957,7 +452,10 @@ mod tests {
     }
 
     #[test]
-    fn test_offscreen_buffer_memory_size() {
+    fn test_offscreen_buffer_cached_memory_size() {
+        // TRIPWIRE: This test verifies that `GetMemSize` returns a consistent value.
+        // If you added a field, ensure that `OffscreenBuffer::new_empty` correctly
+        // includes its memory size in the `cached_memory_size` calculation block!
         let buffer = create_test_buffer();
 
         let mem_size = buffer.get_mem_size();
@@ -966,6 +464,19 @@ mod tests {
         // Test that get_mem_size returns the same value consistently.
         let size2 = buffer.get_mem_size();
         assert_eq!(mem_size, size2);
+    }
+
+    #[test]
+    fn test_offscreen_buffer_struct_size() {
+        // TRIPWIRE: If you add or remove a field from `OffscreenBuffer`, this test will
+        // fail. This is intentional! It reminds you to:
+        // 1. Update `OffscreenBuffer::new_empty` to include your new field's size in
+        //    `cached_memory_size`.
+        // 2. Update this exact byte-size assertion.
+        #[cfg(target_pointer_width = "64")]
+        {
+            assert_eq!(std::mem::size_of::<OffscreenBuffer>(), 416);
+        }
     }
 
     #[test]
@@ -1031,22 +542,5 @@ mod tests {
 
         let diff_chunks = diff.unwrap();
         assert_eq!(diff_chunks.len(), 3);
-    }
-
-    #[test]
-    fn test_character_set_enum() {
-        // Test that CharacterSet enum variants exist.
-        let ascii = CharacterSet::Ascii;
-        let dec_graphics = CharacterSet::DECGraphics;
-
-        // They should be different.
-        assert_ne!(ascii, dec_graphics);
-
-        // Test debug formatting.
-        let ascii_debug = format!("{ascii:?}");
-        let dec_graphics_debug = format!("{dec_graphics:?}");
-
-        assert!(ascii_debug.contains("Ascii"));
-        assert!(dec_graphics_debug.contains("DECGraphics"));
     }
 }

--- a/tui/src/tui/terminal_lib_backends/offscreen_buffer/ofs_buf_line_level_ops.rs
+++ b/tui/src/tui/terminal_lib_backends/offscreen_buffer/ofs_buf_line_level_ops.rs
@@ -61,11 +61,11 @@ impl OffscreenBuffer {
 #[cfg(test)]
 mod tests_line_level_ops {
     use super::*;
-    use crate::{PixelChar, TuiStyle, col, height, len, width};
+    use crate::{OfsBufVT100, PixelChar, TuiStyle, col, height, len, width};
 
-    fn create_test_buffer() -> OffscreenBuffer {
+    fn create_test_buffer() -> OfsBufVT100 {
         let size = width(4) + height(5);
-        OffscreenBuffer::new_empty(size)
+        OfsBufVT100::new_empty(size)
     }
 
     fn create_test_char(ch: char) -> PixelChar {

--- a/tui/src/tui/terminal_lib_backends/offscreen_buffer/paint_impl.rs
+++ b/tui/src/tui/terminal_lib_backends/offscreen_buffer/paint_impl.rs
@@ -74,7 +74,6 @@ use crate::{ColIndex, PaintMode, DEBUG_TUI_COMPOSITOR, DEBUG_TUI_SHOW_PIPELINE, 
             OffscreenBufferPaint, PixelChar, PixelCharDiffChunks, RenderOpCommon,
             RenderOpFlush, RenderOpOutput, RenderOpOutputVec, RenderOpsExec, RowIndex,
             Size, TERMINAL_LIB_BACKEND, TerminalLibBackend, TuiStyle, ch, col,
-            CursorVisibilityState,
             glyphs::SPACER_GLYPH, row,
             terminal_lib_backends::{crossterm_backend::PaintRenderOpImplCrossterm,
                                     direct_to_ansi::RenderOpPaintImplDirectToAnsi}};
@@ -85,12 +84,11 @@ pub struct OffscreenBufferPaintImpl;
 impl OffscreenBufferPaint for OffscreenBufferPaintImpl {
     fn paint(
         &mut self,
-        mut render_ops: RenderOpOutputVec,
+        render_ops: RenderOpOutputVec,
         flush_kind: FlushKind,
         window_size: Size,
         locked_output_device: LockedOutputDevice<'_>,
         paint_mode: PaintMode,
-        cursor_visibility: CursorVisibilityState,
     ) {
         let mut skip_flush = false;
 
@@ -105,12 +103,6 @@ impl OffscreenBufferPaint for OffscreenBufferPaintImpl {
                     RenderOpPaintImplDirectToAnsi.clear_before_flush(locked_output_device);
                 }
             }
-        }
-
-        // Apply cursor visibility state.
-        match cursor_visibility {
-            CursorVisibilityState::Visible => render_ops.push(RenderOpCommon::ShowCursor),
-            CursorVisibilityState::Hidden => render_ops.push(RenderOpCommon::HideCursor),
         }
 
         // Execute each RenderOpOutput using the ExecutableRenderOps trait.
@@ -145,19 +137,12 @@ impl OffscreenBufferPaint for OffscreenBufferPaintImpl {
 
     fn paint_diff(
         &mut self,
-        mut render_ops: RenderOpOutputVec,
+        render_ops: RenderOpOutputVec,
         window_size: Size,
         locked_output_device: LockedOutputDevice<'_>,
         paint_mode: PaintMode,
-        cursor_visibility: CursorVisibilityState,
     ) {
         let mut skip_flush = false;
-
-        // Apply cursor visibility state.
-        match cursor_visibility {
-            CursorVisibilityState::Visible => render_ops.push(RenderOpCommon::ShowCursor),
-            CursorVisibilityState::Hidden => render_ops.push(RenderOpCommon::HideCursor),
-        }
 
         // Execute each RenderOpOutput using the ExecutableRenderOps trait.
         render_ops.execute_all(

--- a/tui/src/tui/terminal_lib_backends/offscreen_buffer/paint_impl.rs
+++ b/tui/src/tui/terminal_lib_backends/offscreen_buffer/paint_impl.rs
@@ -69,12 +69,14 @@
 //! [rendering pipeline overview]: mod@crate::terminal_lib_backends#rendering-pipeline-architecture
 
 // Copyright (c) 2022-2025 R3BL LLC. Licensed under Apache License, Version 2.0.
-use crate::{ColIndex, PaintMode, DEBUG_TUI_COMPOSITOR, DEBUG_TUI_SHOW_PIPELINE, FlushKind,
+use crate::{ColIndex, DEBUG_TUI_COMPOSITOR, DEBUG_TUI_SHOW_PIPELINE, FlushKind,
             GCStringOwned, InlineString, LockedOutputDevice, OffscreenBuffer,
-            OffscreenBufferPaint, PixelChar, PixelCharDiffChunks, RenderOpCommon,
-            RenderOpFlush, RenderOpOutput, RenderOpOutputVec, RenderOpsExec, RowIndex,
-            Size, TERMINAL_LIB_BACKEND, TerminalLibBackend, TuiStyle, ch, col,
-            glyphs::SPACER_GLYPH, row,
+            OffscreenBufferPaint, PaintMode, PixelChar, PixelCharDiffChunks,
+            RenderOpCommon, RenderOpFlush, RenderOpOutput, RenderOpOutputVec,
+            RenderOpsExec, RowIndex, Size, TERMINAL_LIB_BACKEND, TerminalLibBackend,
+            TuiStyle, ch, col,
+            glyphs::SPACER_GLYPH,
+            row,
             terminal_lib_backends::{crossterm_backend::PaintRenderOpImplCrossterm,
                                     direct_to_ansi::RenderOpPaintImplDirectToAnsi}};
 
@@ -100,7 +102,8 @@ impl OffscreenBufferPaint for OffscreenBufferPaintImpl {
             }
             TerminalLibBackend::DirectToAnsi => {
                 if let FlushKind::ClearBeforeFlush = flush_kind {
-                    RenderOpPaintImplDirectToAnsi.clear_before_flush(locked_output_device);
+                    RenderOpPaintImplDirectToAnsi
+                        .clear_before_flush(locked_output_device);
                 }
             }
         }

--- a/tui/src/tui/terminal_lib_backends/offscreen_buffer/pixel_char.rs
+++ b/tui/src/tui/terminal_lib_backends/offscreen_buffer/pixel_char.rs
@@ -26,10 +26,7 @@ pub enum PixelChar {
     Spacer,
 
     /// An actual printable character with associated styling information.
-    PlainText {
-        display_char: char,
-        style: TuiStyle,
-    },
+    PlainText { display_char: char, style: TuiStyle },
 }
 
 pub const EMPTY_CHAR: char = '╳';
@@ -74,7 +71,9 @@ impl Debug for PixelChar {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{SPACER_GLYPH_CHAR, height, new_style, tui::terminal_lib_backends::offscreen_buffer::OffscreenBuffer, tui_color, tui_style_attrib::Underline, tui_style_attribs, width};
+    use crate::{SPACER_GLYPH_CHAR, height, new_style,
+                tui::terminal_lib_backends::offscreen_buffer::OffscreenBuffer,
+                tui_color, tui_style_attrib::Underline, tui_style_attribs, width};
 
     fn create_test_buffer() -> OffscreenBuffer {
         let window_size = width(4) + height(2);

--- a/tui/src/tui/terminal_lib_backends/offscreen_buffer/pixel_char_line.rs
+++ b/tui/src/tui/terminal_lib_backends/offscreen_buffer/pixel_char_line.rs
@@ -11,9 +11,8 @@
 //! [`PixelCharLine`]: crate::PixelCharLine
 
 use super::PixelChar;
-use crate::{ok, tiny_inline_string};
 use crate::{ColWidth, GetMemSize, InlineVec, TinyInlineString, dim_underline,
-            get_mem_size};
+            get_mem_size, ok, tiny_inline_string};
 use smallvec::smallvec;
 use std::{fmt::{self, Debug},
           ops::{Deref, DerefMut}};

--- a/tui/src/tui/terminal_lib_backends/offscreen_buffer/pixel_char_lines.rs
+++ b/tui/src/tui/terminal_lib_backends/offscreen_buffer/pixel_char_lines.rs
@@ -19,6 +19,19 @@ pub struct PixelCharLines {
 }
 
 impl GetMemSize for PixelCharLines {
+    /// Calculates the memory footprint by performing a full traversal of the 2D grid.
+    ///
+    /// This method is an `O(rows * columns)` operation because it iterates over every
+    /// [`PixelCharLine`] and every [`PixelChar`] within it to sum their sizes.
+    ///
+    /// # Performance
+    ///
+    /// Due to the significant runtime cost of this full grid traversal, callers (such as
+    /// parent structs that wrap this grid) should cache the result upon initialization.
+    /// Calling this method dynamically inside a hot loop, such as during a render cycle,
+    /// will result in a severe performance regression.
+    ///
+    /// [`PixelChar`]: crate::PixelChar
     fn get_mem_size(&self) -> usize { get_mem_size::slice_size(self.lines.as_ref()) }
 }
 

--- a/tui/src/tui/terminal_lib_backends/offscreen_buffer/test_fixtures_ofs_buf.rs
+++ b/tui/src/tui/terminal_lib_backends/offscreen_buffer/test_fixtures_ofs_buf.rs
@@ -5,8 +5,8 @@
 //! This module provides assertion functions that are used by various test modules
 //! to verify the state of the offscreen buffer contents.
 
-use crate::{ColWidth, LengthOps, OffscreenBuffer, PixelChar, PixelCharLine, RowHeight,
-            SPACER_GLYPH_CHAR, TuiStyle, col, row};
+use crate::{ColWidth, LengthOps, OffscreenBuffer, OfsBufVT100, PixelChar, PixelCharLine,
+            RowHeight, SPACER_GLYPH_CHAR, TuiStyle, col, row};
 
 /// Assert that a plain character exists at the given position.
 /// This function checks that:
@@ -217,6 +217,15 @@ pub fn create_test_buffer_with_size(
     buffer_height: RowHeight,
 ) -> OffscreenBuffer {
     OffscreenBuffer::new_empty(buffer_width + buffer_height)
+}
+
+#[cfg(test)]
+#[must_use]
+pub fn create_vt100_test_buffer_with_size(
+    buffer_width: ColWidth,
+    buffer_height: RowHeight,
+) -> OfsBufVT100 {
+    OfsBufVT100::new_empty(buffer_width + buffer_height)
 }
 
 /// Creates a plain text [`PixelChar`] with default styling.

--- a/tui/src/tui/terminal_lib_backends/paint.rs
+++ b/tui/src/tui/terminal_lib_backends/paint.rs
@@ -46,23 +46,12 @@ use crate::{DEBUG_TUI_COMPOSITOR, PaintMode, DEBUG_TUI_SHOW_PIPELINE_EXPANDED, G
 use std::fmt::Debug;
 
 /// Executes a selective redraw (diff) paint.
-///
-/// It extracts the [`cursor_visibility`] from the [`OffscreenBuffer`] (which tracks the
-/// parsed [`DECTCEM`] `?25h`/`l` state) and injects it into the execution layer. This
-/// ensures the terminal emulator cursor correctly matches the simulated state before
-/// rendering any ops.
-///
-/// [`cursor_visibility`]: crate::AnsiParserSupport::cursor_visibility
-/// [`DECTCEM`]: https://en.wikipedia.org/wiki/ANSI_escape_code#Set_terminal_mode
-/// [`OffscreenBuffer`]: crate::OffscreenBuffer
 fn perform_diff_paint(
-    ofs_buf: &OffscreenBuffer,
     diff_chunks: &PixelCharDiffChunks,
     window_size: Size,
     locked_output_device: LockedOutputDevice<'_>,
     paint_mode: PaintMode,
 ) {
-    let cursor_visibility = ofs_buf.ansi_parser_support.cursor_visibility;
     match TERMINAL_LIB_BACKEND {
         TerminalLibBackend::Crossterm => {
             let mut crossterm_impl = OffscreenBufferPaintImpl {};
@@ -72,7 +61,6 @@ fn perform_diff_paint(
                 window_size,
                 locked_output_device,
                 paint_mode,
-                cursor_visibility,
             );
         }
         TerminalLibBackend::DirectToAnsi => {
@@ -86,22 +74,12 @@ fn perform_diff_paint(
                 window_size,
                 locked_output_device,
                 paint_mode,
-                cursor_visibility,
             );
         }
     }
 }
 
 /// Executes a complete redraw (full) paint.
-///
-/// It extracts the [`cursor_visibility`] from the [`OffscreenBuffer`] (which tracks the
-/// parsed [`DECTCEM`] `?25h`/`l` state) and injects it into the execution layer. This
-/// ensures the terminal emulator cursor correctly matches the simulated state before
-/// rendering any ops.
-///
-/// [`cursor_visibility`]: crate::AnsiParserSupport::cursor_visibility
-/// [`DECTCEM`]: https://en.wikipedia.org/wiki/ANSI_escape_code#Set_terminal_mode
-/// [`OffscreenBuffer`]: crate::OffscreenBuffer
 fn perform_full_paint(
     ofs_buf: &OffscreenBuffer,
     flush_kind: FlushKind,
@@ -109,7 +87,6 @@ fn perform_full_paint(
     locked_output_device: LockedOutputDevice<'_>,
     paint_mode: PaintMode,
 ) {
-    let cursor_visibility = ofs_buf.ansi_parser_support.cursor_visibility;
     match TERMINAL_LIB_BACKEND {
         TerminalLibBackend::Crossterm => {
             let mut crossterm_impl = OffscreenBufferPaintImpl {};
@@ -120,7 +97,6 @@ fn perform_full_paint(
                 window_size,
                 locked_output_device,
                 paint_mode,
-                cursor_visibility,
             );
         }
         TerminalLibBackend::DirectToAnsi => {
@@ -135,7 +111,6 @@ fn perform_full_paint(
                 window_size,
                 locked_output_device,
                 paint_mode,
-                cursor_visibility,
             );
         }
     }
@@ -213,7 +188,6 @@ pub fn paint<S, AS>(
                 }
                 Some(ref diff_chunks) => {
                     perform_diff_paint(
-                        &buffer_from_pool,
                         diff_chunks,
                         window_size,
                         locked_output_device,

--- a/tui/src/tui/terminal_lib_backends/render_op/render_op_common.rs
+++ b/tui/src/tui/terminal_lib_backends/render_op/render_op_common.rs
@@ -189,7 +189,7 @@ pub enum RenderOpCommon {
 
     /// Save cursor position to be restored later.
     ///
-    /// Maps to [`CSI`] `s` [`ANSI`] sequence (also known as DECSC - save cursor).
+    /// Maps to [`CSI`] `s` [`ANSI`] sequence (also known as [`DECSC`] - save cursor).
     ///
     /// Saves the current cursor position (row and column) in terminal memory.
     /// Use with [`RenderOpCommon::RestoreCursorPosition`] to return to this position.
@@ -199,12 +199,13 @@ pub enum RenderOpCommon {
     ///
     /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
     /// [`CSI`]: crate::CsiSequence
+    /// [`DECSC`]: https://vt100.net/docs/vt510-rm/DECSC.html
     SaveCursorPosition,
 
     /// Restore cursor position previously saved with
     /// [`RenderOpCommon::SaveCursorPosition`].
     ///
-    /// Maps to [`CSI`] `u` [`ANSI`] sequence (also known as DECRC - restore cursor).
+    /// Maps to [`CSI`] `u` [`ANSI`] sequence (also known as [`DECRC`] - restore cursor).
     ///
     /// Restores the cursor to the position that was previously saved.
     ///
@@ -213,6 +214,7 @@ pub enum RenderOpCommon {
     ///
     /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
     /// [`CSI`]: crate::CsiSequence
+    /// [`DECRC`]: https://vt100.net/docs/vt510-rm/DECRC.html
     RestoreCursorPosition,
 
     /// Switches to alternate screen buffer for full-screen applications.


### PR DESCRIPTION
Design doc detailing the clean reversion approach to fix the global component pipeline cursor bug. Resolves #461