### PR TITLE
feat: add OffscreenBuffer::resize() for pane resize without content loss

### DIFF
--- a/.agents/skills/fast-string-allocations/SKILL.md
+++ b/.agents/skills/fast-string-allocations/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: fast-string-allocations
+description: Zero-allocation string building strategies. Use when formatting strings, generating ANSI codes, or writing hot loops to avoid heap allocations and Formatter state machine overhead.
+---
+
+# Fast String Allocations & Zero-Overhead Formatting
+
+When writing code that involves string building, formatting, or rendering (especially in the TUI engine, logging, or event loops), you MUST adhere to the codebase's strict zero-allocation architecture.
+
+## When to Use
+
+- When building ANSI escape sequences
+- When building strings in a 60 FPS event loop or render cycle
+- When using `tracing::*!` macros
+- Whenever you are tempted to use `format!` or `write!` on a `Formatter`
+
+## Core Strategy
+
+Read the full Source of Truth at `mod@crate::core::common::fast_strings#string-allocation-performance-strategy` for detailed architectural constraints.
+
+### Performance Hierarchy (Fastest to Slowest)
+
+1. **Direct `push_str()`** - Zero overhead, direct memory copy.
+2. **`crate::format_no_alloc!`** - Zero heap allocations, reuses existing heap.
+3. **`FastStringify`** - Temporary heap allocation, completely bypasses `Formatter` state machine.
+4. **`inline_string!`** - Stack allocated (16 bytes), but dynamically spills to the heap if exceeded.
+5. **`format!` / `write!`** - Always heap allocates (`format!`) OR uses heavy formatter overhead (`write!`). Avoid in hot paths.
+
+## Implementation Guidelines
+
+### 1. The `FastStringify` Trait
+Use for custom types (like `ANSI` codes) that are serialized millions of times.
+- Bypasses the expensive `Formatter` state machine by pushing everything into a temporary heap `String` and making ONE `f.write_str()` call.
+- Use `generate_impl_display_for_fast_stringify!` to auto-generate the `Display` block.
+
+### 2. The `inline_string!` Macro
+Use for stack-allocated strings (16 bytes).
+- Drop-in replacement for `format!`.
+- The primary use case is the core Editor Component and `tracing::*!` macros.
+- **Warning:** If text exceeds 16 bytes, it spills to the heap and incurs the cost of `format!`.
+
+### 3. The `format_no_alloc!` Macro
+Use for hot loops where the string is guaranteed to exceed 16 bytes (meaning `inline_string!` would spill).
+- Hoist a `String::with_capacity(N)` outside the loop.
+- Pass the hoisted string into the macro inside the loop to clear and write into the existing capacity.
+- Zero allocations per tick.

--- a/.agents/skills/run-clippy/SKILL.md
+++ b/.agents/skills/run-clippy/SKILL.md
@@ -80,7 +80,25 @@ Each gets its own period:
 - Each line could stand alone as a complete thought
 - Separate sentences with distinct subjects
 
-### Step 3: Verify Module Organization
+### Step 3: Enforce Clean Imports (No Inline Absolute Paths)
+
+Scan the changed files for any inline absolute paths (e.g., `crate::Type`, `crate::function!`) and replace them with proper `use` statements at the top of the file.
+
+**✅ Good:**
+```rust
+use crate::{Size, Pos};
+
+pub fn render(size: Size) -> Pos { ... }
+```
+
+**❌ Bad:**
+```rust
+pub fn render(size: crate::Size) -> crate::Pos { ... }
+```
+
+*Note: Intra-doc links like `/// [`Type`]: crate::Type` are exempt from this rule and SHOULD use `crate::` paths.*
+
+### Step 4: Verify Module Organization
 
 Review all `mod.rs` files in the git working tree and ensure they follow the patterns from the `organize-modules` skill:
 
@@ -92,7 +110,7 @@ Review all `mod.rs` files in the git working tree and ensure they follow the pat
 
 If module organization doesn't follow patterns, invoke the `organize-modules` skill for guidance.
 
-### Step 4: Verify Documentation Quality
+### Step 5: Verify Documentation Quality
 
 If working with rustdoc comments (`///` or `//!`):
 

--- a/.agents/skills/write-structured-tracing/SKILL.md
+++ b/.agents/skills/write-structured-tracing/SKILL.md
@@ -40,9 +40,11 @@ crate::DEBUG_TUI_MOD.then(|| {
 });
 ```
 
-## 4. Using `inline_string!` for Complex Formatting
+## 4. Using `inline_string!` vs `format!` for Complex Formatting
 
-When you need to format complex strings within a tracing field, use the `inline_string!` macro and bind it to a field using the `%` (Display) modifier.
+When you need to format complex strings within a tracing field, bind it to a field using the `%` (Display) modifier and follow this rule:
+- If the resulting string will be **<= 16 bytes**, use the `inline_string!` macro to stack-allocate it.
+- If the resulting string will be **> 16 bytes**, use the standard `format!` macro (since `inline_string!` would spill to the heap and allocate anyway).
 
 ```rust
 crate::DEBUG_TUI_MOD.then(|| {
@@ -71,7 +73,7 @@ crate::DEBUG_TUI_PTY_MUX.then(|| {
     // % is Display, ? is Debug.
     tracing::debug! {
         message = "PTYMux::run_event_loop",
-        input_event = %inline_string!("{:?}", input_event)
+        input_event = %format!("{:?}", input_event)
     };
 });
 ```

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -80,6 +80,7 @@
     "conpty",
     "consoleapi",
     "consts",
+    "cooldown",
     "copypasta",
     "coreutils",
     "creds",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,8 @@ in that skill's directory (e.g., `patterns.md`, `reference.md`, `examples.md`).
 - **concurrency-safety** - Thread safety, Chain of Custody, Loud Lock Releases, and AtomicU8Ext patterns. Use when working with threads, locks, or atomics.
   - Supporting file: `patterns.md` (good/bad examples of lock management)
 
+- **fast-string-allocations** - Zero-allocation string building strategies. Use when formatting strings, generating ANSI codes, or writing hot loops to avoid heap allocations and Formatter overhead.
+
 ### Performance
 
 - **analyze-performance** - Flamegraph-based performance regression detection. Use when optimizing

--- a/task/done/pr-458-fix.md
+++ b/task/done/pr-458-fix.md
@@ -1,5 +1,7 @@
 _Task: PR 458 Integration (Mouse Tracking Mode)_
 
+<!-- cspell:words DECSET -->
+
 # User Story & Context
 
 ## Problem
@@ -55,10 +57,10 @@ Remove the abandoned `CursorModeDetector` pattern from the reader task.
   `PtyOutputEvent::CursorModeChange` which is ignored by all consumers.
 - _The Fix:_ Delete `CursorModeDetector`, remove it from `reader_task.rs`, and remove
   `PtyOutputEvent::CursorModeChange` to simplify the PTY reader pipeline.
-- _File(s) Touched:_ `tui/src/core/pty/pty_mux/reader_task.rs`, `pty_output_event.rs`, and
+- _File(s) Touched:_ `tui/src/core/pty/pty_session/tasks/reader_task.rs`, `pty_output_event.rs`, and
   related modules.
 
-## Phase 2: VT100 Parser State Tracking
+## [x] Phase 2: VT100 Parser State Tracking
 
 Implement parsing and state tracking for xterm mouse mode escape sequences (1000, 1002,
 1003, 1006) natively within the VT100 parser.
@@ -76,7 +78,7 @@ Implement parsing and state tracking for xterm mouse mode escape sequences (1000
   - `tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_mode_ops.rs`
   - `tui/src/core/ansi/vt_100_pty_output_parser/ofs_buf_vt_100.rs`
 
-## Phase 3: Input Routing & SGR Translation
+## [x] Phase 3: Input Routing & SGR Translation
 
 Translate and route `crate::InputEvent::Mouse` events to the PTY stdin when mouse tracking
 is active, utilizing strict type-safe coordinates.
@@ -191,15 +193,15 @@ is active, utilizing strict type-safe coordinates.
   - `tui/src/core/ansi/generator/sgr_mouse.rs`
   - `tui/src/core/pty/pty_mux/input_router.rs`
 
-## Phase 4: Testing
+## [x] Phase 4: Testing
 
 Add unit tests to ensure the new state machine and byte generator behave exactly according
 to the VT-100/Xterm specifications.
 
-- [ ] **Parser State Tests:** In `vt_100_pty_output_conformance_tests.rs` (or similar),
+- [x] **Parser State Tests:** In `vt_100_pty_output_conformance_tests.rs` (or similar),
       write tests verifying that sending `CSI ? 1000 h`, `1002 h`, etc. correctly
       transitions `mouse_tracking` to `Enabled`, and `l` resets it.
-- [ ] **SGR Byte Generator Tests:** Add unit tests for `SgrMouseSequence::generate()`
+- [x] **SGR Byte Generator Tests:** Add unit tests for `SgrMouseSequence::generate()`
       verifying all the complex bitwise logic (avoid magic strings; build expected outputs
       using `CSI_START`, `MOUSE_*` constants, and formatting macros):
   - Left click at x=10, y=10 ->
@@ -210,19 +212,77 @@ to the VT-100/Xterm specifications.
     `format!("{CSI_START}<{}{CSI_PARAM_SEPARATOR}10{CSI_PARAM_SEPARATOR}10{MOUSE_SGR_PRESS}", MOUSE_RIGHT_BUTTON_CODE | MOUSE_MODIFIER_SHIFT).into_bytes()`
   - Scroll Up/Down -> correct button IDs and state characters
 
+## [x] Phase 5: Clean up contract between pty_mux_example and pty_mux core module
+
+1. **Problem Statement:** The core `InputRouter` currently hardcodes application-specific
+   UX logic (like `Ctrl+Q` to exit, `F1-F12` for process switching, and desktop
+   notifications). This conflates the example application's requirements with the core
+   multiplexer logic.
+2. **Injection Point (Interceptor):** Introduce a type alias for the interceptor closure
+   that the `PTYMuxBuilder` can accept. This interceptor runs _before_ the `InputRouter`
+   gets the event.
+   ```rust
+   // Readable type alias for the interceptor closure
+   pub type InputInterceptorFn = Box<dyn FnMut(&InputEvent, &mut ProcessManager) -> EventPropagation>;
+   ```
+   We will use the existing `r3bl_tui::EventPropagation` enum to control the bubbling:
+   - `Propagate`: Application ignored the event, let core route it.
+   - `Consumed`: Application handled the event (e.g., switched process).
+   - `ExitMainEventLoop`: Application handled the event and wants to shut down `PTYMux`.
+3. **Refactor `InputRouter`:** Strip out the `F1-F12` and `Ctrl+Q` logic from
+   `InputRouter::handle_input`. Its only responsibilities should be:
+   - Translating `InputEvent::Mouse` into `SGR` sequences and sending them to the active
+     PTY.
+   - Fallback forwarding of all other `InputEvent::Keyboard` events to the active PTY.
+   - Handling `InputEvent::Resize` and `Shutdown`.
+4. **Update `pty_mux_example`:** Implement the interceptor in the example code to provide
+   a closure configuring `F1-F12` to switch processes via `process_manager.switch_to(idx)`
+   and return `EventConsumed::Consumed`, and returning `EventConsumed::Propagate` for all
+   others.
+5. **Clean up dependencies:** Move `show_notification_non_blocking` into
+   `core/notification.rs`.
+
+## [x] Phase 6: String Allocation Architecture (`fast_strings`)
+
+Establish a definitive Zero-Allocation and Performance String architecture for the entire
+codebase.
+
+- _Context:_ We identified confusion and redundant documentation regarding
+  `FastStringify`, `format_no_alloc!`, and `inline_string!`.
+- _The Fix:_
+  - Extracted performance-critical string operations into a new module:
+    `tui/src/core/common/fast_strings/`.
+  - Created a definitive Source of Truth (SOT) in `fast_strings/mod.rs` outlining the
+    Performance Hierarchy.
+  - Linked all relevant types and macros to this central SOT via intra-doc links.
+  - Created a new `fast-string-allocations` skill in `.agents/skills/`.
+
 ---
 
 ## Final Verification & Cleanup
 
-- [ ] Verify full test suite coverage using `./check.fish --full`. and run
+- [x] Verify full test suite coverage using `./check.fish --full`. and run
       `check code quality` skill.
-- [ ] **Mandatory manual review:** Verify every file modified in this task.
-  - [ ] `tui/src/core/ansi/vt_100_pty_output_parser/protocols/csi_codes/private_mode.rs`
-  - [ ] `tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_mode_ops.rs`
-  - [ ] `tui/src/core/ansi/vt_100_pty_output_parser/ofs_buf_vt_100.rs`
-  - [ ] `tui/src/core/pty/pty_mux/input_router.rs`
-  - [ ] `tui/src/core/pty/pty_mux/reader_task.rs`
-  - [ ] `task/prepare-v0.8.0-meta-task.md`
+- [x] **Mandatory manual review:** Verify every file modified in this task.
+  - [x] `tui/src/core/common/fast_strings/fast_stringify.rs`
+  - [x] `tui/src/core/common/fast_strings/format_no_alloc.rs`
+  - [x] `tui/src/core/common/fast_strings/mod.rs`
+  - [x] `tui/src/core/pty/pty_mux/mod.rs`
+  - [x] `tui/src/core/pty/pty_mux/mux.rs`
+  - [x] `tui/src/core/pty/pty_mux/adaptive_render_budget.rs`
+  - [x] `tui/src/core/ansi/vt_100_pty_output_parser/protocols/csi_codes/private_mode.rs`
+  - [x] `tui/src/core/pty/pty_mux/input_router.rs`
+  - [x] `tui/src/core/ansi/vt_100_pty_output_parser/types.rs`
+  - [x] `tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_mode_ops.rs`
+  - [x] `tui/src/core/ansi/vt_100_pty_output_parser/ofs_buf_vt_100.rs`
+  - [x] `tui/src/core/pty/pty_session/tasks/reader_task.rs`
+  - [x] `tui/src/core/ansi/generator/sgr_mouse_sequence.rs`
+  - [x] `tui/src/core/pty/pty_mux/process_manager.rs`
+  - [x] `tui/src/core/mod.rs`
+  - [x] `tui/src/core/notification.rs`
+  - [x] `tui/src/tui/mod.rs`
+  - [x] `tui/examples/pty_mux_example.rs`
+  - [x] `task/prepare-v0.8.0-meta-task.md`
 - [ ] Ensure all work was done on a new branch (e.g., `feat-pty-mouse-tracking`), rather
       than committing directly to `main` or Cecile's divergent branch.
 - [ ] When ready to merge, use the `/merge-pr` slash command to cleanly rebase and merge

--- a/task/prepare-v0.8.0-meta-task.md
+++ b/task/prepare-v0.8.0-meta-task.md
@@ -37,13 +37,16 @@ _Meta Task: Prepare v0.8.0 Release_
 - [x] [LF scroll-up test fix](done/pr-462-fix.md) - https://github.com/r3bl-org/r3bl-open-core/pull/462
 - [x] [DA1 Responses timeout fix](done/pr-455-fix.md) - https://github.com/r3bl-org/r3bl-open-core/pull/455
 - [x] [VT100 Pending Wrap fix](done/pr-456-fix.md) - https://github.com/r3bl-org/r3bl-open-core/pull/456
-- [ ] [Mouse Event Forwarding](pr-458-fix.md) - https://github.com/r3bl-org/r3bl-open-core/pull/458
+- [x] [Mouse Event Forwarding](done/pr-458-fix.md) - https://github.com/r3bl-org/r3bl-open-core/pull/458
+- [ ] [invert control and decouple UI in pty_mux](pty-mux-invert-control.md)
 - [ ] [Scrollback Buffer for PTY](pr-459-fix.md) - https://github.com/r3bl-org/r3bl-open-core/pull/459
 - [ ] **NEEDS RESEARCH & PLANNING** https://github.com/r3bl-org/r3bl-open-core/pull/468
 - [ ] **NEEDS RESEARCH & PLANNING** https://github.com/r3bl-org/r3bl-open-core/pull/466
 - [ ] **NEEDS RESEARCH & PLANNING** https://github.com/r3bl-org/r3bl-open-core/pull/467
 - [ ] **NEEDS RESEARCH & PLANNING** https://github.com/r3bl-org/r3bl-open-core/pull/464
 - [ ] **NEEDS RESEARCH & PLANNING** https://github.com/r3bl-org/r3bl-open-core/pull/465
+- [ ] **NEEDS RESEARCH & PLANNING** https://github.com/r3bl-org/r3bl-open-core/pull/469
+- [ ] [wire up bracketed paste in pty_mux](pty-mux-bracketed-paste.md)
 - [ ] [fix fish shell issues in pty_mux module](task/fix-fish-in-pty-mux.md)
 
 # [TODO] Unify rendering

--- a/task/pty-mux-bracketed-paste.md
+++ b/task/pty-mux-bracketed-paste.md
@@ -1,0 +1,21 @@
+# Implement Bracketed Paste Support in PTY Mux
+
+## Context
+The `PTY` multiplexer currently has a `bracketed_paste` field in `OfsBufVT100` that is marked with `#[allow(dead_code)]`. The `VT-100` sequences for bracketed paste (`ESC [ ? 2004 h` / `ESC [ ? 2004 l`) are currently ignored by the parser in `vt_100_shim_mode_ops.rs`.
+
+Because the multiplexer uses crossterm (which enables bracketed paste on the host terminal globally), all pasted text arrives at `PTYMux` as a single `Event::Paste(text)`. We need to dynamically route this paste event to the active child process, wrapping it in `\x1b[200~` and `\x1b[201~` only if the child process requested bracketed paste mode.
+
+## [ ] Phase 1: Un-ignore the sequence and track state
+- Modify `vt_100_shim_mode_ops.rs` to stop ignoring `ESC [ ? 2004 h` and `ESC [ ? 2004 l`.
+- Wire these sequences to update `OfsBufVT100.bracketed_paste`.
+- Remove the `#[allow(dead_code)]` from `BracketedPasteState` in `ofs_buf_vt_100.rs`.
+
+## [ ] Phase 2: Route `Event::Paste` in `InputRouter`
+- Update `InputRouter::handle_input` to properly handle `crossterm::event::Event::Paste(text)`.
+- When a `Paste` event is received, query the active process's `terminal_state.bracketed_paste`.
+- If `Enabled`, send `\x1b[200~` + `text` + `\x1b[201~` to the child PTY.
+- If `Disabled`, simply send the raw `text` to the child PTY.
+
+## [ ] Phase 3: Verification
+- Add integration tests verifying that pasting text routes correctly based on the active process's bracketed paste mode.
+- Update `prepare-v0.8.0-meta-task.md` and check this task off.

--- a/task/pty-mux-invert-control.md
+++ b/task/pty-mux-invert-control.md
@@ -1,0 +1,22 @@
+# Refactor PTY Mux: Invert Control and Decouple UI (SOC)
+
+## Context
+Currently, the `PTYMux` engine takes over the main thread with a blocking `loop {}`, meaning it owns the event loop, handles all rendering itself, and hardcodes the status bar text directly in its `OutputRenderer`. This limits composability and makes it difficult for applications to integrate `PTYMux` seamlessly.
+
+To solve this, we need to invert the control flow, turning `PTYMux` into an event-driven engine that the application can drive.
+
+## Goals & Benefits
+- **Widget Composability**: `PTYMux` becomes a reusable component yielding an `OffscreenBuffer`, allowing apps to seamlessly place terminals in split panes or layouts.
+- **App-Level Interception**: The app owns the event loop, meaning it can easily intercept keys to render global overlays (like a Command Palette) without the engine swallowing the events.
+- **True Decoupling**: The application handles the final screen composite and `.flush()`, letting it draw its own custom status bars without the engine knowing about them.
+
+## [ ] Phase 1: Decouple Status Bar UI
+- Refactor `output_renderer.rs` so that the `pty_mux` engine does not hardcode the status bar string (e.g., `F1: Switch | Ctrl+Q: Quit`).
+- Remove the status bar compositing logic from the core engine.
+
+## [ ] Phase 2: Invert the Event Loop
+- Refactor `PTYMux` into an event-driven engine. Instead of a blocking `loop {}`, expose methods like `engine.tick()` and `engine.handle_input()`.
+- Shift the blocking `crossterm` event polling loop out of `PTYMux` and into `pty_mux_example`.
+
+## [ ] Phase 3: Application-Driven Rendering
+- Let `pty_mux_example` retrieve the `OffscreenBuffer` from the engine, composite its own custom status bar UI on top of it, and then explicitly call `.flush()` to draw to the terminal.

--- a/tui/examples/pty_mux_example.rs
+++ b/tui/examples/pty_mux_example.rs
@@ -54,12 +54,13 @@
 //! [`PTYMux`]: r3bl_tui::core::pty_mux::PTYMux
 //! [`SIGWINCH`]: signal_hook::consts::SIGWINCH
 
-use r3bl_tui::{IntoErr, TuiAvailability, assert_terminal_is_interactive,
-               core::pty_mux::PTYMux, ok, set_mimalloc_in_main,
-               try_initialize_logging_global};
+use r3bl_tui::{EventPropagation, InputEvent, IntoErr, Key, KeyPress, KeyState, ModifierKeysMask, TuiAvailability, assert_terminal_is_interactive, core::pty_mux::{PTYMux, ProcessManager}, is_command_available, ok, set_mimalloc_in_main, show_notification_non_blocking, try_initialize_logging_global};
 use tracing_core::LevelFilter;
 
+const ENABLE_NOTIFICATIONS: bool = false;
+
 #[tokio::main]
+#[allow(clippy::too_many_lines)]
 async fn main() -> miette::Result<()> {
     set_mimalloc_in_main!();
     assert_terminal_is_interactive();
@@ -87,7 +88,7 @@ async fn main() -> miette::Result<()> {
     println!("📋 Available processes:");
     let mut current_f_key = 1;
     for (name, command, _args) in &processes {
-        if r3bl_tui::is_command_available(command) {
+        if is_command_available(command) {
             println!("   • F{current_f_key}: {name} ({command})");
             current_f_key += 1;
         }
@@ -101,7 +102,7 @@ async fn main() -> miette::Result<()> {
     let mut added_count = 0;
 
     for (name, command, args) in processes {
-        if r3bl_tui::is_command_available(command) {
+        if is_command_available(command) {
             builder = builder.add_process(name, command, args);
             added_count += 1;
         }
@@ -114,6 +115,8 @@ async fn main() -> miette::Result<()> {
             is installed and in PATH."
         );
     }
+
+    builder = builder.input_interceptor_fn(Box::new(interceptor_fn));
 
     let multiplexer = match builder.build() {
         TuiAvailability::Available(mux) => mux,
@@ -141,4 +144,76 @@ async fn main() -> miette::Result<()> {
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
     ok!()
+}
+
+fn interceptor_fn(
+    input_event: &InputEvent,
+    process_manager: &mut ProcessManager,
+) -> EventPropagation {
+    match input_event {
+        // 1. Handle F1-F12 keys to switch processes.
+        InputEvent::Keyboard(KeyPress::Plain {
+            key: Key::FunctionKey(fn_key),
+        }) => {
+            let fn_number = u8::from(*fn_key);
+            let process_index = (fn_number - 1) as usize;
+
+            if process_index < process_manager.processes().len() {
+                let old_index = process_manager.active_index();
+                if old_index != process_index {
+                    process_manager.switch_to(process_index);
+
+                    if ENABLE_NOTIFICATIONS {
+                        let process_name =
+                            &process_manager.processes()[process_index].command;
+                        show_notification_non_blocking(
+                            "PTY Mux - Process Switch",
+                            &format!("Switching to {process_name}"),
+                        );
+                    }
+                }
+                return EventPropagation::ConsumedRender;
+            }
+        }
+
+        // 2. Handle Ctrl+Q to exit.
+        InputEvent::Keyboard(KeyPress::WithModifiers {
+            key: Key::Character('q'),
+            mask:
+                ModifierKeysMask {
+                    ctrl_key_state: KeyState::Pressed,
+                    ..
+                },
+        }) => {
+            if ENABLE_NOTIFICATIONS {
+                show_notification_non_blocking("PTY Mux - Exit", "Exiting PTY Mux");
+            }
+            return EventPropagation::ExitMainEventLoop;
+        }
+
+        // 3. Log other unhandled keyboard events.
+        InputEvent::Keyboard(key) => {
+            if ENABLE_NOTIFICATIONS {
+                show_notification_non_blocking(
+                    "PTY Mux - Key Press",
+                    &format!("Key pressed: {key:?}"),
+                );
+            }
+        }
+
+        // 4. Log other non-mouse input events.
+        other_event
+            if ENABLE_NOTIFICATIONS && !matches!(other_event, InputEvent::Mouse(_)) =>
+        {
+            show_notification_non_blocking(
+                "PTY Mux - Input Event",
+                &format!("Input event received: {other_event:?}"),
+            );
+        }
+
+        // 5. Ignore everything else.
+        _ => {}
+    }
+
+    EventPropagation::Propagate
 }

--- a/tui/examples/spawn_pty_output_capture.rs
+++ b/tui/examples/spawn_pty_output_capture.rs
@@ -142,7 +142,7 @@ async fn run_build_with_osc_capture(run_number: u32) -> miette::Result<()> {
                             }
                         }
                     }
-                    PtyOutputEvent::Exit(_) | PtyOutputEvent::Output(_) | PtyOutputEvent::UnexpectedExit(_) | PtyOutputEvent::WriteError(_) | PtyOutputEvent::CursorModeChange(_) => {
+                    PtyOutputEvent::Exit(_) | PtyOutputEvent::Output(_) | PtyOutputEvent::UnexpectedExit(_) | PtyOutputEvent::WriteError(_) => {
                         // These events are ignored or handled by the completion logic.
                     }
                 }

--- a/tui/src/core/ansi/constants/input_sequences.rs
+++ b/tui/src/core/ansi/constants/input_sequences.rs
@@ -869,8 +869,7 @@ pub const CSI_PREFIX_LEN: usize = CSI_PREFIX.len();
 
 // ==================== DECCKM Cursor Key Mode Sequences ====================
 //
-// Complete byte sequences for detecting DECCKM mode changes in PTY output. Used by
-// `CursorModeDetector::scan_for_mode_change()`.
+// Complete byte sequences for detecting DECCKM mode changes in PTY output.
 
 /// [`DEC`] Cursor Key Mode (DECCKM) Enable: Switch to application mode cursor keys.
 ///

--- a/tui/src/core/ansi/constants/mouse.rs
+++ b/tui/src/core/ansi/constants/mouse.rs
@@ -26,8 +26,26 @@
 //! `00100011` (Decimal `35`) : Final payload byte (`32 | 3`)
 //! ```
 //!
+//! ### Bitmask arithmetic operations
+//!
+//! *(See also: [`keyboard` module docs] for a contrasting example of where arithmetic
+//! addition is required by the VT100 spec).*
+//!
+//! When combining bitmasks (like applying a modifier to a button):
+//! - **always** use bitwise OR (`|` or `|=`)
+//! - **do not** use of arithmetic addition (`+` or `+=`).
+//!
+//! While `32 + 3 = 35` and `32 | 3 = 35` produce the same result when bits do not
+//! overlap, arithmetic addition is unsafe if a flag is accidentally applied twice. For
+//! example, applying the [`MOUSE_MOTION_FLAG`] (`32`) twice:
+//! - **Unsafe (`+`)**: `32 + 32 = 64`. This causes a binary carry-over into Bit 6,
+//!   corrupting the value and incorrectly triggering the [`MOUSE_SCROLL_THRESHOLD`].
+//! - **Safe (`|`)**: `32 | 32 = 32`. Bitwise OR guarantees the bit is simply turned on,
+//!   preventing state corruption and unintended side effects.
+//!
 //! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
 //! [`CSI`]: crate::CsiSequence
+//! [`keyboard` module docs]: mod@crate::core::ansi::vt_100_terminal_input_parser::keyboard#how-bitmask-encoding-for-modifiers-works
 //! [`RXVT`]: https://en.wikipedia.org/wiki/Rxvt
 //! [`SGR`]: crate::SgrCode
 //! [`X10`]: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-Mouse-Tracking

--- a/tui/src/core/ansi/generator/mod.rs
+++ b/tui/src/core/ansi/generator/mod.rs
@@ -26,6 +26,7 @@ mod dsr_sequence;
 mod esc_sequence;
 mod sgr_code;
 mod da_sequence;
+mod sgr_mouse_sequence;
 
 // Test/doc-only modules.
 #[cfg(any(test, doc))]
@@ -42,3 +43,4 @@ pub use dsr_sequence::*;
 pub use esc_sequence::*;
 pub use sgr_code::*;
 pub use da_sequence::*;
+pub use sgr_mouse_sequence::*;

--- a/tui/src/core/ansi/generator/sgr_mouse_sequence.rs
+++ b/tui/src/core/ansi/generator/sgr_mouse_sequence.rs
@@ -1,0 +1,218 @@
+// Copyright (c) 2025 R3BL LLC. Licensed under Apache License, Version 2.0.
+
+use crate::{Button, KeyState, MouseInput, MouseInputKind, TermCol, TermRow,
+            core::ansi::constants::{MOUSE_LEFT_BUTTON_CODE, MOUSE_MIDDLE_BUTTON_CODE,
+                                    MOUSE_MODIFIER_ALT, MOUSE_MODIFIER_CTRL,
+                                    MOUSE_MODIFIER_SHIFT, MOUSE_MOTION_FLAG,
+                                    MOUSE_RELEASE_BUTTON_CODE, MOUSE_RIGHT_BUTTON_CODE,
+                                    MOUSE_SCROLL_DOWN_BUTTON, MOUSE_SCROLL_LEFT_BUTTON,
+                                    MOUSE_SCROLL_RIGHT_BUTTON, MOUSE_SCROLL_UP_BUTTON,
+                                    MOUSE_SGR_PREFIX, MOUSE_SGR_PRESS,
+                                    MOUSE_SGR_RELEASE}};
+
+#[derive(Debug)]
+pub struct SgrMouseSequence;
+
+impl SgrMouseSequence {
+    /// Generates an [`ANSI`] [`SGR`] mouse sequence for the given `MouseInput`.
+    ///
+    /// The [`SGR`] mouse sequence format is:
+    /// `CSI < button_code ; x ; y M` (for press/scroll/drag/hover)
+    /// `CSI < button_code ; x ; y m` (for release)
+    ///
+    /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
+    /// [`SGR`]: crate::SgrCode
+    #[must_use]
+    pub fn generate(mouse_input: &MouseInput, x: TermCol, y: TermRow) -> Option<Vec<u8>> {
+        let mut is_release = false;
+
+        let mut button_code = match mouse_input.kind {
+            MouseInputKind::MouseDown(button) => Self::get_button_code(button),
+            MouseInputKind::MouseUp(button) => {
+                is_release = true;
+                Self::get_button_code(button)
+            }
+            MouseInputKind::MouseDrag(button) => {
+                Self::get_button_code(button) | MOUSE_MOTION_FLAG
+            }
+            MouseInputKind::MouseMove => MOUSE_RELEASE_BUTTON_CODE | MOUSE_MOTION_FLAG,
+            MouseInputKind::ScrollUp => MOUSE_SCROLL_UP_BUTTON,
+            MouseInputKind::ScrollDown => MOUSE_SCROLL_DOWN_BUTTON,
+            MouseInputKind::ScrollLeft => MOUSE_SCROLL_LEFT_BUTTON,
+            MouseInputKind::ScrollRight => MOUSE_SCROLL_RIGHT_BUTTON,
+        };
+
+        if let Some(modifiers) = &mouse_input.maybe_modifier_keys {
+            if modifiers.shift_key_state == KeyState::Pressed {
+                button_code |= MOUSE_MODIFIER_SHIFT;
+            }
+            if modifiers.alt_key_state == KeyState::Pressed {
+                button_code |= MOUSE_MODIFIER_ALT;
+            }
+            if modifiers.ctrl_key_state == KeyState::Pressed {
+                button_code |= MOUSE_MODIFIER_CTRL;
+            }
+        }
+
+        let suffix = if is_release {
+            MOUSE_SGR_RELEASE
+        } else {
+            MOUSE_SGR_PRESS
+        };
+
+        let prefix_str = std::str::from_utf8(MOUSE_SGR_PREFIX).unwrap_or("\x1b[<");
+
+        Some(
+            format!(
+                "{}{};{};{}{}",
+                prefix_str, button_code, x, y, suffix as char
+            )
+            .into_bytes(),
+        )
+    }
+
+    fn get_button_code(button: Button) -> u16 {
+        match button {
+            Button::Left => MOUSE_LEFT_BUTTON_CODE,
+            Button::Middle => MOUSE_MIDDLE_BUTTON_CODE,
+            Button::Right => MOUSE_RIGHT_BUTTON_CODE,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Button, KeyState, ModifierKeysMask, MouseInput, MouseInputKind, col, row};
+    use core::num::NonZeroU16;
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn test_sgr_mouse_sequence() {
+        let prefix_str = std::str::from_utf8(MOUSE_SGR_PREFIX).unwrap_or("\x1b[<");
+
+        let nz_10 = NonZeroU16::new(10).unwrap();
+        let term_col = crate::term_col(nz_10);
+        let term_row = crate::term_row(nz_10);
+
+        // 1. Left click at x=10, y=10
+        let input1 = MouseInput {
+            pos: col(9) + row(9),
+            kind: MouseInputKind::MouseDown(Button::Left),
+            maybe_modifier_keys: None,
+        };
+        let bytes1 = SgrMouseSequence::generate(&input1, term_col, term_row).unwrap();
+        assert_eq!(
+            bytes1,
+            format!(
+                "{}{};10;10{}",
+                prefix_str, MOUSE_LEFT_BUTTON_CODE, MOUSE_SGR_PRESS as char
+            )
+            .into_bytes()
+        );
+
+        // 2. Left release at x=10, y=10
+        let input2 = MouseInput {
+            pos: col(9) + row(9),
+            kind: MouseInputKind::MouseUp(Button::Left),
+            maybe_modifier_keys: None,
+        };
+        let bytes2 = SgrMouseSequence::generate(&input2, term_col, term_row).unwrap();
+        assert_eq!(
+            bytes2,
+            format!(
+                "{}{};10;10{}",
+                prefix_str, MOUSE_LEFT_BUTTON_CODE, MOUSE_SGR_RELEASE as char
+            )
+            .into_bytes()
+        );
+
+        // 3. Right click with Shift modifier
+        let mut modifiers = ModifierKeysMask::new();
+        modifiers.shift_key_state = KeyState::Pressed;
+        let input3 = MouseInput {
+            pos: col(9) + row(9),
+            kind: MouseInputKind::MouseDown(Button::Right),
+            maybe_modifier_keys: Some(modifiers),
+        };
+        let bytes3 = SgrMouseSequence::generate(&input3, term_col, term_row).unwrap();
+        assert_eq!(
+            bytes3,
+            format!(
+                "{}{};10;10{}",
+                prefix_str,
+                MOUSE_RIGHT_BUTTON_CODE | MOUSE_MODIFIER_SHIFT,
+                MOUSE_SGR_PRESS as char
+            )
+            .into_bytes()
+        );
+
+        // 4. Scroll Up
+        let input4 = MouseInput {
+            pos: col(9) + row(9),
+            kind: MouseInputKind::ScrollUp,
+            maybe_modifier_keys: None,
+        };
+        let bytes4 = SgrMouseSequence::generate(&input4, term_col, term_row).unwrap();
+        assert_eq!(
+            bytes4,
+            format!(
+                "{}{};10;10{}",
+                prefix_str, MOUSE_SCROLL_UP_BUTTON, MOUSE_SGR_PRESS as char
+            )
+            .into_bytes()
+        );
+
+        // 5. Scroll Down
+        let input5 = MouseInput {
+            pos: col(9) + row(9),
+            kind: MouseInputKind::ScrollDown,
+            maybe_modifier_keys: None,
+        };
+        let bytes5 = SgrMouseSequence::generate(&input5, term_col, term_row).unwrap();
+        assert_eq!(
+            bytes5,
+            format!(
+                "{}{};10;10{}",
+                prefix_str, MOUSE_SCROLL_DOWN_BUTTON, MOUSE_SGR_PRESS as char
+            )
+            .into_bytes()
+        );
+
+        // 6. Hover (Move without buttons)
+        let input6 = MouseInput {
+            pos: col(9) + row(9),
+            kind: MouseInputKind::MouseMove,
+            maybe_modifier_keys: None,
+        };
+        let bytes6 = SgrMouseSequence::generate(&input6, term_col, term_row).unwrap();
+        assert_eq!(
+            bytes6,
+            format!(
+                "{}{};10;10{}",
+                prefix_str,
+                MOUSE_RELEASE_BUTTON_CODE | MOUSE_MOTION_FLAG,
+                MOUSE_SGR_PRESS as char
+            )
+            .into_bytes()
+        );
+
+        // 7. Drag (Middle button)
+        let input7 = MouseInput {
+            pos: col(9) + row(9),
+            kind: MouseInputKind::MouseDrag(Button::Middle),
+            maybe_modifier_keys: None,
+        };
+        let bytes7 = SgrMouseSequence::generate(&input7, term_col, term_row).unwrap();
+        assert_eq!(
+            bytes7,
+            format!(
+                "{}{};10;10{}",
+                prefix_str,
+                MOUSE_MIDDLE_BUTTON_CODE | MOUSE_MOTION_FLAG,
+                MOUSE_SGR_PRESS as char
+            )
+            .into_bytes()
+        );
+    }
+}

--- a/tui/src/core/ansi/vt_100_pty_output_parser/hidden_screen_state.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/hidden_screen_state.rs
@@ -1,0 +1,136 @@
+// Copyright (c) 2025 R3BL LLC. Licensed under Apache License, Version 2.0.
+
+use crate::{GetMemSize, MemorySize, PixelCharLines, Pos, Size};
+
+/// Internal offscreen buffer state for the alternate screen.
+///
+/// This represents the *internal state* of the engine, tracking whether the grid
+/// buffers are currently swapped.
+///
+/// For the external VT100 mode requested by the child process, see
+/// [`RequestedScreenMode`].
+///
+/// [`RequestedScreenMode`]: crate::RequestedScreenMode
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ActiveScreenBuffer {
+    /// Alternate screen buffer is actively displayed.
+    Alternate,
+
+    /// Alternate screen buffer is inactive, primary screen is displayed.
+    #[default]
+    Primary,
+}
+
+/// Encapsulated state representing the alternate screen support and its independent
+/// cursor.
+///
+/// This struct manages the hidden buffer (which is either the primary or alternate
+/// screen depending on the active state) and the cursor position associated with it.
+///
+/// # Initialization
+///
+/// The hidden buffer is eagerly allocated at creation time ([`new_empty()`]). This
+/// avoids the complexity and overhead of `Option`-wrapping the buffer, trading a small,
+/// fixed memory cost for cleaner, faster O(1) access.
+///
+/// # [`SGR`] Style Inheritance & [`BCE`] (Background Color Erase) Compliance
+///
+/// Under [`VT-100`], [`xterm`], and standard [`ANSI`] specifications, graphic rendition
+/// states (foreground/background colors, bold, italic) are globally shared and preserved
+/// across screen buffer switches.
+///
+/// This struct implements this specification by separating the alternate buffer
+/// ([`hidden_buffer`]) from the overall parser emulation state. When entering the
+/// alternate screen:
+/// - The alternate buffer inherits the active graphic style from the main buffer.
+/// - The buffer is cleared utilizing [`create_empty_pixel_char()`] to ensure that erased
+///   cells carry the active background color and attributes, fully complying with
+///   Background Color Erase ([`BCE`]) rules.
+///
+/// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
+/// [`BCE`]: https://invisible-island.net/xterm/xterm.faq.html#what_is_bce
+/// [`create_empty_pixel_char()`]: crate::OfsBufVT100::create_empty_pixel_char
+/// [`hidden_buffer`]: HiddenScreenState::hidden_buffer
+/// [`new_empty()`]: crate::HiddenScreenState::new_empty
+/// [`SGR`]: crate::SgrCode
+/// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
+/// [`xterm`]: https://en.wikipedia.org/wiki/Xterm
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HiddenScreenState {
+    /// The secondary buffer grid representing the alternate screen. Always allocated at
+    /// buffer creation time to avoid having to use [`Option`] which adds needless
+    /// complexity for a very small cost in terms of memory.
+    pub hidden_buffer: PixelCharLines,
+
+    /// Saved cursor position for the hidden buffer.
+    pub hidden_cursor_pos: Pos,
+
+    /// Cached memory size of this struct to provide O(1) retrieval.
+    pub cached_memory_size: MemorySize,
+}
+
+impl HiddenScreenState {
+    #[must_use]
+    pub fn new_empty(arg_window_size: impl Into<Size>) -> Self {
+        let window_size = arg_window_size.into();
+        let hidden_buffer = PixelCharLines::new_empty(window_size);
+
+        let cached_memory_size = {
+            let primary_buffer_mem = hidden_buffer.get_mem_size();
+            let hidden_cursor_pos = size_of::<Pos>();
+            MemorySize::new(primary_buffer_mem + hidden_cursor_pos)
+        };
+
+        Self {
+            hidden_buffer,
+            hidden_cursor_pos: Pos::default(),
+            cached_memory_size,
+        }
+    }
+}
+
+impl GetMemSize for HiddenScreenState {
+    /// Acts as a fast O(1) getter for the cached memory size to avoid O(N) traversal
+    /// of the entire alternate screen buffer grid.
+    fn get_mem_size(&self) -> usize { self.cached_memory_size.size().unwrap_or(0) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RequestedScreenMode;
+
+    #[test]
+    fn test_hidden_screen_state_struct_size() {
+        assert_eq!(size_of::<ActiveScreenBuffer>(), 1);
+        assert_eq!(size_of::<RequestedScreenMode>(), 1);
+
+        // TRIPWIRE: If you add or remove a field from `HiddenScreenState`, this test will
+        // fail. This is intentional! It reminds you to:
+        // 1. Update the `GetMemSize` implementation for this struct to include your new
+        //    field.
+        // 2. Update this exact byte-size assertion.
+        #[cfg(target_pointer_width = "64")]
+        {
+            assert_eq!(size_of::<HiddenScreenState>(), 416);
+        }
+    }
+
+    #[test]
+    fn test_hidden_screen_state_get_mem_size() {
+        // TRIPWIRE: This test verifies that `GetMemSize` actually sums up all the fields.
+        // If you added a field, you MUST add its memory size calculation to
+        // `expected_size` below, and ensure the actual `GetMemSize`
+        // implementation matches it.
+        use crate::{height, width};
+        let size = height(10) + width(20);
+        let support = HiddenScreenState::new_empty(size);
+
+        let calculated_size = support.get_mem_size();
+        let expected_size = support.hidden_buffer.get_mem_size() + size_of::<Pos>();
+
+        assert_eq!(calculated_size, expected_size);
+        // Ensure consistency across calls
+        assert_eq!(calculated_size, support.get_mem_size());
+    }
+}

--- a/tui/src/core/ansi/vt_100_pty_output_parser/mod.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/mod.rs
@@ -54,15 +54,15 @@
 pub mod ansi_parser_public_api;
 pub mod pty_response_event;
 pub mod ofs_buf_vt_100;
+pub mod hidden_screen_state;
 pub mod performer;
 pub mod protocols;
+mod modes;
 
 #[cfg(any(test, doc))]
 pub mod ops;
 #[cfg(not(any(test, doc)))]
 mod ops;
-
-
 
 #[cfg(any(test, doc))]
 pub mod ops_impl_ofs_buf;
@@ -78,5 +78,7 @@ pub mod vt_100_pty_output_conformance_tests;
 pub use ansi_parser_public_api::*;
 pub use pty_response_event::*;
 pub use ofs_buf_vt_100::*;
+pub use hidden_screen_state::*;
 pub use ops::*;
 pub use protocols::*;
+pub use modes::*;

--- a/tui/src/core/ansi/vt_100_pty_output_parser/modes.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/modes.rs
@@ -1,0 +1,129 @@
+// Copyright (c) 2022-2025 R3BL LLC. Licensed under Apache License, Version 2.0.
+
+/// Auto-wrap mode ([`DECAWM`]) state.
+///
+/// Controls line wrapping behavior when text reaches the right margin.
+///
+/// [`DECAWM`]: https://vt100.net/docs/vt510-rm/DECAWM.html
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AutoWrapMode {
+    /// Characters automatically wrap to the next line (DECAWM `?7h`)
+    #[default]
+    Enabled,
+
+    /// Characters overwrite at the right margin (DECAWM `?7l`)
+    Disabled,
+}
+
+/// Terminal cursor visibility state.
+///
+/// Controls whether the terminal cursor is displayed or hidden. Corresponds to the
+/// [`DECTCEM`] (`?25`) private mode.
+///
+/// # Usage in [`PTY`] Mux
+///
+/// When used inside [`ParserGlobalState::cursor_visibility`], it stores the *requested*
+/// visibility state of the child process. The [`PTY Mux`] compositor
+/// ([`OutputRenderer::composite_virtual_cursor_into_buffer`]) reads this to determine if
+/// it needs to paint a simulated, virtual block cursor into the [`OffscreenBuffer`].
+///
+/// > Note: The host terminal emulator's actual cursor is permanently suppressed via
+/// > [`hide_cursor`] when the multiplexer is active. We rely exclusively
+/// > on the virtual block cursor rendering (which allows us to have multiple cursors).
+///
+/// [`DECTCEM`]: https://vt100.net/docs/vt510-rm/DECTCEM.html
+/// [`hide_cursor`]: crate::TerminalModeController::hide_cursor
+/// [`OffscreenBuffer`]: crate::OffscreenBuffer
+/// [`OutputRenderer::composite_virtual_cursor_into_buffer`]:
+///     crate::core::pty::OutputRenderer::composite_virtual_cursor_into_buffer
+/// [`ParserGlobalState::cursor_visibility`]: crate::ParserGlobalState::cursor_visibility
+/// [`PTY Mux`]: crate::PTYMux
+/// [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CursorVisibilityMode {
+    /// Cursor is visible ([`DECTCEM`] `ESC [ ? 25 h`)
+    ///
+    /// [`DECTCEM`]: https://vt100.net/docs/vt510-rm/DECTCEM.html
+    #[default]
+    Visible,
+
+    /// Cursor is hidden ([`DECTCEM`] `ESC [ ? 25 l`)
+    ///
+    /// [`DECTCEM`]: https://vt100.net/docs/vt510-rm/DECTCEM.html
+    Hidden,
+}
+
+/// Mouse event tracking state.
+///
+/// Controls whether the terminal captures and reports mouse events.
+///
+/// # Implementation Note
+///
+/// [`PTYMux`] uses a simplified "firehose" approach for mouse events:
+///
+/// - Rather than strictly adhering to the legacy [`1000`]/[`1002`]/[`1003`] protocols
+///   (which differ in event filtering and byte-encoded coordinates), we treat any request
+///   for mouse tracking identically.
+/// - If a sub-process requests *any* mouse tracking, we route all mouse events (clicks,
+///   drags, motion) using the modern `1006` [`SGR`] [`PrivateModeType::SgrMouseMode`]
+///   protocol format unconditionally. This satisfies 99% of modern TUI apps.
+///
+/// [`1000`]: crate::PrivateModeType::X11MouseTracking
+/// [`1002`]: crate::PrivateModeType::CellMotionMouseTracking
+/// [`1003`]: crate::PrivateModeType::ApplicationMouseTracking
+/// [`PrivateModeType::SgrMouseMode`]: crate::PrivateModeType::SgrMouseMode
+/// [`PTYMux`]: crate::PTYMux
+/// [`SGR`]: crate::SgrCode
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MouseTrackingMode {
+    /// Mouse tracking enabled.
+    ///
+    /// The multiplexer engine unconditionally formats all events as [`SGR`] extended
+    /// mouse tracking (`1006` protocol), which uses string coordinates. See
+    /// [`PrivateModeType::SgrMouseMode`].
+    ///
+    /// [`PrivateModeType::SgrMouseMode`]: crate::PrivateModeType::SgrMouseMode
+    /// [`SGR`]: crate::SgrCode
+    Enabled,
+
+    /// Mouse tracking disabled.
+    #[default]
+    Disabled,
+}
+
+/// The [`VT-100`] requested screen buffer mode.
+///
+/// This represents the *mode* requested by the external terminal application via escape
+/// sequences (e.g., `ESC [ ? 1049 h` for Alternate, `l` for Primary).
+///
+/// The engine processes this requested mode and updates its internal
+/// [`ActiveScreenBuffer`] accordingly (which performs the actual buffer swapping).
+///
+/// [`ActiveScreenBuffer`]: crate::ActiveScreenBuffer
+/// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestedScreenMode {
+    /// Request to use the primary (default) screen buffer.
+    Primary,
+    /// Request to use the alternate screen buffer (preserving primary content).
+    Alternate,
+}
+
+pub mod terminal_mode_state_todo {
+    /// Bracketed paste mode state.
+    ///
+    /// Controls whether text pasted from clipboard is wrapped with special escape
+    /// sequences (`OSC 52`), allowing applications to distinguish pasted text from
+    /// keyboard input.
+    ///
+    /// [`OSC`]: crate::osc_codes::OscSequence
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+    #[allow(dead_code)]
+    pub enum BracketedPasteMode {
+        /// Bracketed paste mode enabled
+        Enabled,
+        /// Bracketed paste mode disabled
+        #[default]
+        Disabled,
+    }
+}

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ofs_buf_vt_100.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ofs_buf_vt_100.rs
@@ -1,7 +1,8 @@
 // Copyright (c) 2022-2025 R3BL LLC. Licensed under Apache License, Version 2.0.
 
-use crate::{PtyResponseEvent, GetMemSize, MemorySize, OffscreenBuffer,
-            PixelCharLines, Pos, Size, TermRow, TuiStyle, osc::OscEvent};
+use super::modes::{AutoWrapMode, CursorVisibilityMode, MouseTrackingMode,
+                   terminal_mode_state_todo};
+use crate::{ActiveScreenBuffer, GetMemSize, HiddenScreenState, OffscreenBuffer, Pos, PtyResponseEvent, Size, TermRow, TuiStyle, osc::OscEvent};
 use std::{fmt::Debug,
           mem::size_of,
           ops::{Deref, DerefMut}};
@@ -211,7 +212,7 @@ pub struct ParserGlobalState {
     /// [`AnsiToOfsBufPerformer`]: crate::AnsiToOfsBufPerformer
     /// [`DECAWM`]: https://vt100.net/docs/vt510-rm/DECAWM.html
     /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
-    pub auto_wrap_mode: AutoWrapState,
+    pub auto_wrap_mode: AutoWrapMode,
 
     /// Pending wrap state for deferred wrapping.
     ///
@@ -297,118 +298,19 @@ pub struct ParserGlobalState {
     /// Corresponds to the [`DECTCEM`] (`?25`) private mode.
     ///
     /// [`DECTCEM`]: https://vt100.net/docs/vt510-rm/DECTCEM.html
-    pub cursor_visibility: CursorVisibilityState,
+    pub cursor_visibility: CursorVisibilityMode,
 }
 
 impl ParserGlobalState {
     /// Puts the terminal into a pending wrap state.
-    pub fn set_pending_wrap(&mut self) {
-        self.pending_wrap = PendingWrap::Yes;
-    }
+    pub fn set_pending_wrap(&mut self) { self.pending_wrap = PendingWrap::Yes; }
 
     /// Clears the pending wrap state.
-    pub fn clear_pending_wrap(&mut self) {
-        self.pending_wrap = PendingWrap::No;
-    }
+    pub fn clear_pending_wrap(&mut self) { self.pending_wrap = PendingWrap::No; }
 
     /// Returns the current pending wrap state.
     #[must_use]
-    pub fn get_pending_wrap(&self) -> PendingWrap {
-        self.pending_wrap
-    }
-}
-
-/// Character set modes for terminal emulation.
-///
-/// Used by [`AnsiToOfsBufPerformer`] to handle `ESC ( <char>` sequences that switch
-/// between [`ASCII`] and [`DEC`] line-drawing graphics.
-///
-/// [`AnsiToOfsBufPerformer`]: crate::AnsiToOfsBufPerformer
-/// [`ASCII`]: https://en.wikipedia.org/wiki/ASCII
-/// [`DEC`]: https://en.wikipedia.org/wiki/Digital_Equipment_Corporation
-/// [`ESC`]: crate::EscSequence
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum CharacterSet {
-    /// Normal [`ASCII`] character set:
-    /// - `ESC ( B`
-    /// - or `[27, 40, 66]` in decimal
-    ///
-    /// [`ASCII`]: https://en.wikipedia.org/wiki/ASCII
-    /// [`ESC`]: crate::EscSequence
-    #[default]
-    Ascii,
-    /// [`DEC`] Special Graphics character set for line drawing:
-    /// - `ESC ( 0`
-    /// - or `[27, 40, 48]` in decimal
-    ///
-    /// Maps [`ASCII`] characters to box-drawing Unicode characters.
-    ///
-    /// [`ASCII`]: https://en.wikipedia.org/wiki/ASCII
-    /// [`DEC`]: https://en.wikipedia.org/wiki/Digital_Equipment_Corporation
-    /// [`ESC`]: crate::EscSequence
-    DECGraphics,
-}
-
-/// Auto-wrap mode ([`DECAWM`]) state.
-///
-/// Controls line wrapping behavior when text reaches the right margin.
-///
-/// [`DECAWM`]: https://vt100.net/docs/vt510-rm/DECAWM.html
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum AutoWrapState {
-    /// Characters automatically wrap to the next line (DECAWM `?7h`)
-    #[default]
-    Enabled,
-    /// Characters overwrite at the right margin (DECAWM `?7l`)
-    Disabled,
-}
-
-/// Pending wrap state for deferred wrapping.
-///
-/// Controls whether a wrap to the next line is pending.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum PendingWrap {
-    Yes,
-    #[default]
-    No,
-}
-
-/// Terminal cursor visibility state.
-///
-/// Controls whether the terminal cursor is displayed or hidden. Corresponds to the
-/// [`DECTCEM`] (`?25`) private mode.
-///
-/// # Usage in [`PTY`] Mux
-///
-/// When used inside [`ParserGlobalState::cursor_visibility`], it stores the *requested*
-/// visibility state of the child process. The [`PTY Mux`] compositor
-/// ([`OutputRenderer::composite_virtual_cursor_into_buffer`]) reads this to determine if
-/// it needs to paint a simulated, virtual block cursor into the [`OffscreenBuffer`].
-///
-/// > Note: The host terminal emulator's actual cursor is permanently suppressed via
-/// > [`hide_cursor`] when the multiplexer is active. We rely exclusively
-/// > on the virtual block cursor rendering (which allows us to have multiple cursors).
-///
-/// [`DECTCEM`]: https://vt100.net/docs/vt510-rm/DECTCEM.html
-/// [`hide_cursor`]: crate::TerminalModeController::hide_cursor
-/// [`OffscreenBuffer`]: crate::OffscreenBuffer
-/// [`OutputRenderer::composite_virtual_cursor_into_buffer`]:
-///     crate::core::pty::OutputRenderer::composite_virtual_cursor_into_buffer
-/// [`ParserGlobalState::cursor_visibility`]: crate::ParserGlobalState::cursor_visibility
-/// [`PTY Mux`]: crate::PTYMux
-/// [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum CursorVisibilityState {
-    /// Cursor is visible ([`DECTCEM`] `ESC [ ? 25 h`)
-    ///
-    /// [`DECTCEM`]: https://vt100.net/docs/vt510-rm/DECTCEM.html
-    #[default]
-    Visible,
-    /// Cursor is hidden ([`DECTCEM`] `ESC [ ? 25 l`)
-    ///
-    /// [`DECTCEM`]: https://vt100.net/docs/vt510-rm/DECTCEM.html
-    Hidden,
+    pub fn get_pending_wrap(&self) -> PendingWrap { self.pending_wrap }
 }
 
 /// State tracking for terminal operational modes.
@@ -432,20 +334,10 @@ pub struct TerminalModeState {
     /// and `ESC [ ? 1049 l` sequences.
     ///
     /// [`AnsiToOfsBufPerformer`]: crate::AnsiToOfsBufPerformer
-    pub alternate_screen: AlternateScreenState,
+    pub active_screen_buffer: ActiveScreenBuffer,
 
-    /// Mouse event tracking status.
-    ///
-    /// **TODO**: The parser currently ignores this [`VT-100`] sequence
-    /// (`vt_100_shim_mode_ops.rs`) because the [`PTY`] multiplexer does not yet route
-    /// complex input events. When supported, this field should be wired up to the
-    /// [`ANSI`] parser and the `dead_code` allowance removed.
-    ///
-    /// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
-    /// [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
-    /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
-    #[allow(dead_code)]
-    pub mouse_tracking: terminal_mode_state_todo::MouseTrackingState,
+    /// Mouse tracking state (mode and formatting).
+    pub mouse_tracking: MouseTrackingMode,
 
     /// Bracketed paste mode status.
     ///
@@ -458,136 +350,51 @@ pub struct TerminalModeState {
     /// [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
     /// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
     #[allow(dead_code)]
-    pub bracketed_paste: terminal_mode_state_todo::BracketedPasteState,
+    pub bracketed_paste: terminal_mode_state_todo::BracketedPasteMode,
 }
 
-mod terminal_mode_state_todo {
-    #[allow(clippy::wildcard_imports)]
-    use super::*;
 
-    /// Mouse event tracking state.
-    ///
-    /// Controls whether the terminal captures mouse click, movement, and scroll events.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-    #[allow(dead_code)]
-    pub enum MouseTrackingState {
-        /// Mouse tracking enabled - terminal sends mouse events
-        Enabled,
-        /// Mouse tracking disabled
-        #[default]
-        Disabled,
-    }
-
-    /// Bracketed paste mode state.
-    ///
-    /// Controls whether text pasted from clipboard is wrapped with special escape
-    /// sequences (`OSC 52`), allowing applications to distinguish pasted text from
-    /// keyboard input.
-    ///
-    /// [`OSC`]: crate::osc_codes::OscSequence
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-    #[allow(dead_code)]
-    pub enum BracketedPasteState {
-        /// Bracketed paste mode enabled
-        Enabled,
-        /// Bracketed paste mode disabled
-        #[default]
-        Disabled,
-    }
-}
-
-/// Alternate screen buffer state.
+/// Character set modes for terminal emulation.
 ///
-/// Controls whether terminal output is redirected to an alternate screen buffer,
-/// preserving the original screen content. This is used by full-screen applications
-/// (`vim`, `less`, etc.) to avoid cluttering the shell history.
+/// Used by [`AnsiToOfsBufPerformer`] to handle `ESC ( <char>` sequences that switch
+/// between [`ASCII`] and [`DEC`] line-drawing graphics.
+///
+/// [`AnsiToOfsBufPerformer`]: crate::AnsiToOfsBufPerformer
+/// [`ASCII`]: https://en.wikipedia.org/wiki/ASCII
+/// [`DEC`]: https://en.wikipedia.org/wiki/Digital_Equipment_Corporation
+/// [`ESC`]: crate::EscSequence
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum AlternateScreenState {
-    /// Alternate screen buffer active
-    Active,
-    /// Alternate screen buffer inactive, using primary screen
+pub enum CharacterSet {
+    /// Normal [`ASCII`] character set:
+    /// - `ESC ( B`
+    /// - or `[27, 40, 66]` in decimal
+    ///
+    /// [`ASCII`]: https://en.wikipedia.org/wiki/ASCII
+    /// [`ESC`]: crate::EscSequence
     #[default]
-    Inactive,
+    Ascii,
+
+    /// [`DEC`] Special Graphics character set for line drawing:
+    /// - `ESC ( 0`
+    /// - or `[27, 40, 48]` in decimal
+    ///
+    /// Maps [`ASCII`] characters to box-drawing Unicode characters.
+    ///
+    /// [`ASCII`]: https://en.wikipedia.org/wiki/ASCII
+    /// [`DEC`]: https://en.wikipedia.org/wiki/Digital_Equipment_Corporation
+    /// [`ESC`]: crate::EscSequence
+    DECGraphics,
 }
 
-/// The requested screen buffer mode.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RequestedScreenMode {
-    Primary,
-    Alternate,
-}
-
-/// Encapsulated state representing the alternate screen support and its independent
-/// cursor positions.
+/// Pending wrap state for deferred wrapping.
 ///
-/// # [`SGR`] Style Inheritance & [`BCE`] (Background Color Erase) Compliance
-///
-/// Under [`VT-100`], [`xterm`], and standard [`ANSI`] specifications, graphic rendition
-/// states (foreground/background colors, bold, italic) are globally shared and preserved
-/// across screen buffer switches.
-///
-/// This struct implements this specification by separating the alternate buffer
-/// ([`hidden_buffer`]) from the overall parser emulation state. When entering the
-/// alternate screen:
-/// - The alternate buffer inherits the active graphic style from the main buffer.
-/// - The buffer is cleared utilizing [`create_empty_pixel_char()`] to ensure that erased
-///   cells carry the active background color and attributes, fully complying with
-///   Background Color Erase ([`BCE`]) rules.
-///
-/// [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
-/// [`BCE`]: https://invisible-island.net/xterm/xterm.faq.html#what_is_bce
-/// [`create_empty_pixel_char()`]: crate::OfsBufVT100::create_empty_pixel_char
-/// [`hidden_buffer`]: HiddenScreenState::hidden_buffer
-/// [`SGR`]: crate::SgrCode
-/// [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
-/// [`xterm`]: https://en.wikipedia.org/wiki/Xterm
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct HiddenScreenState {
-    /// The secondary buffer grid representing the alternate screen. Always allocated at
-    /// buffer creation time to avoid having to use [`Option`] which adds needless
-    /// complexity for a very small cost in terms of memory.
-    pub hidden_buffer: PixelCharLines,
+/// Controls whether a wrap to the next line is pending.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PendingWrap {
+    Yes,
 
-    /// Saved cursor position for the hidden buffer.
-    pub hidden_cursor_pos: Pos,
-
-    /// Cached memory size of this struct to provide O(1) retrieval.
-    pub cached_memory_size: MemorySize,
-}
-
-mod hidden_screen_state_impl {
-    #[allow(clippy::wildcard_imports)]
-    use super::*;
-
-    impl HiddenScreenState {
-        #[must_use]
-        pub fn new_empty(arg_window_size: impl Into<Size>) -> Self {
-            let window_size = arg_window_size.into();
-            let hidden_buffer = PixelCharLines::new_empty(window_size);
-
-            let cached_memory_size = {
-                let primary_buffer_mem = hidden_buffer.get_mem_size();
-
-                MemorySize::new(
-                    primary_buffer_mem +
-                // hidden_cursor_pos
-                size_of::<Pos>(),
-                )
-            };
-
-            Self {
-                hidden_buffer,
-                hidden_cursor_pos: Pos::default(),
-                cached_memory_size,
-            }
-        }
-    }
-
-    impl GetMemSize for HiddenScreenState {
-        /// Acts as a fast O(1) getter for the cached memory size to avoid O(N) traversal
-        /// of the entire alternate screen buffer grid.
-        fn get_mem_size(&self) -> usize { self.cached_memory_size.size().unwrap_or(0) }
-    }
+    #[default]
+    No,
 }
 
 #[cfg(test)]
@@ -606,19 +413,6 @@ mod tests {
             // First we assert against a dummy value to see the real sizes in the test
             // output, then we will update it.
             assert_eq!(size_of::<OfsBufVT100>(), 928);
-        }
-    }
-
-    #[test]
-    fn test_hidden_screen_state_struct_size() {
-        // TRIPWIRE: If you add or remove a field from `HiddenScreenState`, this test will
-        // fail. This is intentional! It reminds you to:
-        // 1. Update the `GetMemSize` implementation for this struct to include your new
-        //    field.
-        // 2. Update this exact byte-size assertion.
-        #[cfg(target_pointer_width = "64")]
-        {
-            assert_eq!(size_of::<HiddenScreenState>(), 416);
         }
     }
 
@@ -642,23 +436,5 @@ mod tests {
         assert_eq!(calculated_size, expected_size);
         // Ensure consistency across calls
         assert_eq!(calculated_size, state.get_mem_size());
-    }
-
-    #[test]
-    fn test_hidden_screen_state_get_mem_size() {
-        // TRIPWIRE: This test verifies that `GetMemSize` actually sums up all the fields.
-        // If you added a field, you MUST add its memory size calculation to
-        // `expected_size` below, and ensure the actual `GetMemSize`
-        // implementation matches it.
-        use crate::{height, width};
-        let size = height(10) + width(20);
-        let support = HiddenScreenState::new_empty(size);
-
-        let calculated_size = support.get_mem_size();
-        let expected_size = support.hidden_buffer.get_mem_size() + size_of::<Pos>();
-
-        assert_eq!(calculated_size, expected_size);
-        // Ensure consistency across calls
-        assert_eq!(calculated_size, support.get_mem_size());
     }
 }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_mode_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops/vt_100_shim_mode_ops.rs
@@ -1,5 +1,7 @@
 // Copyright (c) 2025 R3BL LLC. Licensed under Apache License, Version 2.0.
 
+// cspell:words URXVT
+
 //! Mode setting operations (SM/RM).
 //!
 //! This module acts as a thin shim layer that delegates to the actual implementation.
@@ -58,10 +60,9 @@
 //! [ops module]: crate::core::ansi::vt_100_pty_output_parser::ops
 
 use super::super::{PrivateModeType, ansi_parser_public_api::AnsiToOfsBufPerformer};
-use crate::{APPLICATION_MOUSE_TRACKING, AutoWrapState, BRACKETED_PASTE_MODE,
-            CELL_MOTION_MOUSE_TRACKING, CursorVisibilityState, DEBUG_TUI_VT100_PARSER,
-            RequestedScreenMode, SGR_MOUSE_MODE, URXVT_MOUSE_EXTENSION,
-            UTF8_MOUSE_EXTENSION, X11_MOUSE_TRACKING,
+use crate::{AutoWrapMode, BRACKETED_PASTE_MODE, CursorVisibilityMode, DEBUG_TUI_VT100_PARSER,
+            RequestedScreenMode, URXVT_MOUSE_EXTENSION,
+            UTF8_MOUSE_EXTENSION, MouseTrackingMode,
             core::ansi::constants::CSI_PRIVATE_MODE_PREFIX};
 use vte::Params;
 
@@ -79,7 +80,7 @@ pub fn set_mode(
             PrivateModeType::AutoWrap => {
                 performer
                     .ofs_buf_vt_100
-                    .set_requested_auto_wrap_mode(AutoWrapState::Enabled);
+                    .set_requested_auto_wrap_mode(AutoWrapMode::Enabled);
             }
             PrivateModeType::AlternateScreenBuffer => {
                 performer
@@ -89,18 +90,25 @@ pub fn set_mode(
             PrivateModeType::ShowCursor => {
                 performer
                     .ofs_buf_vt_100
-                    .set_requested_cursor_visibility_mode(CursorVisibilityState::Visible);
+                    .set_requested_cursor_visibility_mode(CursorVisibilityMode::Visible);
             }
-            // Safely suppress/ignore modern TUI extensions (like mouse tracking and
-            // bracketed paste). Currently, the multiplexer does not support
-            // routing rich input events back into the PTY. Downgrading to
-            // debug prevents heavy log spam from interactive TUIs (like hx/gitui).
+            PrivateModeType::X11MouseTracking
+            | PrivateModeType::CellMotionMouseTracking
+            | PrivateModeType::ApplicationMouseTracking => {
+                performer
+                    .ofs_buf_vt_100
+                    .set_requested_mouse_tracking_mode(MouseTrackingMode::Enabled);
+            }
+            PrivateModeType::SgrMouseMode => {
+                // We always use SGR formatting internally, so we don't need to do
+                // anything here.
+            }
+            // Safely suppress/ignore other modern TUI extensions (like bracketed paste).
+            // Currently, the multiplexer does not support routing rich input events back
+            // into the PTY. Downgrading to debug prevents heavy log spam from interactive
+            // TUIs (like hx/gitui).
             PrivateModeType::Other(
-                X11_MOUSE_TRACKING
-                | CELL_MOTION_MOUSE_TRACKING
-                | APPLICATION_MOUSE_TRACKING
-                | UTF8_MOUSE_EXTENSION
-                | SGR_MOUSE_MODE
+                UTF8_MOUSE_EXTENSION
                 | URXVT_MOUSE_EXTENSION
                 | BRACKETED_PASTE_MODE,
             ) => {
@@ -138,7 +146,7 @@ pub fn reset_mode(
             PrivateModeType::AutoWrap => {
                 performer
                     .ofs_buf_vt_100
-                    .set_requested_auto_wrap_mode(AutoWrapState::Disabled);
+                    .set_requested_auto_wrap_mode(AutoWrapMode::Disabled);
             }
             PrivateModeType::AlternateScreenBuffer => {
                 performer
@@ -148,18 +156,24 @@ pub fn reset_mode(
             PrivateModeType::ShowCursor => {
                 performer
                     .ofs_buf_vt_100
-                    .set_requested_cursor_visibility_mode(CursorVisibilityState::Hidden);
+                    .set_requested_cursor_visibility_mode(CursorVisibilityMode::Hidden);
             }
-            // Safely suppress/ignore modern TUI extensions (like mouse tracking and
-            // bracketed paste). Currently, the multiplexer does not support
-            // routing rich input events back into the PTY. Downgrading to
-            // debug prevents heavy log spam from interactive TUIs (like hx/gitui).
+            PrivateModeType::X11MouseTracking
+            | PrivateModeType::CellMotionMouseTracking
+            | PrivateModeType::ApplicationMouseTracking => {
+                performer
+                    .ofs_buf_vt_100
+                    .set_requested_mouse_tracking_mode(MouseTrackingMode::Disabled);
+            }
+            PrivateModeType::SgrMouseMode => {
+                // We always use SGR formatting internally, so we don't need to do anything here.
+            }
+            // Safely suppress/ignore other modern TUI extensions (like bracketed paste).
+            // Currently, the multiplexer does not support routing rich input events back
+            // into the PTY. Downgrading to debug prevents heavy log spam from interactive
+            // TUIs (like hx/gitui).
             PrivateModeType::Other(
-                X11_MOUSE_TRACKING
-                | CELL_MOTION_MOUSE_TRACKING
-                | APPLICATION_MOUSE_TRACKING
-                | UTF8_MOUSE_EXTENSION
-                | SGR_MOUSE_MODE
+                UTF8_MOUSE_EXTENSION
                 | URXVT_MOUSE_EXTENSION
                 | BRACKETED_PASTE_MODE,
             ) => {

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_char_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_char_ops.rs
@@ -31,7 +31,7 @@
 
 #[allow(clippy::wildcard_imports)]
 use super::super::*;
-use crate::{ArrayBoundsCheck, ArrayOverflowResult, AutoWrapState, ColIndex, Length,
+use crate::{ArrayBoundsCheck, ArrayOverflowResult, AutoWrapMode, ColIndex, Length,
             NumericValue, OfsBufVT100, PixelChar,
             core::coordinates::bounds_check::{CursorBoundsCheck, LengthOps,
                                               RangeBoundsExt, RangeConvertExt},
@@ -367,7 +367,7 @@ impl OfsBufVT100 {
             // yet. It just parks the cursor directly on top of the character it just
             // printed at the right edge and flags itself with `PendingWrap::Yes`.
             if new_col.overflows(col_max) == ArrayOverflowResult::Overflowed {
-                if self.parser_global_state.auto_wrap_mode == AutoWrapState::Enabled {
+                if self.parser_global_state.auto_wrap_mode == AutoWrapMode::Enabled {
                     // DECAWM enabled: enter pending wrap state.
                     self.parser_global_state.set_pending_wrap();
                 }
@@ -1089,7 +1089,7 @@ mod tests_print_char {
         let mut buffer = create_vt100_test_buffer_with_size(width(5), height(3));
 
         // Ensure DECAWM is enabled (default).
-        buffer.parser_global_state.auto_wrap_mode = AutoWrapState::Enabled;
+        buffer.parser_global_state.auto_wrap_mode = AutoWrapMode::Enabled;
 
         // Position cursor at end of line (column 4 in 5-width buffer).
         buffer.cursor_pos = row(1) + col(4);

--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_mode_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_mode_ops.rs
@@ -5,8 +5,8 @@
 //! This module implements mode operations that correspond to [`ANSI`] mode sequences
 //! handled by the [`mode_ops`] module. These include:
 //!
-//! - `SM h` (Set Mode) - [`set_requested_auto_wrap_mode`] ([`AutoWrapState::Enabled`])
-//! - `RM l` (Reset Mode) - [`set_requested_auto_wrap_mode`] ([`AutoWrapState::Disabled`])
+//! - `SM h` (Set Mode) - [`set_requested_auto_wrap_mode`] ([`AutoWrapMode::Enabled`])
+//! - `RM l` (Reset Mode) - [`set_requested_auto_wrap_mode`] ([`AutoWrapMode::Disabled`])
 //!
 //! All operations maintain [`VT-100`] compliance and handle proper mode state management
 //! for terminal operations.
@@ -21,6 +21,8 @@
 //! [`set_requested_auto_wrap_mode`]: crate::OfsBufVT100::set_requested_auto_wrap_mode
 //! [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
 
+
+
 #[allow(clippy::wildcard_imports)]
 use super::super::*;
 use std::mem::swap;
@@ -30,7 +32,7 @@ impl OfsBufVT100 {
     ///
     /// When enabled, text automatically wraps to the next line when it reaches the right
     /// margin.
-    pub fn set_requested_auto_wrap_mode(&mut self, requested_state: AutoWrapState) {
+    pub fn set_requested_auto_wrap_mode(&mut self, requested_state: AutoWrapMode) {
         self.parser_global_state.auto_wrap_mode = requested_state;
     }
 
@@ -41,9 +43,17 @@ impl OfsBufVT100 {
     /// [`DECTCEM`]: https://en.wikipedia.org/wiki/ANSI_escape_code#Set_terminal_mode
     pub fn set_requested_cursor_visibility_mode(
         &mut self,
-        requested_state: CursorVisibilityState,
+        requested_state: CursorVisibilityMode,
     ) {
         self.parser_global_state.cursor_visibility = requested_state;
+    }
+
+    /// Set the mouse tracking mode.
+    ///
+    /// Controls whether the terminal captures and reports mouse events (e.g. click,
+    /// scroll).
+    pub fn set_requested_mouse_tracking_mode(&mut self, state: MouseTrackingMode) {
+        self.terminal_mode.mouse_tracking = state;
     }
 
     /// Toggle between the primary and alternate screen buffers.
@@ -55,23 +65,23 @@ impl OfsBufVT100 {
     /// - Sets the active cursor position to the saved alternate cursor position.
     /// - Clears the alternate screen buffer with cells carrying the active style to be
     ///   [`BCE`] (Background Color Erase) compliant.
-    /// - Updates the terminal mode to [`AlternateScreenState::Active`].
+    /// - Updates the terminal mode to [`ActiveScreenBuffer::Alternate`].
     ///
     /// When switching back to the primary screen buffer:
     /// - Saves the alternate cursor position.
     /// - Swaps the 2D grid buffers back.
     /// - Restores the primary cursor position.
-    /// - Updates the terminal mode to [`AlternateScreenState::Inactive`].
+    /// - Updates the terminal mode to [`ActiveScreenBuffer::Primary`].
     ///
-    /// [`AlternateScreenState::Active`]: crate::AlternateScreenState::Active
-    /// [`AlternateScreenState::Inactive`]: crate::AlternateScreenState::Inactive
+    /// [`ActiveScreenBuffer::Alternate`]: crate::ActiveScreenBuffer::Alternate
+    /// [`ActiveScreenBuffer::Primary`]: crate::ActiveScreenBuffer::Primary
     /// [`BCE`]: https://invisible-island.net/xterm/xterm.faq.html#what_is_bce
     /// [`self.buffer`]: field@crate::OfsBufVT100::ofs_buf
     /// [`self.hidden_screen_state.hidden_buffer`]: field@crate::HiddenScreenState::hidden_buffer
     pub fn set_alt_screen_mode(&mut self, requested_screen_mode: RequestedScreenMode) {
-        match (self.terminal_mode.alternate_screen, requested_screen_mode) {
-            // Transition: Primary -> Alternate Screen
-            (AlternateScreenState::Inactive, RequestedScreenMode::Alternate) => {
+        match (self.terminal_mode.active_screen_buffer, requested_screen_mode) {
+            // Transition: Primary -> Alternate Screen.
+            (ActiveScreenBuffer::Primary, RequestedScreenMode::Alternate) => {
                 // Swap the screen buffer grids and their respective cursor positions.
                 swap(
                     &mut self.ofs_buf.buffer,
@@ -83,7 +93,7 @@ impl OfsBufVT100 {
                 );
 
                 // Update mode status.
-                self.terminal_mode.alternate_screen = AlternateScreenState::Active;
+                self.terminal_mode.active_screen_buffer = ActiveScreenBuffer::Alternate;
 
                 // Clear the alternate screen buffer using BCE-compliant active style.
                 let empty_char = self.create_empty_pixel_char();
@@ -94,8 +104,8 @@ impl OfsBufVT100 {
                 }
             }
 
-            // Transition: Alternate -> Primary Screen
-            (AlternateScreenState::Active, RequestedScreenMode::Primary) => {
+            // Transition: Alternate -> Primary Screen.
+            (ActiveScreenBuffer::Alternate, RequestedScreenMode::Primary) => {
                 // Swap the screen buffer grids and their respective cursor positions.
                 swap(
                     &mut self.ofs_buf.buffer,
@@ -107,7 +117,7 @@ impl OfsBufVT100 {
                 );
 
                 // Update mode status.
-                self.terminal_mode.alternate_screen = AlternateScreenState::Inactive;
+                self.terminal_mode.active_screen_buffer = ActiveScreenBuffer::Primary;
             }
 
             // No-op: requested mode is already the active mode (e.g. Active -> Alternate)
@@ -134,13 +144,13 @@ mod tests_mode_ops {
         // Initially should be enabled by default.
         assert_eq!(
             buffer.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Enabled
+            AutoWrapMode::Enabled
         );
 
-        buffer.set_requested_auto_wrap_mode(AutoWrapState::Enabled);
+        buffer.set_requested_auto_wrap_mode(AutoWrapMode::Enabled);
         assert_eq!(
             buffer.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Enabled
+            AutoWrapMode::Enabled
         );
     }
 
@@ -148,10 +158,10 @@ mod tests_mode_ops {
     fn test_set_auto_wrap_mode_disabled() {
         let mut buffer = create_test_buffer();
 
-        buffer.set_requested_auto_wrap_mode(AutoWrapState::Disabled);
+        buffer.set_requested_auto_wrap_mode(AutoWrapMode::Disabled);
         assert_eq!(
             buffer.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Disabled
+            AutoWrapMode::Disabled
         );
     }
 
@@ -160,24 +170,24 @@ mod tests_mode_ops {
         let mut buffer = create_test_buffer();
 
         // Start enabled.
-        buffer.set_requested_auto_wrap_mode(AutoWrapState::Enabled);
+        buffer.set_requested_auto_wrap_mode(AutoWrapMode::Enabled);
         assert_eq!(
             buffer.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Enabled
+            AutoWrapMode::Enabled
         );
 
         // Disable.
-        buffer.set_requested_auto_wrap_mode(AutoWrapState::Disabled);
+        buffer.set_requested_auto_wrap_mode(AutoWrapMode::Disabled);
         assert_eq!(
             buffer.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Disabled
+            AutoWrapMode::Disabled
         );
 
         // Enable again.
-        buffer.set_requested_auto_wrap_mode(AutoWrapState::Enabled);
+        buffer.set_requested_auto_wrap_mode(AutoWrapMode::Enabled);
         assert_eq!(
             buffer.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Enabled
+            AutoWrapMode::Enabled
         );
     }
 
@@ -187,8 +197,8 @@ mod tests_mode_ops {
 
         // Initially should be Inactive.
         assert_eq!(
-            buffer.terminal_mode.alternate_screen,
-            AlternateScreenState::Inactive
+            buffer.terminal_mode.active_screen_buffer,
+            ActiveScreenBuffer::Primary
         );
         assert_eq!(buffer.cursor_pos, Pos::default());
 
@@ -202,8 +212,8 @@ mod tests_mode_ops {
         // Toggle to Alternate Screen.
         buffer.set_alt_screen_mode(RequestedScreenMode::Alternate);
         assert_eq!(
-            buffer.terminal_mode.alternate_screen,
-            AlternateScreenState::Active
+            buffer.terminal_mode.active_screen_buffer,
+            ActiveScreenBuffer::Alternate
         );
 
         // Cursor pos should be reset to default/alt state (0, 0).
@@ -237,8 +247,8 @@ mod tests_mode_ops {
         // Toggle back to Primary.
         buffer.set_alt_screen_mode(RequestedScreenMode::Primary);
         assert_eq!(
-            buffer.terminal_mode.alternate_screen,
-            AlternateScreenState::Inactive
+            buffer.terminal_mode.active_screen_buffer,
+            ActiveScreenBuffer::Primary
         );
 
         // Cursor pos should restore to (2, 3).
@@ -272,8 +282,8 @@ mod tests_mode_ops {
         // Toggle to Alternate Screen again.
         buffer.set_alt_screen_mode(RequestedScreenMode::Alternate);
         assert_eq!(
-            buffer.terminal_mode.alternate_screen,
-            AlternateScreenState::Active
+            buffer.terminal_mode.active_screen_buffer,
+            ActiveScreenBuffer::Alternate
         );
 
         // Saved hidden (primary) cursor should now be the new location (7, 8).

--- a/tui/src/core/ansi/vt_100_pty_output_parser/protocols/csi_codes/private_mode.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/protocols/csi_codes/private_mode.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2025 R3BL LLC. Licensed under Apache License, Version 2.0.
 
-//! [`DEC`] Private Mode types for [`CSI`] ? h/l sequences.
+//! [`DEC`] Private Mode types for the following [`CSI`] sequences:
+//! 1. `CSI ? <param> h` (set) and
+//! 2. `CSI ? <param> l` (reset) sequences.
 //!
 //! This module handles the various private mode settings that control terminal behavior,
 //! such as cursor visibility, auto-wrap, and alternate screen buffer.
@@ -9,13 +11,17 @@
 //! [`DEC`]: https://en.wikipedia.org/wiki/Digital_Equipment_Corporation
 
 use crate::{ParamsExt,
-            core::ansi::constants::{ALT_SCREEN_BUFFER, DECANM_VT52_MODE,
+            core::ansi::constants::{ALT_SCREEN_BUFFER, APPLICATION_MOUSE_TRACKING,
+                                    CELL_MOTION_MOUSE_TRACKING, DECANM_VT52_MODE,
                                     DECAWM_AUTO_WRAP, DECCKM_CURSOR_KEYS,
                                     DECCOLM_132_COLUMN, DECOM_ORIGIN_MODE,
                                     DECSCLM_SMOOTH_SCROLL, DECSCNM_REVERSE_VIDEO,
-                                    DECTCEM_SHOW_CURSOR, SAVE_CURSOR_DEC}};
+                                    DECTCEM_SHOW_CURSOR, SAVE_CURSOR_DEC,
+                                    SGR_MOUSE_MODE, X11_MOUSE_TRACKING}};
 
-/// [`DEC`] Private Mode types for [`CSI`] ? h/l sequences
+/// [`DEC`] Private Mode types for the following [`CSI`] sequences:
+/// 1. `CSI ? <param> h` (set) and
+/// 2. `CSI ? <param> l` (reset) sequences.
 ///
 /// [`CSI`]: crate::CsiSequence
 /// [`DEC`]: https://en.wikipedia.org/wiki/Digital_Equipment_Corporation
@@ -23,24 +29,78 @@ use crate::{ParamsExt,
 pub enum PrivateModeType {
     /// DECCKM - Application Cursor Keys (1)
     CursorKeys,
+
     /// DECANM - VT52 Mode (2)
     Vt52Mode,
+
     /// DECCOLM - 132 Column Mode (3)
     Column132,
+
     /// DECSCLM - Smooth Scroll (4)
     SmoothScroll,
+
     /// DECSCNM - Reverse Video (5)
     ReverseVideo,
+
     /// DECOM - Origin Mode (6)
     OriginMode,
+
     /// DECAWM - Auto Wrap Mode (7)
     AutoWrap,
+
     /// DECTCEM - Show/Hide Cursor (25)
     ShowCursor,
+
     /// Save Cursor (1048)
     SaveCursorDec,
+
     /// Use Alternate Screen Buffer (1049)
     AlternateScreenBuffer,
+
+    /// X11 Mouse Tracking (1000).
+    /// Only sends mouse clicks and scroll wheel events to the app.
+    ///
+    /// **Note:** See [`MouseTrackingMode`] for how our engine handles this.
+    ///
+    /// [`MouseTrackingMode`]: crate::MouseTrackingMode
+    X11MouseTracking,
+
+    /// Cell Motion Mouse Tracking (1002).
+    /// Sends clicks and drag events (when the mouse moves while a button is held down).
+    ///
+    /// **Note:** See [`MouseTrackingMode`] for how our engine handles this.
+    ///
+    /// [`MouseTrackingMode`]: crate::MouseTrackingMode
+    CellMotionMouseTracking,
+
+    /// Application Mouse Tracking (1003).
+    /// Sends everything—clicks, drags, and all raw mouse movement (hovering).
+    ///
+    /// **Note:** See [`MouseTrackingMode`] for how our engine handles this.
+    ///
+    /// [`MouseTrackingMode`]: crate::MouseTrackingMode
+    ApplicationMouseTracking,
+
+    /// [`SGR`] Mouse Mode (1006).
+    ///
+    /// This is a modifier. By default, legacy mouse reporting breaks if your terminal is
+    /// wider than 223 columns. [`SGR`] mode tells the terminal to format the coordinates
+    /// as plain text (e.g., `CSI < button ; x ; y M`) so it can support infinitely large
+    /// screens.
+    ///
+    /// Usually, modern TUI apps will request both a tracking mode (like
+    /// [`CellMotionMouseTracking`] `1002` or [`ApplicationMouseTracking`] `1003` to say
+    /// *when* to get events) and `SgrMouseMode` `1006` (to say *how* to format those
+    /// events).
+    ///
+    /// **Note:** See [`MouseTrackingMode`] for how our engine handles this.
+    ///
+    /// [`ApplicationMouseTracking`]: Self::ApplicationMouseTracking
+    /// [`CellMotionMouseTracking`]: Self::CellMotionMouseTracking
+    /// [`MouseTrackingMode`]: crate::MouseTrackingMode
+    /// [`SGR`]: crate::SgrCode
+    SgrMouseMode,
+
     /// Unknown/unsupported private mode
     Other(u16),
 }
@@ -59,6 +119,10 @@ impl PrivateModeType {
             Self::ShowCursor => DECTCEM_SHOW_CURSOR,
             Self::SaveCursorDec => SAVE_CURSOR_DEC,
             Self::AlternateScreenBuffer => ALT_SCREEN_BUFFER,
+            Self::X11MouseTracking => X11_MOUSE_TRACKING,
+            Self::CellMotionMouseTracking => CELL_MOTION_MOUSE_TRACKING,
+            Self::ApplicationMouseTracking => APPLICATION_MOUSE_TRACKING,
+            Self::SgrMouseMode => SGR_MOUSE_MODE,
             Self::Other(n) => *n,
         }
     }
@@ -77,6 +141,10 @@ impl From<u16> for PrivateModeType {
             DECTCEM_SHOW_CURSOR => Self::ShowCursor,
             SAVE_CURSOR_DEC => Self::SaveCursorDec,
             ALT_SCREEN_BUFFER => Self::AlternateScreenBuffer,
+            X11_MOUSE_TRACKING => Self::X11MouseTracking,
+            CELL_MOTION_MOUSE_TRACKING => Self::CellMotionMouseTracking,
+            APPLICATION_MOUSE_TRACKING => Self::ApplicationMouseTracking,
+            SGR_MOUSE_MODE => Self::SgrMouseMode,
             n => Self::Other(n),
         }
     }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_mode_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_mode_ops.rs
@@ -33,7 +33,7 @@ use crate::{core::ansi::vt_100_pty_output_parser::{CsiSequence, PrivateModeType}
 /// Tests for DECAWM (Auto Wrap Mode) operations.
 pub mod auto_wrap_mode {
     use super::*;
-    use crate::AutoWrapState;
+    use crate::AutoWrapMode;
 
     #[test]
     fn test_decawm_enable() {
@@ -42,7 +42,7 @@ pub mod auto_wrap_mode {
         // Auto wrap is enabled by default
         assert_eq!(
             ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Enabled
+            AutoWrapMode::Enabled
         );
 
         // Disable first to test enable
@@ -53,7 +53,7 @@ pub mod auto_wrap_mode {
         let _result = ofs_buf_vt_100.apply_ansi_bytes(disable_sequence);
         assert_eq!(
             ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Disabled
+            AutoWrapMode::Disabled
         );
 
         // Enable auto wrap mode
@@ -66,7 +66,7 @@ pub mod auto_wrap_mode {
         // Verify mode is enabled
         assert_eq!(
             ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Enabled
+            AutoWrapMode::Enabled
         );
     }
 
@@ -77,7 +77,7 @@ pub mod auto_wrap_mode {
         // Auto wrap is enabled by default
         assert_eq!(
             ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Enabled
+            AutoWrapMode::Enabled
         );
 
         // Disable auto wrap mode
@@ -90,7 +90,7 @@ pub mod auto_wrap_mode {
         // Verify mode is disabled
         assert_eq!(
             ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Disabled
+            AutoWrapMode::Disabled
         );
     }
 
@@ -146,7 +146,7 @@ pub mod auto_wrap_mode {
         let _result = ofs_buf_vt_100.apply_ansi_bytes(disable_sequence);
         assert_eq!(
             ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Disabled
+            AutoWrapMode::Disabled
         );
 
         // Perform other operations
@@ -163,7 +163,7 @@ pub mod auto_wrap_mode {
         // Mode should persist
         assert_eq!(
             ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Disabled
+            AutoWrapMode::Disabled
         );
 
         // Re-enable and verify
@@ -174,7 +174,7 @@ pub mod auto_wrap_mode {
         let _result = ofs_buf_vt_100.apply_ansi_bytes(enable_sequence);
         assert_eq!(
             ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Enabled
+            AutoWrapMode::Enabled
         );
     }
 }
@@ -182,7 +182,7 @@ pub mod auto_wrap_mode {
 /// Tests for mode state combinations and interactions.
 pub mod mode_interactions {
     use super::*;
-    use crate::AutoWrapState;
+    use crate::AutoWrapMode;
 
     #[test]
     fn test_multiple_mode_changes() {
@@ -191,7 +191,7 @@ pub mod mode_interactions {
         // Start with defaults
         assert_eq!(
             ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Enabled
+            AutoWrapMode::Enabled
         );
 
         // Toggle auto wrap multiple times
@@ -202,7 +202,7 @@ pub mod mode_interactions {
         let _result = ofs_buf_vt_100.apply_ansi_bytes(disable_sequence);
         assert_eq!(
             ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Disabled
+            AutoWrapMode::Disabled
         );
 
         let enable_sequence = format!(
@@ -212,7 +212,7 @@ pub mod mode_interactions {
         let _result = ofs_buf_vt_100.apply_ansi_bytes(enable_sequence);
         assert_eq!(
             ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Enabled
+            AutoWrapMode::Enabled
         );
 
         let disable_sequence2 = format!(
@@ -222,7 +222,7 @@ pub mod mode_interactions {
         let _result = ofs_buf_vt_100.apply_ansi_bytes(disable_sequence2);
         assert_eq!(
             ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Disabled
+            AutoWrapMode::Disabled
         );
     }
 
@@ -238,7 +238,7 @@ pub mod mode_interactions {
         let _result = ofs_buf_vt_100.apply_ansi_bytes(disable_sequence);
         assert_eq!(
             ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Disabled
+            AutoWrapMode::Disabled
         );
 
         // Save cursor
@@ -253,7 +253,7 @@ pub mod mode_interactions {
         let _result = ofs_buf_vt_100.apply_ansi_bytes(enable_sequence);
         assert_eq!(
             ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Enabled
+            AutoWrapMode::Enabled
         );
 
         // Restore cursor
@@ -263,7 +263,7 @@ pub mod mode_interactions {
         // Mode should persist (not affected by cursor restore)
         assert_eq!(
             ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Enabled
+            AutoWrapMode::Enabled
         );
     }
 }
@@ -271,7 +271,7 @@ pub mod mode_interactions {
 /// Tests for the Alternate Screen Buffer (`?1049`) mode operations.
 pub mod alt_screen_mode {
     use super::*;
-    use crate::AlternateScreenState;
+    use crate::ActiveScreenBuffer;
 
     #[test]
     fn test_alt_screen_enable_and_disable_via_ansi() {
@@ -279,8 +279,8 @@ pub mod alt_screen_mode {
 
         // Initially inactive.
         assert_eq!(
-            ofs_buf_vt_100.terminal_mode.alternate_screen,
-            AlternateScreenState::Inactive
+            ofs_buf_vt_100.terminal_mode.active_screen_buffer,
+            ActiveScreenBuffer::Primary
         );
 
         // Enable alternate screen buffer (`?1049h`)
@@ -290,8 +290,8 @@ pub mod alt_screen_mode {
         );
         let _result = ofs_buf_vt_100.apply_ansi_bytes(enable_sequence);
         assert_eq!(
-            ofs_buf_vt_100.terminal_mode.alternate_screen,
-            AlternateScreenState::Active
+            ofs_buf_vt_100.terminal_mode.active_screen_buffer,
+            ActiveScreenBuffer::Alternate
         );
 
         // Disable alternate screen buffer (`?1049l`)
@@ -301,8 +301,57 @@ pub mod alt_screen_mode {
         );
         let _result = ofs_buf_vt_100.apply_ansi_bytes(disable_sequence);
         assert_eq!(
-            ofs_buf_vt_100.terminal_mode.alternate_screen,
-            AlternateScreenState::Inactive
+            ofs_buf_vt_100.terminal_mode.active_screen_buffer,
+            ActiveScreenBuffer::Primary
         );
+    }
+}
+
+/// Tests for Mouse Tracking Mode operations.
+pub mod mouse_tracking_mode {
+    use super::*;
+    use crate::MouseTrackingMode;
+
+    #[test]
+    fn test_mouse_tracking_enable_and_disable() {
+        let mut ofs_buf = create_test_offscreen_buffer_10r_by_10c();
+
+        // Initially disabled.
+        assert_eq!(ofs_buf.terminal_mode.mouse_tracking, MouseTrackingMode::Disabled);
+
+        // Enable legacy mouse tracking (1000)
+        let enable_1000 = format!("{}", CsiSequence::EnablePrivateMode(PrivateModeType::X11MouseTracking));
+        let _unused = ofs_buf.apply_ansi_bytes(enable_1000);
+        assert_eq!(ofs_buf.terminal_mode.mouse_tracking, MouseTrackingMode::Enabled);
+
+        // Disable legacy mouse tracking
+        let disable_1000 = format!("{}", CsiSequence::DisablePrivateMode(PrivateModeType::X11MouseTracking));
+        let _unused = ofs_buf.apply_ansi_bytes(disable_1000);
+        assert_eq!(ofs_buf.terminal_mode.mouse_tracking, MouseTrackingMode::Disabled);
+
+        // Enable legacy mouse tracking (1002)
+        let enable_1002 = format!("{}", CsiSequence::EnablePrivateMode(PrivateModeType::CellMotionMouseTracking));
+        let _unused = ofs_buf.apply_ansi_bytes(enable_1002);
+        assert_eq!(ofs_buf.terminal_mode.mouse_tracking, MouseTrackingMode::Enabled);
+        let _unused = ofs_buf.apply_ansi_bytes(format!("{}", CsiSequence::DisablePrivateMode(PrivateModeType::CellMotionMouseTracking)));
+
+        // Enable legacy mouse tracking (1003)
+        let enable_1003 = format!("{}", CsiSequence::EnablePrivateMode(PrivateModeType::ApplicationMouseTracking));
+        let _unused = ofs_buf.apply_ansi_bytes(enable_1003);
+        assert_eq!(ofs_buf.terminal_mode.mouse_tracking, MouseTrackingMode::Enabled);
+        
+        // Enable SGR mouse tracking (1006)
+        let enable_1006 = format!("{}", CsiSequence::EnablePrivateMode(PrivateModeType::SgrMouseMode));
+        let _unused = ofs_buf.apply_ansi_bytes(enable_1006);
+        assert_eq!(ofs_buf.terminal_mode.mouse_tracking, MouseTrackingMode::Enabled);
+
+        // Disable SGR mouse tracking
+        let disable_1006 = format!("{}", CsiSequence::DisablePrivateMode(PrivateModeType::SgrMouseMode));
+        let _unused = ofs_buf.apply_ansi_bytes(disable_1006);
+        assert_eq!(ofs_buf.terminal_mode.mouse_tracking, MouseTrackingMode::Enabled);
+
+        // Finally disable tracking
+        let _unused = ofs_buf.apply_ansi_bytes(format!("{}", CsiSequence::DisablePrivateMode(PrivateModeType::ApplicationMouseTracking)));
+        assert_eq!(ofs_buf.terminal_mode.mouse_tracking, MouseTrackingMode::Disabled);
     }
 }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_scroll_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_scroll_ops.rs
@@ -13,7 +13,7 @@
 //! - Interactions between scroll regions and cursor positioning
 
 use super::super::test_fixtures_vt_100_ansi_conformance::*;
-use crate::{AutoWrapState, EscSequence, TuiStyle, col,
+use crate::{AutoWrapMode, EscSequence, TuiStyle, col,
             core::ansi::{constants::{IND_INDEX_DOWN, RI_REVERSE_INDEX_UP},
                          vt_100_pty_output_parser::{CsiSequence, PrivateModeType,
                                                     ansi_parser_public_api::AnsiToOfsBufPerformer}},
@@ -65,7 +65,7 @@ pub mod auto_wrap {
         // Verify auto-wrap is enabled by default.
         assert!(
             performer.ofs_buf_vt_100.parser_global_state.auto_wrap_mode
-                == AutoWrapState::Enabled,
+                == AutoWrapMode::Enabled,
             "Auto-wrap mode should be enabled by default"
         );
 
@@ -131,7 +131,7 @@ pub mod auto_wrap {
         // Verify auto-wrap is now disabled.
         assert!(
             performer.ofs_buf_vt_100.parser_global_state.auto_wrap_mode
-                == AutoWrapState::Disabled,
+                == AutoWrapMode::Disabled,
             "Auto-wrap mode should be disabled after CSI ?7l"
         );
 
@@ -163,7 +163,7 @@ pub mod auto_wrap {
         // Start with default (enabled)
         assert_eq!(
             performer.ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Enabled
+            AutoWrapMode::Enabled
         );
 
         // Disable auto-wrap.
@@ -172,7 +172,7 @@ pub mod auto_wrap {
         performer.apply_ansi_bytes(disable_sequence);
         assert_eq!(
             performer.ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Disabled
+            AutoWrapMode::Disabled
         );
 
         // Re-enable auto-wrap using CSI `?7h`.
@@ -181,7 +181,7 @@ pub mod auto_wrap {
         performer.apply_ansi_bytes(enable_sequence);
         assert_eq!(
             performer.ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Enabled
+            AutoWrapMode::Enabled
         );
 
         // Test that wrapping works again.

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_system_state_management.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_system_state_management.rs
@@ -11,7 +11,7 @@
 //! [`SGR`]: crate::SgrCode
 
 use super::super::test_fixtures_vt_100_ansi_conformance::*;
-use crate::{ANSIBasicColor, AutoWrapState, EraseDisplayMode, SgrCode, col,
+use crate::{ANSIBasicColor, AutoWrapMode, EraseDisplayMode, SgrCode, col,
             core::ansi::vt_100_pty_output_parser::{CsiSequence, PrivateModeType},
             row, term_col, term_row};
 
@@ -246,7 +246,7 @@ pub mod character_set_state_management {
         );
         assert_eq!(
             ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Disabled
+            AutoWrapMode::Disabled
         );
 
         // Change modes but keep character set
@@ -259,7 +259,7 @@ pub mod character_set_state_management {
         // Auto-wrap should change but character set should persist
         assert_eq!(
             ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Enabled
+            AutoWrapMode::Enabled
         );
         assert_eq!(
             ofs_buf_vt_100.parser_global_state.character_set,
@@ -405,7 +405,7 @@ pub mod scroll_region_state_interactions {
 /// Tests for complex state combinations and edge cases.
 pub mod complex_state_combinations {
     use super::*;
-    use crate::AutoWrapState;
+    use crate::AutoWrapMode;
 
     #[test]
     fn test_full_state_combination() {
@@ -468,7 +468,7 @@ pub mod complex_state_combinations {
         );
         assert_eq!(
             ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Enabled
+            AutoWrapMode::Enabled
         );
     }
 
@@ -506,7 +506,7 @@ pub mod complex_state_combinations {
         );
         assert_eq!(
             ofs_buf_vt_100.parser_global_state.auto_wrap_mode,
-            AutoWrapState::Disabled
+            AutoWrapMode::Disabled
         );
 
         // Current style should still have bold

--- a/tui/src/core/ansi/vt_100_terminal_input_parser/keyboard.rs
+++ b/tui/src/core/ansi/vt_100_terminal_input_parser/keyboard.rs
@@ -152,6 +152,9 @@
 //!
 //! ### How Bitmask Encoding for Modifiers Works
 //!
+//! *(See also: [`mouse` module docs] for a contrasting example of where pure bitwise OR
+//! is required).*
+//!
 //! [`CSI`] sequences encode modifiers as a number after the semicolon: `ESC [ 1 ; <n> A`.
 //! The number `n` is calculated by adding the values of pressed modifiers to 1:
 //!
@@ -160,9 +163,10 @@
 //!
 //! Formula: n = 1 + (pressed modifiers)
 //!
-//! Examples:             (bitmask)
-//!                        ┌─ n ─┐   ┌─ offset (1-indexed, not 0-indexed)
-//!                        ▼     ▼   ▼
+//! Examples:
+//!                           n          offset (1-indexed, not 0-indexed)
+//!                           │          │
+//!                           ▼          ▼
 //! Ctrl+Up       : ESC [ 1 ; 5 A    5 = 1 + Ctrl(4)
 //! Alt+Down      : ESC [ 1 ; 3 B    3 = 1 + Alt(2)
 //! Ctrl+Shift+Up : ESC [ 1 ; 6 A    6 = 1 + Shift(1) + Ctrl(4)
@@ -459,6 +463,7 @@
 //! [`ESC`]: crate::EscSequence
 //! [`keyboard`]: mod@super
 //! [`Kitty`]: https://sw.kovidgoyal.net/kitty/
+//! [`mouse` module docs]: mod@crate::core::ansi::constants::mouse#bitmask-arithmetic-operations
 //! [`mouse`]: mod@super::mouse
 //! [`router`]: mod@super::router
 //! [`RXVT`]: https://en.wikipedia.org/wiki/Rxvt

--- a/tui/src/core/common/fast_strings/fast_stringify.rs
+++ b/tui/src/core/common/fast_strings/fast_stringify.rs
@@ -3,8 +3,15 @@
 //! Trait for high-performance string building for complex types. See [`FastStringify`],
 //! [`BufTextStorage`] and [`generate_impl_display_for_fast_stringify!`] for details.
 //!
-//! [`generate_impl_display_for_fast_stringify!`]: crate::generate_impl_display_for_fast_stringify
+//! [`fast_strings`]: mod@fast_strings#string-allocation-performance-strategy
+//! [`generate_impl_display_for_fast_stringify!`]:
+//!     macro@crate::generate_impl_display_for_fast_stringify
 
+#[allow(
+    unused_imports,
+    reason = "For short import statements in link ref defs"
+)]
+use crate::core::common::fast_strings;
 use std::fmt::{Display, Formatter, Result};
 
 /// High-performance string building for complex types that avoids formatter overhead.
@@ -13,11 +20,15 @@ use std::fmt::{Display, Formatter, Result};
 /// [`FastStringify`] **must also implement** [`Display`]. This allows the trait to
 /// provide optimized string building while maintaining compatibility with Rust's standard
 /// formatting infrastructure.
+/// - You do not have to implement [`Display`] manually since we have a declarative macro
+///   ([`generate_impl_display_for_fast_stringify!`]) that will do this for you.
+/// - We chose not to write this as a derive proc macro to avoid slowing down the build
+///   process.
 ///
 /// # How to Implement
 ///
 /// Both [`FastStringify`] and [`Display`] must be implemented, but the [`Display`]
-/// implementation is always the same boilerplate. Use the
+/// implementation is always the same boilerplate and you can use the
 /// [`generate_impl_display_for_fast_stringify!`] macro to generate it automatically.
 ///
 /// 1. **Implement [`write_to_buf()`]** with your custom formatting logic
@@ -25,60 +36,29 @@ use std::fmt::{Display, Formatter, Result};
 ///    [`Display`] implementation
 ///
 /// ```rust
-///    # use r3bl_tui::{
-///    #    FastStringify, BufTextStorage, generate_impl_display_for_fast_stringify, ok
-///    # };
-///    # use std::fmt::{Result, Write};
-///    # struct MyType { value: i32 }
-///    impl FastStringify for MyType {
-///        fn write_to_buf(&self, acc: &mut BufTextStorage) -> Result {
-///            acc.push_str("MyType { value: ");
-///            write!(acc, "{}", self.value)?;  // Use write! only when formatting needed
-///            acc.push_str(" }");
-///            ok!()
-///        }
-///    }
-///
-///    // ✨ One line instead of 5-line Display impl!
-///    generate_impl_display_for_fast_stringify!(MyType);
-///    ```
-///
-/// # Why Use This?
-///
-/// The standard [`Display`] trait using [`Formatter`] has significant overhead for types
-/// that build strings from many pieces. Each [`write!`] call goes through the formatter's
-/// state machine, checking flags and doing bounds checks. [`FastStringify`] batches all
-/// content into a single buffer, then makes ONE write to the formatter using
-/// [`write_str`], reducing overhead from ~16% to ~5-8% in performance profiles.
-///
-/// # Performance Hierarchy (fastest to slowest)
-///
-/// 1. **Direct `push_str()`** - The absolute fastest when you have a `&str`
-///
-///    ```rust
-///    # let mut buffer = String::new();
-///    buffer.push_str("Hello, world!");  // Zero overhead, direct memory copy
-///    ```
-///
-/// 2. **[`FastStringify`] trait** - Fast batched writing for complex types. See
-///    [implementation example] above.
-///
-/// 3. **[`write!`] with [`FormatArgs`]** - Slowest due to formatting overhead
-///
-///    ```rust
-///    # use std::fmt::Write;
-///    # let mut buffer = String::new();
-///    # let value = 42;
-///    // Goes through formatter state machine
-///    write!(buffer, "Value: {}", value)?;
-///    # Ok::<(), std::fmt::Error>(())
-///    ```
+/// # use r3bl_tui::{
+/// #    FastStringify, BufTextStorage, generate_impl_display_for_fast_stringify, ok
+/// # };
+/// # use std::fmt::{Result, Write};
+/// # struct MyType { value: i32 }
+/// impl FastStringify for MyType {
+///     fn write_to_buf(&self, acc: &mut BufTextStorage) -> Result {
+///         acc.push_str("MyType { value: ");
+///         write!(acc, "{}", self.value)?;  // Use write! only when formatting needed
+///         acc.push_str(" }");
+///         ok!()
+///     }
+/// }
+/// 
+/// // ✨ One line instead of 5-line Display impl!
+/// generate_impl_display_for_fast_stringify!(MyType);
+/// ```
 ///
 /// [`Display`]: Display
 /// [`FormatArgs`]: std::fmt::Arguments
 /// [`Formatter`]: std::fmt::Formatter
 /// [`generate_impl_display_for_fast_stringify!`]:
-///     crate::generate_impl_display_for_fast_stringify
+///     macro@crate::generate_impl_display_for_fast_stringify
 /// [`push_str`]: String::push_str
 /// [`write!`]: std::write
 /// [`write_buf_to_fmt()`]: FastStringify::write_buf_to_fmt
@@ -229,9 +209,8 @@ macro_rules! generate_impl_display_for_fast_stringify {
 
 #[cfg(test)]
 mod tests {
-    use crate::ok;
-
     use super::*;
+    use crate::ok;
     use pretty_assertions::assert_eq;
     use std::fmt::Write;
 

--- a/tui/src/core/common/fast_strings/format_no_alloc.rs
+++ b/tui/src/core/common/fast_strings/format_no_alloc.rs
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 R3BL LLC. Licensed under Apache License, Version 2.0.
+
+//! Extension trait and macro to perform zero-allocation formatting into preallocated
+//! string. See [`PreallocatedStringExt`] and [`format_no_alloc!`] for details.
+//!
+//! [`format_no_alloc!`]: macro@crate::format_no_alloc
+//! [`PreallocatedStringExt`]: crate::PreallocatedStringExt
+
+#[allow(
+    unused_imports,
+    reason = "For short import statements in link ref defs"
+)]
+use crate::core::common::fast_strings;
+use std::fmt::{Arguments, Write};
+
+/// Trait to extend [`String`] with an ergonomic method for zero-allocation formatting.
+///
+/// This provides the underlying mechanics for the [`format_no_alloc!`] macro, but can
+/// also be used directly when working manually with [`std::fmt::Arguments`].
+///
+/// See [`fast_strings`] for the central architecture covering all string performance and
+/// allocation strategies in the codebase.
+///
+/// [`fast_strings`]: mod@fast_strings#string-allocation-performance-strategy
+/// [`format_no_alloc!`]: macro@crate::format_no_alloc
+pub trait PreallocatedStringExt {
+    /// Clears the string, writes the formatted arguments without allocating new heap
+    /// memory, and returns the borrowed string slice.
+    fn format_into(&mut self, args: Arguments<'_>) -> &str;
+}
+
+impl PreallocatedStringExt for String {
+    fn format_into(&mut self, args: Arguments<'_>) -> &str {
+        self.clear();
+        let _unused = Write::write_fmt(self, args);
+        self.as_str()
+    }
+}
+
+/// A highly ergonomic macro that acts as a zero-heap-allocation drop-in replacement for
+/// [`format!`] when you are inside a hot loop and already have a pre-allocated [`String`]
+/// buffer available to reuse.
+///
+/// It will clear the given buffer, write the format string directly into the existing
+/// heap capacity using [`std::fmt::Write`], and evaluate to a `&str`.
+///
+/// See [`fast_strings`] for the central architecture covering all string performance and
+/// allocation strategies in the codebase.
+///
+/// # How format args are passed to the trait method
+///
+/// In the macro code below, we call [`format_args!`]. This generates a return type of
+/// [`Arguments`], which is then passed as the second parameter `args` of the call to the
+/// [`format_into()`] method of the trait.
+///
+/// # Example
+///
+/// ```rust
+/// use r3bl_tui::format_no_alloc;
+///
+/// // Allocate ONCE outside the hot loop
+/// let mut title_buf = String::with_capacity(128);
+///
+/// for i in 0..100 {
+///     // Zero heap allocations per tick!
+///     let title_ref = format_no_alloc!(title_buf, "Tick count: {i}");
+///     // title_ref is a `&str` and title_buf's capacity is reused.
+/// }
+/// ```
+///
+/// [`fast_strings`]:
+///     mod@crate::core::common::fast_strings#string-allocation-performance-strategy
+/// [`format_into()`]: PreallocatedStringExt::format_into
+#[macro_export]
+macro_rules! format_no_alloc {
+    ($buf:expr, $($arg:tt)*) => {{
+        use $crate::PreallocatedStringExt;
+        $buf.format_into(format_args!($($arg)*))
+    }};
+}

--- a/tui/src/core/common/fast_strings/mod.rs
+++ b/tui/src/core/common/fast_strings/mod.rs
@@ -1,0 +1,75 @@
+// Copyright (c) 2025 R3BL LLC. Licensed under Apache License, Version 2.0.
+
+//! # String Allocation Performance Strategy
+//!
+//! This codebase is heavily optimized for zero-allocation rendering and formatting.
+//! Depending on the specific use case, we use one of three core approaches for building
+//! strings.
+//!
+//! ## Performance Hierarchy (fastest to slowest for standard formatting)
+//!
+//! 1. Direct [`push_str()`] - Zero overhead, direct memory copy.
+//! 2. [`format_no_alloc!`] - Zero heap allocations, reuses existing heap.
+//! 3. [`FastStringify`] - Temporary heap allocation, bypasses formatter state machine.
+//! 4. [`inline_string!`] - Stack allocated, but spills to heap if > [`16`] bytes.
+//! 5. [`format!`] / [`write!`] - Double whammy - always heap allocates (for [`format!`])
+//!    and/or uses heavy formatter overhead (for [`write!`]).
+//!
+//! ## 1. [`FastStringify`] Trait (For High-Throughput [`ANSI`] & Custom Types)
+//!
+//! The standard [`Display`] trait using [`Formatter`] has significant overhead. Each
+//! [`write!`] macro call expands to [`write_fmt`], which spins up a state machine to
+//! parse arguments, check flags, and handle dynamic dispatch.
+//!
+//! [`FastStringify`] batches all content into a single buffer, then makes ONE
+//! [`write_str()`] call. Unlike [`write!`], [`write_str`] completely bypasses the
+//! formatting engine and copies the bytes directly.
+//!
+//! - Tradeoff: It actually introduces a short-lived heap allocation to build the batched
+//!   string, but bypasses the expensive [`Formatter`] state machine. For complex types
+//!   serialized millions of times (like [`ANSI`] codes), this is significantly faster
+//!   than standard [`Display`].
+//!
+//! ## 2. [`inline_string!`] Macro (For the Stack / Editor Engine)
+//!
+//! [`inline_string!`] writes formatted text directly into a [`InlineString`] allocated on
+//! the stack ([`16`] bytes). It acts as a drop-in replacement for [`format!`].
+//!
+//! - Use Case: The primary use case is the core [Editor Component], which processes
+//!   thousands of individual characters or short grapheme clusters (1-4 bytes) per frame.
+//!   It is also highly recommended for `tracing::*!` macros when logging small variables.
+//! - Warning: If the formatted text exceeds [`16`] bytes, it will dynamically spill to
+//!   the heap, incurring the same cost as [`format!`].
+//!
+//! ## 3. [`format_no_alloc!`] Macro (For Hot Loops)
+//!
+//! When you need to build dynamic strings in a hot loop (like a 60 FPS event loop) that
+//! are guaranteed to exceed [`16`] bytes, [`inline_string!`] will spill. Instead, use
+//! [`format_no_alloc!`].
+//!
+//! - Use Case: You hoist a [`String::with_capacity(N)`] outside the loop, and pass it to
+//!   the macro inside the loop. It clears the buffer and writes into the existing heap
+//!   capacity, ensuring absolutely zero heap allocations per tick.
+//!
+//! [`16`]: crate::core::DEFAULT_STRING_STORAGE_SIZE
+//! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
+//! [`Display`]: std::fmt::Display
+//! [`FastStringify`]: crate::FastStringify
+//! [`format!`]: std::format
+//! [`format_no_alloc!`]: macro@crate::format_no_alloc
+//! [`Formatter`]: std::fmt::Formatter
+//! [`inline_string!`]: crate::inline_string
+//! [`InlineString`]: crate::InlineString
+//! [`push_str()`]: String::push_str
+//! [`String::with_capacity(N)`]: String::with_capacity
+//! [`write!`]: std::write
+//! [`write_fmt`]: std::fmt::Formatter::write_fmt
+//! [`write_str()`]: std::fmt::Formatter::write_str
+//! [`write_str`]: std::fmt::Formatter::write_str
+//! [Editor Component]: crate::EditorComponent
+
+pub mod fast_stringify;
+pub mod format_no_alloc;
+
+pub use fast_stringify::*;
+pub use format_no_alloc::*;

--- a/tui/src/core/common/lru_cache.rs
+++ b/tui/src/core/common/lru_cache.rs
@@ -35,9 +35,9 @@
 //! assert_eq!(cache.get(&"key".to_string()), Some(&42));
 //! ```
 
+use crate::StdMutex;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use std::{hash::Hash, sync::Arc};
-use crate::StdMutex;
 
 /// Entry in the LRU cache containing the value and access metadata.
 #[derive(Clone, Debug)]

--- a/tui/src/core/common/mod.rs
+++ b/tui/src/core/common/mod.rs
@@ -1,11 +1,15 @@
 // Copyright (c) 2022-2025 R3BL LLC. Licensed under Apache License, Version 2.0.
 
+//! # String Allocation Performance and Strategy for the entire codebase
+//!
+//! This codebase is heavily optimized for zero-allocation rendering and formatting.
+//! Depending on the specific use case, we use one of three core approaches for building
 // Attach sources.
 pub mod common_atomic;
 pub mod common_enums;
 pub mod common_math;
 pub mod common_result_and_error;
-pub mod fast_stringify;
+pub mod fast_strings;
 pub mod get_mem_size;
 pub mod lru_cache;
 pub mod memoized_value;
@@ -26,7 +30,7 @@ pub use common_atomic::*;
 pub use common_enums::*;
 pub use common_math::*;
 pub use common_result_and_error::*;
-pub use fast_stringify::*;
+pub use fast_strings::*;
 pub use get_mem_size::*;
 pub use lru_cache::*;
 pub use memoized_value::*;

--- a/tui/src/core/common/scoped_mutex/deadlock_prevention/constants.rs
+++ b/tui/src/core/common/scoped_mutex/deadlock_prevention/constants.rs
@@ -6,7 +6,7 @@
 //! [`DeadlockPreventionPolicy`]: crate::DeadlockPreventionPolicy
 
 /// The maximum number of simultaneous locks that can be tracked in the [`SharedLedger`].
-/// 
+///
 /// [`SharedLedger`]: crate::SharedLedger
 pub const ADDRESS_SIZE: usize = 4;
 

--- a/tui/src/core/common/scoped_mutex/deadlock_prevention/mod.rs
+++ b/tui/src/core/common/scoped_mutex/deadlock_prevention/mod.rs
@@ -5,10 +5,10 @@
 //!
 //! [`ScopedMutex`]: crate::ScopedMutex
 
+mod constants;
 mod policy;
 mod policy_impl;
-mod constants;
 
+pub use constants::*;
 pub use policy::*;
 pub use policy_impl::*;
-pub use constants::*;

--- a/tui/src/core/mod.rs
+++ b/tui/src/core/mod.rs
@@ -13,6 +13,7 @@ pub mod test_fixtures;
 pub mod common;
 pub mod log;
 pub mod misc;
+pub mod notification;
 pub mod heap_alloc_types;
 pub mod ansi;
 
@@ -35,6 +36,7 @@ pub use graphemes::*;
 pub use heap_alloc_types::*;
 pub use log::*;
 pub use misc::*;
+pub use notification::*;
 pub use osc::*;
 pub use pty::*;
 pub use script::*;

--- a/tui/src/core/notification.rs
+++ b/tui/src/core/notification.rs
@@ -1,6 +1,5 @@
 // Copyright (c) 2025 R3BL LLC. Licensed under Apache License, Version 2.0.
 
-use crate::tui::DEBUG_TUI_SHOW_PTY_MUX_NOTIFICATIONS;
 use notify_rust::{Notification, Timeout};
 
 /// Default notification display duration.
@@ -15,10 +14,6 @@ pub const NOTIFICATION_TIMEOUT_MS: u32 = 1_000;
 ///
 /// [`show()`]: notify_rust::Notification::show
 pub fn show_notification_non_blocking(title: &str, message: &str) {
-    if !DEBUG_TUI_SHOW_PTY_MUX_NOTIFICATIONS {
-        return;
-    }
-
     // Don't block calling thread since this is synchronous blocking OS API call.
     std::thread::spawn({
         let title_owned = title.to_string();

--- a/tui/src/core/pty/pty_mux/adaptive_render_budget.rs
+++ b/tui/src/core/pty/pty_mux/adaptive_render_budget.rs
@@ -1,0 +1,189 @@
+// Copyright (c) 2025 R3BL LLC. Licensed under Apache License, Version 2.0.
+
+//! Implements an adaptive render budget to prevent terminal emulator overload.
+//!
+//! If a terminal emulator is overwhelmed by receiving too many [`ANSI`] escape sequences
+//! too quickly, it can cause severe UI lag and flickering. This module implements
+//! an asymmetric backoff algorithm (throttling) to dynamically adjust the frame rate
+//! (target FPS) based on how quickly the terminal is able to process and flush the
+//! output buffer.
+//!
+//! - **Backpressure Detection**: If flushing the buffer takes too long (exceeds a
+//!   threshold), the system assumes the terminal is struggling and applies a heavy
+//!   penalty to the render loop, dropping the frame rate.
+//! - **Asymmetric Recovery**: Once the terminal catches up, the system slowly restores
+//!   the frame rate to its target 60 FPS, ensuring it doesn't immediately overwhelm the
+//!   terminal again.
+//!
+//! The main entry points to this module are the methods on the [`Budget`] struct:
+//! - [`should_render()`]: Determines if a frame should be drawn based on the current
+//!   budget.
+//! - [`mark_start()`]: Records the timestamp before sending data to the terminal.
+//! - [`mark_end()`]: Measures elapsed time and executes the asymmetric backoff algorithm.
+//!
+//! [`ANSI`]: https://en.wikipedia.org/wiki/ANSI_escape_code
+//! [`mark_end()`]: Budget::mark_end
+//! [`mark_start()`]: Budget::mark_start
+//! [`should_render()`]: Budget::should_render
+
+use super::ProcessManager;
+use crate::DEBUG_TUI_PTY_MUX;
+use std::time::{Duration, Instant};
+
+/// Default render speed is ~60 FPS.
+pub const DEFAULT_FRAME_DELAY_MS: Duration = Duration::from_millis(16);
+
+/// Slowest render speed is ~10 FPS.
+pub const MAX_FRAME_DELAY_MS: Duration = Duration::from_millis(100);
+
+/// Min FPS is uncapped. If the terminal is fast enough, there is no throttling and it
+/// will render as fast as possible.
+pub const MIN_FRAME_DELAY_MS: Duration = Duration::from_millis(0);
+
+/// Flush taking >5ms indicates pressure.
+pub const RENDER_TIME_BACKPRESSURE_THRESHOLD_MS: Duration =
+    Duration::from_millis(RENDER_TIME_BASE * 5);
+
+// Asymmetric backoff - penalty is 5 x higher than reward. If we detect backpressure,
+// we backoff and hit the brakes hard.
+pub const THROTTLE_PENALTY_MS: Duration = Duration::from_millis(RENDER_TIME_BASE * 10);
+
+// Asymmetric backoff - reward is 5 x lower than reward. If we detect flushing is
+// getting faster, we are easy in the recovery, by getting back on the gas
+// gradually.
+pub const RECOVERY_REWARD_MS: Duration = Duration::from_millis(RENDER_TIME_BASE);
+
+const RENDER_TIME_BASE: u64 = 1;
+
+#[derive(Debug)]
+pub enum AdaptiveRenderResult {
+    Skip,
+    Render,
+}
+
+#[derive(Debug)]
+pub struct Budget {
+    pub last_render_time: Instant,
+    pub render_cooldown_delay: Duration,
+    pub maybe_render_start: Option<Instant>,
+}
+
+impl Default for Budget {
+    fn default() -> Self {
+        Self {
+            last_render_time: Instant::now(),
+            render_cooldown_delay: DEFAULT_FRAME_DELAY_MS,
+            maybe_render_start: None,
+        }
+    }
+}
+
+impl Budget {
+    /// Decides if we should render this frame based on output and budget.
+    pub fn should_render(
+        &self,
+        process_manager: &mut ProcessManager,
+    ) -> AdaptiveRenderResult {
+        let process_had_output = process_manager.poll_all_processes();
+        if !process_had_output {
+            return AdaptiveRenderResult::Skip;
+        }
+        let time_since_last_render = self.last_render_time.elapsed();
+        if time_since_last_render >= self.render_cooldown_delay {
+            AdaptiveRenderResult::Render
+        } else {
+            AdaptiveRenderResult::Skip
+        }
+    }
+
+    /// Marks the start of a rendering pass. This timestamp is used to measure how
+    /// long the rendering operation takes, which informs the adaptive budget
+    /// calculation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called twice without an intervening [`mark_end()`] call, enforcing
+    /// the strict [`mark_start()`] -> render -> [`mark_end()`] state machine.
+    ///
+    /// [`mark_end()`]: Self::mark_end
+    /// [`mark_start()`]: Self::mark_start
+    pub fn mark_start(&mut self) {
+        assert!(
+            self.maybe_render_start.is_none(),
+            "Can't call mark_start() more than once"
+        );
+        self.maybe_render_start = Some(Instant::now());
+    }
+
+    /// Updates the budget based on how long the render actually took.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called without a preceding [`mark_start()`] call, enforcing the
+    /// strict [`mark_start()`] -> render -> [`mark_end()`] state machine.
+    ///
+    /// [`mark_end()`]: Self::mark_end
+    /// [`mark_start()`]: Self::mark_start
+    pub fn mark_end(&mut self) {
+        // Mark the end of the render pass. This is how long a render pass took.
+        let render_duration = self
+            .maybe_render_start
+            .take()
+            .expect("Can't call mark_end() without calling mark_start() first")
+            .elapsed();
+
+        // Mark the current time as the last render time. This will be used in the
+        // should_render() method.
+        self.last_render_time = Instant::now();
+
+        // Adjust budget dynamically based on detected back pressure. We are
+        // implementing asymmetric backoff.
+        let backpressure_detected =
+            render_duration > RENDER_TIME_BACKPRESSURE_THRESHOLD_MS;
+        if backpressure_detected {
+            // Penalize render budget for backpressure.
+            self.render_cooldown_delay = self
+                .render_cooldown_delay
+                .saturating_add(THROTTLE_PENALTY_MS)
+                .min(MAX_FRAME_DELAY_MS);
+
+            DEBUG_TUI_PTY_MUX.then(|| {
+                // % is Display, ? is Debug.
+                tracing::info! {
+                    message = "Budget::mark_end",
+                    info = %format!(
+                        "Render took {:?} (> {:?}). Throttling frame delay to {:?}",
+                        render_duration,
+                        RENDER_TIME_BACKPRESSURE_THRESHOLD_MS,
+                        self.render_cooldown_delay
+                    )
+                };
+            });
+        } else {
+            // Used for logging.
+            let old_delay = self.render_cooldown_delay;
+
+            // Reward render budget for smooth rendering.
+            self.render_cooldown_delay = self
+                .render_cooldown_delay
+                .saturating_sub(RECOVERY_REWARD_MS)
+                .max(MIN_FRAME_DELAY_MS);
+
+            // Only log recovery if the delay actually changed to avoid spamming
+            // the logs
+            if old_delay != self.render_cooldown_delay {
+                DEBUG_TUI_PTY_MUX.then(|| {
+                    // % is Display, ? is Debug.
+                    tracing::info! {
+                        message = "Budget::mark_end",
+                        info = %format!(
+                            "Render took {:?}. Recovering frame delay to {:?}",
+                            render_duration,
+                            self.render_cooldown_delay
+                        )
+                    };
+                });
+            }
+        }
+    }
+}

--- a/tui/src/core/pty/pty_mux/input_router.rs
+++ b/tui/src/core/pty/pty_mux/input_router.rs
@@ -2,16 +2,31 @@
 
 //! Dynamic input event routing for the [`PTY`] multiplexer.
 //!
-//! This module handles keyboard input routing, including dynamic process switching
-//! shortcuts (F1 through F9 based on the number of processes) and terminal resize events.
+//! This module intercepts and routes all user input (keyboard, mouse, terminal resize) to
+//! either the multiplexer's control layer or the currently active background process.
 //!
+//! ## Core Responsibilities
+//!
+//! 1. _Multiplexer Control_: Handles global multiplexer management commands, such as
+//!    exiting the session and dynamically switching focus between concurrent processes.
+//! 2. _Keyboard Input_: Forwards all other keyboard inputs safely to the active [`PTY`]
+//!    session.
+//! 3. _Mouse Tracking_: Intercepts terminal mouse events, respects the active buffer's
+//!    [`MouseTrackingState`], and translates clicks, scrolls, and motion into [`VT-100`]
+//!    compliant [`SGR`] sequences via [`SgrMouseSequence`].
+//! 4. _Resize Events_: Propagates terminal resize events to the process manager to update
+//!    all underlying sessions.
+//!
+//! [`MouseTrackingState`]: crate::MouseTrackingState
 //! [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
+//! [`SGR`]: crate::SgrCode
+//! [`SgrMouseSequence`]: crate::SgrMouseSequence
+//! [`VT-100`]: https://vt100.net/docs/vt100-ug/chapter3.html
 
-use super::{ProcessManager, show_notification_non_blocking};
-use crate::{Continuation, InputEvent, Key, KeyPress, KeyState, ModifierKeysMask,
-            PtyInputEvent, Size,
-            core::{osc::OscController, terminal_io::OutputDevice},
-            ok};
+use super::ProcessManager;
+use crate::{ArrayBoundsCheck, ArrayOverflowResult, ColIndex, Continuation,
+            DEBUG_TUI_PTY_MUX, InputEvent, MouseTrackingMode, RowHeight, RowIndex, Size,
+            TermCol, TermRow};
 
 /// Routes input events to appropriate handlers and manages dynamic keyboard shortcuts.
 #[derive(Debug)]
@@ -36,93 +51,20 @@ impl InputRouter {
         &mut self,
         event: InputEvent,
         process_manager: &mut ProcessManager,
-        osc: &mut OscController<'_>,
-        _output_device: &OutputDevice,
     ) -> miette::Result<Continuation> {
         match event {
             InputEvent::Keyboard(key) => {
-                match key {
-                    // Process switching: Handle F1 through F12 for switching processes
-                    KeyPress::Plain {
-                        key: Key::FunctionKey(fn_key),
-                    } => {
-                        let fn_number = u8::from(fn_key);
-                        let process_index = (fn_number - 1) as usize;
-
-                        tracing::debug!("Received F{} for process switching", fn_number);
-
-                        // Only switch if the process index is valid for current process
-                        // count.
-                        if process_index < process_manager.processes().len() {
-                            let old_index = process_manager.active_index();
-                            if old_index == process_index {
-                                tracing::debug!(
-                                    "F{} pressed but already on process {}",
-                                    fn_number,
-                                    process_index
-                                );
-                            } else {
-                                tracing::debug!(
-                                    "Process switch: {} -> {} (triggered by F{})",
-                                    old_index,
-                                    process_index,
-                                    fn_number
-                                );
-
-                                // Show notification for process switching.
-                                let process_name =
-                                    &process_manager.processes()[process_index].command;
-                                show_notification_non_blocking(
-                                    "PTY Mux - Process Switch",
-                                    &format!("Switching to {process_name}"),
-                                );
-
-                                process_manager.switch_to(process_index);
-                                Self::update_terminal_title(process_manager, osc)?;
-                                tracing::debug!("Process switch completed successfully");
-                            }
-                        } else {
-                            tracing::warn!(
-                                "Invalid process index {} for current process count {} (F{} pressed)",
-                                process_index,
-                                process_manager.processes().len(),
-                                fn_number
-                            );
-                        }
-                    }
-                    // Exit shortcut: Ctrl+Q
-                    KeyPress::WithModifiers {
-                        key: Key::Character('q'),
-                        mask:
-                            ModifierKeysMask {
-                                ctrl_key_state: KeyState::Pressed,
-                                shift_key_state: _, // Don't care about shift state
-                                alt_key_state: _,   // Don't care about alt state
-                            },
-                    } => {
-                        tracing::debug!("Exit requested (Ctrl+Q)");
-
-                        // Show notification for exit.
-                        show_notification_non_blocking(
-                            "PTY Mux - Exit",
-                            "Exiting PTY Mux",
-                        );
-
-                        return Ok(Continuation::Stop); // Exit requested
-                    }
-                    _ => {
-                        // Show notification for other key presses (useful for debugging)
-                        show_notification_non_blocking(
-                            "PTY Mux - Key Press",
-                            &format!("Key pressed: {key:?}"),
-                        );
-
-                        // Forward all other input to active PTY using proper conversion.
-                        if let Some(pty_event) = Option::<PtyInputEvent>::from(key) {
-                            tracing::debug!("Forwarding input to PTY: {:?}", pty_event);
-                            process_manager.send_input(pty_event)?;
-                        }
-                    }
+                // Forward all keyboard input to active PTY using proper conversion.
+                if let Some(pty_event) = key.into() {
+                    DEBUG_TUI_PTY_MUX.then(|| {
+                        // % is Display, ? is Debug.
+                        tracing::debug! {
+                            message = "InputRouter::handle_input",
+                            status = "Forwarding input to PTY",
+                            pty_event = ?pty_event,
+                        };
+                    });
+                    process_manager.send_input(pty_event)?;
                 }
             }
             InputEvent::Resize(new_size) => {
@@ -134,34 +76,61 @@ impl InputRouter {
                 // events that will never come.
                 return Ok(Continuation::Stop);
             }
+            InputEvent::Mouse(mouse_input) => {
+                let active_buffer = process_manager.get_active_buffer();
+
+                // We use a simplified "firehose" approach. If the app requested *any*
+                // tracking protocol (1000/1002/1003), `mouse.mode` becomes `Enabled`.
+                // When enabled, we unconditionally route all events (clicks, drags,
+                // motion) back to the app using the modern SGR (1006)
+                // format, ignoring `mouse.format`.
+                match active_buffer.terminal_mode.mouse_tracking {
+                    MouseTrackingMode::Enabled => {
+                        let mouse_col: ColIndex = mouse_input.pos.col_index;
+                        let mouse_row: RowIndex = mouse_input.pos.row_index;
+
+                        let pty_height: RowHeight = active_buffer.window_size.row_height;
+                        if mouse_row.overflows(pty_height)
+                            == ArrayOverflowResult::Overflowed
+                        {
+                            return Ok(Continuation::Continue);
+                        }
+
+                        let term_col: TermCol = mouse_col.into();
+                        let term_row: TermRow = mouse_row.into();
+
+                        let sgr_bytes: Option<Vec<u8>> =
+                            crate::SgrMouseSequence::generate(
+                                &mouse_input,
+                                term_col,
+                                term_row,
+                            );
+                        if let Some(bytes) = sgr_bytes {
+                            let _unused = process_manager
+                                .send_input(crate::PtyInputEvent::Write(bytes));
+                        } else {
+                            DEBUG_TUI_PTY_MUX.then(|| {
+                                // % is Display, ? is Debug.
+                                tracing::error! {
+                                    message = "InputRouter::handle_input",
+                                    status = "Unsupported mouse event for SGR translation",
+                                    mouse_event = ?mouse_input,
+                                };
+                            });
+                        }
+                    }
+                    MouseTrackingMode::Disabled => {
+                        // Do nothing.
+                    }
+                }
+            }
             _ => {
-                // Other input events (Mouse, Focus, BracketedPaste) are
+                // Other input events (Focus, BracketedPaste) are
                 // ignored for now.
             }
         }
 
         Ok(Continuation::Continue)
-    }
-
-    /// Updates the terminal title based on the currently active process.
-    fn update_terminal_title(
-        process_manager: &ProcessManager,
-        osc: &mut OscController<'_>,
-    ) -> miette::Result<()> {
-        // Check if the active process has set a custom terminal title.
-        let title = if let Some(custom_title) = process_manager.active_terminal_title() {
-            // Use the process's custom title.
-            format!(
-                "PTYMux - {} - {}",
-                process_manager.active_name(),
-                custom_title
-            )
-        } else {
-            // Use default title with just process name.
-            format!("PTYMux - {}", process_manager.active_name())
-        };
-        osc.set_title_and_tab(&title)?;
-        ok!()
     }
 
     /// Handles terminal resize events.

--- a/tui/src/core/pty/pty_mux/mod.rs
+++ b/tui/src/core/pty/pty_mux/mod.rs
@@ -68,10 +68,6 @@
 //! }
 //! ```
 //!
-//! [`OSC`]: crate::osc_codes::OscSequence
-//! [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
-
-//!
 //! ## Underlying protocol parser
 //!
 //! - [`vt_100_pty_output_parser`]: The [`ANSI`] parser module that processes escape
@@ -93,15 +89,15 @@
 //! [`vt_100_pty_output_parser`]: mod@crate::core::ansi::vt_100_pty_output_parser
 
 // Attach.
+mod adaptive_render_budget;
 mod input_router;
 mod mux;
-mod notification;
 mod output_renderer;
 mod process_manager;
 
-// Re-export.
+// Public re-exports (flat API)
+pub use adaptive_render_budget::*;
 pub use input_router::*;
 pub use mux::*;
-pub use notification::*;
 pub use output_renderer::*;
 pub use process_manager::*;

--- a/tui/src/core/pty/pty_mux/mux.rs
+++ b/tui/src/core/pty/pty_mux/mux.rs
@@ -1,7 +1,5 @@
 // Copyright (c) 2025 R3BL LLC. Licensed under Apache License, Version 2.0.
 
-// cspell:words cooldown
-
 //! Main [`PTY`] multiplexer orchestrator.
 //!
 //! This module provides the main [`PTYMux`] struct that coordinates all components and
@@ -9,127 +7,198 @@
 //!
 //! [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
 
-use super::{InputRouter, OutputRenderer, Process, ProcessManager, output_renderer,
-            show_notification_non_blocking};
-use crate::{AnsiSequenceGenerator, Continuation, DEBUG_TUI_PTY_MUX, InputEvent, Size,
-            TerminalInteractiveStatus, TuiAvailability, col,
+use super::{InputRouter, OutputRenderer, Process, ProcessManager};
+use crate::{AnsiSequenceGenerator, Continuation, DEBUG_TUI_PTY_MUX, EventPropagation,
+            InputEvent, Size, TerminalInteractiveStatus, TuiAvailability, col,
             core::{check_is_terminal_interactive, emit_stderr_redirection_disclaimer,
                    get_size,
                    osc::OscController,
+                   pty::pty_mux::{AdaptiveRenderResult::{Render, Skip},
+                                  Budget},
                    terminal_io::{InputDevice, OutputDevice, TerminalModeController}},
-            ok, row};
+            format_no_alloc, ok,
+            pty_mux::output_renderer::MAX_PROCESSES,
+            row};
 use std::{fmt::Debug,
+          thread::sleep,
           time::{Duration, Instant}};
 use tokio::time::interval;
 
+pub const STATUS_BAR_UPDATE_INTERVAL_MS: u64 = 500;
+pub const OUTPUT_POLL_INTERVAL_MS: u64 = 10;
+
 /// Builder for configuring and creating a [`PTYMux`] instance.
-#[derive(Default, Debug)]
+///
+/// This struct follows the builder pattern to configure the initial state of the terminal
+/// multiplexer before it begins running. You can use it to set up the underlying
+/// processes to spawn, define the virtual terminal size, and attach an optional
+/// [`InputInterceptorFn`] to handle global hotkeys.
+///
+/// Once configuration is complete, call [`build()`] to construct the actual [`PTYMux`]
+/// engine.
+///
+/// # Examples
+///
+/// ```rust
+/// use r3bl_tui::pty_mux::PTYMux;
+///
+/// let builder = PTYMux::builder()
+///     .add_process("htop", "htop", vec![])
+///     .add_process("bash", "bash", vec![]);
+/// ```
+///
+/// [`build()`]: PTYMuxBuilder::build
+#[derive(Default)]
 pub struct PTYMuxBuilder {
     process_configs: Vec<(String, String, Vec<String>)>,
     terminal_size: Option<Size>,
+    maybe_input_interceptor_fn: Option<Box<InputInterceptorFn>>,
 }
 
-impl PTYMuxBuilder {
-    /// Sets the processes to be managed by the multiplexer.
-    #[must_use]
-    pub fn processes(
-        mut self,
-        processes: Vec<(impl Into<String>, impl Into<String>, Vec<String>)>,
-    ) -> Self {
-        self.process_configs = processes
-            .into_iter()
-            .map(|(n, c, a)| (n.into(), c.into(), a))
-            .collect();
-        self
+/// Type alias for the input interceptor closure.
+///
+/// This closure is executed on every [`InputEvent`] before it is routed to the currently
+/// active process. It is primarily used to define global hotkeys (e.g., for switching
+/// panes or exiting the multiplexer).
+///
+/// Because it implements [`FnMut`], it can capture and mutate variables from its
+/// surrounding environment. It also receives a mutable reference to the
+/// [`ProcessManager`], which allows it to change the active process index or inspect
+/// running processes.
+///
+/// The closure must return an [`EventPropagation`] to indicate whether the event should
+/// continue to the active process.
+///
+/// [`EventPropagation`]: crate::EventPropagation
+/// [`InputEvent`]: crate::InputEvent
+/// [`ProcessManager`]: super::ProcessManager
+pub type InputInterceptorFn =
+    dyn FnMut(&InputEvent, &mut ProcessManager) -> EventPropagation;
+
+mod impl_pty_mux_builder {
+    #[allow(clippy::wildcard_imports)]
+    use super::*;
+
+    impl Debug for PTYMuxBuilder {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("PTYMuxBuilder")
+                .field("process_configs", &self.process_configs)
+                .field("terminal_size", &self.terminal_size)
+                .field(
+                    "maybe_input_interceptor_fn",
+                    &if self.maybe_input_interceptor_fn.is_some() {
+                        "Some(...)"
+                    } else {
+                        "None"
+                    },
+                )
+                .finish()
+        }
     }
 
-    /// Adds a single process to the multiplexer.
-    #[must_use]
-    pub fn add_process(
-        mut self,
-        name: impl Into<String>,
-        command: impl Into<String>,
-        args: Vec<String>,
-    ) -> Self {
-        self.process_configs
-            .push((name.into(), command.into(), args));
-        self
-    }
-
-    /// Sets the terminal size for the multiplexer.
-    #[must_use]
-    pub fn terminal_size(mut self, size: Size) -> Self {
-        self.terminal_size = Some(size);
-        self
-    }
-
-    /// Builds the [`PTYMux`] instance.
-    ///
-    /// # Returns
-    ///
-    /// Returns a [`TuiAvailability`] containing the [`PTYMux`] instance if the
-    /// terminal is interactive.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    /// - No processes are configured
-    /// - More than [`MAX_PROCESSES`] processes are configured
-    ///
-    /// [`check_is_terminal_interactive()`]: crate::check_is_terminal_interactive
-    /// [`MAX_PROCESSES`]: output_renderer::MAX_PROCESSES
-    #[must_use]
-    pub fn build(self) -> TuiAvailability<PTYMux> {
-        if self.process_configs.is_empty() {
-            return TuiAvailability::Broken(miette::miette!(
-                "At least one process must be configured"
-            ));
+    impl PTYMuxBuilder {
+        /// Adds a single process to the multiplexer.
+        #[must_use]
+        pub fn add_process(
+            mut self,
+            name: impl Into<String>,
+            command: impl Into<String>,
+            args: Vec<String>,
+        ) -> Self {
+            self.process_configs
+                .push((name.into(), command.into(), args));
+            self
         }
 
-        if self.process_configs.len() > output_renderer::MAX_PROCESSES {
-            return TuiAvailability::Broken(miette::miette!(
-                "Maximum of {} processes allowed",
-                output_renderer::MAX_PROCESSES
-            ));
+        /// Sets the terminal size for the multiplexer.
+        #[must_use]
+        pub fn terminal_size(mut self, size: Size) -> Self {
+            self.terminal_size = Some(size);
+            self
         }
 
-        match check_is_terminal_interactive() {
-            TerminalInteractiveStatus::NotAvailable(reason) => {
-                TuiAvailability::NotAvailable(reason)
+        /// Sets the input interceptor for handling custom global shortcuts.
+        #[must_use]
+        pub fn input_interceptor_fn(
+            mut self,
+            interceptor: Box<InputInterceptorFn>,
+        ) -> Self {
+            self.maybe_input_interceptor_fn = Some(interceptor);
+            self
+        }
+
+        /// Builds the [`PTYMux`] instance.
+        ///
+        /// # Returns
+        ///
+        /// Returns a [`TuiAvailability`] containing the [`PTYMux`] instance if the
+        /// terminal is interactive.
+        ///
+        /// # Errors
+        ///
+        /// Returns an error if:
+        /// - No processes are configured
+        /// - More than [`MAX_PROCESSES`] processes are configured
+        ///
+        /// [`check_is_terminal_interactive()`]: crate::check_is_terminal_interactive
+        /// [`MAX_PROCESSES`]: super::MAX_PROCESSES
+        #[must_use]
+        pub fn build(self) -> TuiAvailability<PTYMux> {
+            if self.process_configs.is_empty() {
+                return TuiAvailability::Broken(miette::miette!(
+                    "At least one process must be configured"
+                ));
             }
 
-            TerminalInteractiveStatus::Available => {
-                let init = || -> miette::Result<PTYMux> {
-                    let terminal_size = match self.terminal_size {
-                        Some(size) => size,
-                        None => get_size()?,
-                    };
+            if self.process_configs.len() > MAX_PROCESSES {
+                return TuiAvailability::Broken(miette::miette!(
+                    "Maximum of {} processes allowed",
+                    MAX_PROCESSES
+                ));
+            }
 
-                    let processes = self
-                        .process_configs
-                        .into_iter()
-                        .map(|(name, command, args)| {
-                            Process::new(name, command, args, terminal_size)
+            match check_is_terminal_interactive() {
+                TerminalInteractiveStatus::NotAvailable(reason) => {
+                    TuiAvailability::NotAvailable(reason)
+                }
+
+                TerminalInteractiveStatus::Available => {
+                    let init = || -> miette::Result<PTYMux> {
+                        let terminal_size = match self.terminal_size {
+                            Some(size) => size,
+                            None => get_size()?,
+                        };
+
+                        let processes = self
+                            .process_configs
+                            .into_iter()
+                            .map(|(name, command, args)| {
+                                Process::new(name, command, args, terminal_size)
+                            })
+                            .collect();
+
+                        emit_stderr_redirection_disclaimer();
+
+                        let output_device = OutputDevice::new_stdout();
+                        let input_device = InputDevice::default();
+
+                        Ok(PTYMux {
+                            process_manager: ProcessManager::new(
+                                processes,
+                                terminal_size,
+                            ),
+                            input_router: InputRouter::new(),
+                            output_renderer: OutputRenderer::new(terminal_size),
+                            terminal_size,
+                            output_device,
+                            input_device,
+                            maybe_input_interceptor_fn: self.maybe_input_interceptor_fn,
                         })
-                        .collect();
-
-                    emit_stderr_redirection_disclaimer();
-
-                    let output_device = OutputDevice::new_stdout();
-                    let input_device = InputDevice::default();
-
-                    Ok(PTYMux {
-                        process_manager: ProcessManager::new(processes, terminal_size),
-                        input_router: InputRouter::new(),
-                        output_renderer: OutputRenderer::new(terminal_size),
-                        terminal_size,
-                        output_device,
-                        input_device,
-                    })
-                };
-                match init() {
-                    Ok(mux) => TuiAvailability::Available(mux),
-                    Err(e) => TuiAvailability::Broken(e),
+                    };
+                    match init() {
+                        Ok(mux) => TuiAvailability::Available(mux),
+                        Err(e) => TuiAvailability::Broken(e),
+                    }
                 }
             }
         }
@@ -146,605 +215,501 @@ pub struct PTYMux {
     terminal_size: Size,
     output_device: OutputDevice,
     input_device: InputDevice,
+    maybe_input_interceptor_fn: Option<Box<InputInterceptorFn>>,
 }
 
-impl Debug for PTYMux {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("PTYMux")
-            .field("process_manager", &self.process_manager)
-            .field("input_router", &self.input_router)
-            .field("output_renderer", &self.output_renderer)
-            .field("terminal_size", &self.terminal_size)
-            .field("output_device", &"<OutputDevice>")
-            .field("input_device", &"<InputDevice>")
-            .finish()
+mod impl_pty_mux {
+    #[allow(clippy::wildcard_imports)]
+    use super::*;
+
+    impl Debug for PTYMux {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("PTYMux")
+                .field("process_manager", &self.process_manager)
+                .field("input_router", &self.input_router)
+                .field("output_renderer", &self.output_renderer)
+                .field("terminal_size", &self.terminal_size)
+                .field("output_device", &"<OutputDevice>")
+                .field("input_device", &"<InputDevice>")
+                .field(
+                    "input_interceptor",
+                    &if self.maybe_input_interceptor_fn.is_some() {
+                        "Some(...)"
+                    } else {
+                        "None"
+                    },
+                )
+                .finish()
+        }
     }
-}
 
-impl PTYMux {
-    /// Creates a new builder for configuring a [`PTYMux`] instance.
-    #[must_use]
-    pub fn builder() -> PTYMuxBuilder { PTYMuxBuilder::default() }
+    impl PTYMux {
+        /// Creates a new builder for configuring a [`PTYMux`] instance.
+        #[must_use]
+        pub fn builder() -> PTYMuxBuilder { PTYMuxBuilder::default() }
 
-    /// Runs the multiplexer event loop.
-    ///
-    /// This is the main entry point that:
-    /// 1. Starts raw mode
-    /// 2. Sets initial terminal title
-    /// 3. Runs the main event loop
-    /// 4. Cleans up on exit
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    /// - Terminal title ([`OSC`]) setup fails
-    /// - Process spawning fails
-    /// - Status bar rendering fails
-    /// - Input or output event handling fails during the main loop
-    ///
-    /// # Note on [`stderr`] redirection
-    ///
-    /// This function calls [`emit_stderr_redirection_disclaimer()`] to ensure that if
-    /// [`stderr`] is redirected, the user is notified that application logs are handled
-    /// internally.
-    ///
-    /// # Other entry points for interactive terminal apps
-    ///
-    /// See [interactive terminal application entry points].
-    ///
-    /// [`emit_stderr_redirection_disclaimer()`]: crate::emit_stderr_redirection_disclaimer
-    /// [`OSC`]: crate::OscEvent
-    /// [`stderr`]: std::io::stderr
-    /// [interactive terminal application entry points]: crate#interactive-terminal-application-entry-points
-    pub async fn run(mut self) -> miette::Result<()> {
-        // Start raw mode.
-        let _raw_mode_guard = self.output_device.enter_raw_mode()?;
-        let _fullscreen_tui_mode_guard = self.output_device.setup_full_screen_tui()?;
+        /// Runs the multiplexer event loop.
+        ///
+        /// This is the main entry point that:
+        /// 1. Starts raw mode
+        /// 2. Sets initial terminal title
+        /// 3. Runs the main event loop
+        /// 4. Cleans up on exit
+        ///
+        /// # Errors
+        ///
+        /// Returns an error if:
+        /// - Terminal title ([`OSC`]) setup fails
+        /// - Process spawning fails
+        /// - Status bar rendering fails
+        /// - Input or output event handling fails during the main loop
+        ///
+        /// # Note on [`stderr`] redirection
+        ///
+        /// This function calls [`emit_stderr_redirection_disclaimer()`] to ensure that if
+        /// [`stderr`] is redirected, the user is notified that application logs are
+        /// handled internally.
+        ///
+        /// # Other entry points for interactive terminal apps
+        ///
+        /// See [interactive terminal application entry points].
+        ///
+        /// [`emit_stderr_redirection_disclaimer()`]: crate::emit_stderr_redirection_disclaimer
+        /// [`OSC`]: crate::OscEvent
+        /// [`stderr`]: std::io::stderr
+        /// [interactive terminal application entry points]: crate#interactive-terminal-application-entry-points
+        pub async fn run(mut self) -> miette::Result<()> {
+            // Start raw mode.
+            let _raw_mode_guard = self.output_device.enter_raw_mode()?;
+            let _fullscreen_tui_mode_guard =
+                self.output_device.setup_full_screen_tui()?;
 
-        DEBUG_TUI_PTY_MUX.then(|| {
+            DEBUG_TUI_PTY_MUX.then(|| {
+                // % is Display, ? is Debug.
+                tracing::debug! {
+                    message = "PTYMux::run",
+                    info = "Raw mode started"
+                };
+            });
+
+            // Set initial terminal title using OSC controller.
+            {
+                let mut osc = OscController::new(&self.output_device);
+                osc.set_title_and_tab("PTYMux Example - Starting")?;
+            }
+
+            // Start all processes at startup.
+            DEBUG_TUI_PTY_MUX.then(|| {
+                // % is Display, ? is Debug.
+                tracing::debug! {
+                    message = "PTYMux::run",
+                    info = "Starting all processes"
+                };
+            });
+            self.process_manager.start_all_processes()?;
+
+            // Clear screen before showing first process.
+            self.output_device.write(|out| {
+                let _unused =
+                    out.write_all(AnsiSequenceGenerator::clear_screen().as_bytes());
+                let _unused = out.write_all(
+                    AnsiSequenceGenerator::cursor_position(row(0), col(0)).as_bytes(),
+                );
+                let _unused = out.flush();
+            });
+
+            // Trigger initial process switch to show first process.
+            self.process_manager.switch_to(0);
+
+            // Render initial status bar.
+            self.output_renderer
+                .render_initial_status_bar(&self.output_device, &self.process_manager)?;
+
+            // Main event loop
+            DEBUG_TUI_PTY_MUX.then(|| {
+                // % is Display, ? is Debug.
+                tracing::debug! {
+                    message = "PTYMux::run",
+                    info = "Starting main event loop"
+                };
+            });
+            let result = self.run_event_loop().await;
+            DEBUG_TUI_PTY_MUX.then(|| {
             // % is Display, ? is Debug.
             tracing::debug! {
                 message = "PTYMux::run",
-                info = %crate::inline_string!("Raw mode started")
+                info = %format!("Main event loop exited with result: {result:?}")
             };
         });
 
-        // Set initial terminal title using OSC controller.
-        {
-            let mut osc = OscController::new(&self.output_device);
-            osc.set_title_and_tab("PTYMux Example - Starting")?;
+            // Always cleanup regardless of error.
+            self.cleanup_terminal();
+
+            // `_fullscreen_tui_mode_guard` and `_raw_mode_guard` are dropped here,
+            // which securely restores the terminal to its original state.
+            result
         }
 
-        // Start all processes at startup.
-        DEBUG_TUI_PTY_MUX.then(|| {
-            // % is Display, ? is Debug.
-            tracing::debug! {
-                message = "PTYMux::run",
-                info = %crate::inline_string!("Starting all processes")
-            };
-        });
-        self.process_manager.start_all_processes()?;
+        /// Main event loop that handles input and output events.
+        async fn run_event_loop(&mut self) -> miette::Result<()> {
+            // Create a periodic timer for status bar updates.
+            let mut status_bar_interval =
+                interval(Duration::from_millis(STATUS_BAR_UPDATE_INTERVAL_MS));
 
-        // Clear screen before showing first process.
-        self.output_device.write(|out| {
-            let _unused = out.write_all(AnsiSequenceGenerator::clear_screen().as_bytes());
-            let _unused = out.write_all(
-                AnsiSequenceGenerator::cursor_position(row(0), col(0)).as_bytes(),
-            );
-            let _unused = out.flush();
-        });
+            // Create a fast timer for polling PTY output.
+            let mut output_poll_interval =
+                interval(Duration::from_millis(OUTPUT_POLL_INTERVAL_MS));
 
-        // Trigger initial process switch to show first process.
-        self.process_manager.switch_to(0);
+            let mut render_budget = Budget::default();
 
-        // Render initial status bar.
-        self.output_renderer
-            .render_initial_status_bar(&self.output_device, &self.process_manager)?;
+            // Reusable String to avoid allocating a new one for the title on every tick.
+            let mut title_buffer =
+                String::with_capacity(self.terminal_size.col_width.as_usize());
 
-        // Main event loop
-        DEBUG_TUI_PTY_MUX.then(|| {
-            // % is Display, ? is Debug.
-            tracing::debug! {
-                message = "PTYMux::run",
-                info = %crate::inline_string!("Starting main event loop")
-            };
-        });
-        let result = self.run_event_loop().await;
-        DEBUG_TUI_PTY_MUX.then(|| {
-            // % is Display, ? is Debug.
-            tracing::debug! {
-                message = "PTYMux::run",
-                info = %crate::inline_string!("Main event loop exited with result: {:?}", result)
-            };
-        });
+            loop {
+                tokio::select! {
+                    // Poll ALL processes and update their virtual terminal buffers.
+                    // https://developerlife.com/2024/07/10/rust-async-cancellation-safety-tokio/#example-1-right-and-wrong-way-to-sleep-and-interval
+                    _ = output_poll_interval.tick() => {
+                        match render_budget.should_render(&mut self.process_manager) {
+                            Render => {
+                                render_budget.mark_start();
+                                // Get the active process's virtual terminal and render it.
+                                self.output_renderer.render_from_active_buffer(
+                                    &self.output_device,
+                                    &self.process_manager
+                                )?;
+                                // Clear the "needs rendering" flag for the active process.
+                                self.process_manager.mark_active_as_rendered();
+                                render_budget.mark_end();
+                            },
+                            Skip => {
+                                DEBUG_TUI_PTY_MUX.then(|| {
+                                    // % is Display, ? is Debug.
+                                    tracing::info! {
+                                        message = "Skipping render, backpressure detected in stdout",
+                                        info = %format!(
+                                            "Current frame delay: {:?}",
+                                            render_budget.render_cooldown_delay
+                                        )
+                                    };
+                                });
+                            },
 
-        // Always cleanup regardless of error.
-        self.cleanup_terminal();
-
-        // `_fullscreen_tui_mode_guard` and `_raw_mode_guard` are dropped here,
-        // which securely restores the terminal to its original state.
-        result
-    }
-
-    /// Main event loop that handles input and output events.
-    async fn run_event_loop(&mut self) -> miette::Result<()> {
-        use adaptive_render_budget::{AdaptiveRenderResult::{Render, Skip},
-                                     Budget};
-
-        // Create a periodic timer for status bar updates.
-        let mut status_bar_interval = interval(Duration::from_millis(500));
-
-        // Create a fast timer for polling PTY output.
-        let mut output_poll_interval = interval(Duration::from_millis(10));
-
-        let mut render_budget = Budget::default();
-
-        loop {
-            tokio::select! {
-                // Poll ALL processes and update their virtual terminal buffers.
-                // https://developerlife.com/2024/07/10/rust-async-cancellation-safety-tokio/#example-1-right-and-wrong-way-to-sleep-and-interval
-                _ = output_poll_interval.tick() => {
-                    match render_budget.should_render(&mut self.process_manager) {
-                        Render => {
-                            render_budget.mark_start();
-                            // Get the active process's virtual terminal and render it.
-                            self.output_renderer.render_from_active_buffer(
-                                &self.output_device,
-                                &self.process_manager
-                            )?;
-                            // Clear the "needs rendering" flag for the active process.
-                            self.process_manager.mark_active_as_rendered();
-                            render_budget.mark_end();
-                        },
-                        Skip => {
-                            DEBUG_TUI_PTY_MUX.then(|| {
-                                // % is Display, ? is Debug.
-                                tracing::info! {
-                                    message = "Skipping render, backpressure detected in stdout",
-                                    info = %crate::inline_string!("Current frame delay: {:?}", render_budget.render_cooldown_delay)
-                                };
-                            });
-                        },
-
-                    }
-                }
-
-                // Handle user input using existing InputDevice.
-                Some(input_event) = self.input_device.next() => {
-                    crate::DEBUG_TUI_PTY_MUX.then(|| {
-                        // % is Display, ? is Debug.
-                        tracing::debug! {
-                            message = "PTYMux::run_event_loop",
-                            info = %crate::inline_string!("Received input event: {:?}", input_event)
-                        };
-                    });
-
-                    // Show desktop notification for input event (filter out mouse events)
-                    if !matches!(input_event, InputEvent::Mouse(_)) {
-                        show_notification_non_blocking("PTY Mux - Input Event", &format!("Input event received: {input_event:?}"));
+                        }
                     }
 
-                    // Create OSC controller for this input handling.
-                    let mut osc = OscController::new(&self.output_device);
-
-                    // Handle input events using the input router.
-                    crate::DEBUG_TUI_PTY_MUX.then(|| {
-                        // % is Display, ? is Debug.
-                        tracing::debug! {
-                            message = "PTYMux::run_event_loop",
-                            info = %crate::inline_string!("Handling input event: {:?}", input_event)
-                        };
-                    });
-                    let continuation = self.input_router.handle_input(
-                        input_event,
-                        &mut self.process_manager,
-                        &mut osc,
-                        &self.output_device
-                    )?;
-
-                    if continuation == Continuation::Stop {
-                        crate::DEBUG_TUI_PTY_MUX.then(|| {
+                    // Handle user input using existing InputDevice.
+                    Some(input_event) = self.input_device.next() => {
+                        DEBUG_TUI_PTY_MUX.then(|| {
                             // % is Display, ? is Debug.
                             tracing::debug! {
                                 message = "PTYMux::run_event_loop",
-                                info = %crate::inline_string!("Exit requested by input router - breaking main event loop")
+                                info = %format!(
+                                    "Received input event: {:?}",
+                                    input_event
+                                )
                             };
                         });
-                        break;
+
+                        if let Some(interceptor) = &mut self.maybe_input_interceptor_fn {
+                            match interceptor(&input_event, &mut self.process_manager) {
+                                EventPropagation::Propagate => {}
+                                EventPropagation::Consumed | EventPropagation::ConsumedRender => continue,
+                                EventPropagation::ExitMainEventLoop => break,
+                            }
+                        }
+
+                        // Create OSC controller for this input handling.
+
+                        // Handle input events using the input router.
+                        DEBUG_TUI_PTY_MUX.then(|| {
+                            // % is Display, ? is Debug.
+                            tracing::debug! {
+                                message = "PTYMux::run_event_loop",
+                                info = %format!(
+                                    "Handling input event: {:?}",
+                                    input_event
+                                )
+                            };
+                        });
+                        let continuation = self.input_router.handle_input(
+                            input_event,
+                            &mut self.process_manager,
+                        )?;
+
+                        if continuation == Continuation::Stop {
+                            DEBUG_TUI_PTY_MUX.then(|| {
+                                // % is Display, ? is Debug.
+                                tracing::debug! {
+                                    message = "PTYMux::run_event_loop",
+                                    info = "Exit requested by input router - breaking main event loop"
+                                };
+                            });
+                            break;
+                        }
+                    }
+
+                    // Periodic status bar updates - ensures status bar is visible even when idle.
+                    _ = status_bar_interval.tick() => {
+                        self.output_renderer.render_initial_status_bar(&self.output_device, &self.process_manager)?;
+                        let mut osc = OscController::new(&self.output_device);
+                        self.update_terminal_title(&mut osc, &mut title_buffer)?;
                     }
                 }
-
-                // Periodic status bar updates - ensures status bar is visible even when idle.
-                _ = status_bar_interval.tick() => {
-                    self.output_renderer.render_initial_status_bar(&self.output_device, &self.process_manager)?;
-                }
             }
-        }
 
-        DEBUG_TUI_PTY_MUX.then(|| {
-            // % is Display, ? is Debug.
-            tracing::debug! {
-                message = "PTYMux::run_event_loop",
-                info = %crate::inline_string!("Event loop completed - returning Ok(())")
-            };
-        });
-
-        ok!()
-    }
-
-    /// Updates terminal size for all components.
-    ///
-    /// This method is called when the terminal is resized and ensures all components are
-    /// aware of the new size.
-    pub fn update_terminal_size(&mut self, new_size: Size) {
-        self.terminal_size = new_size;
-        self.process_manager.handle_terminal_resize(new_size);
-        self.output_renderer.update_terminal_size(new_size);
-    }
-
-    /// Gets the current terminal size.
-    #[must_use]
-    pub fn terminal_size(&self) -> Size { self.terminal_size }
-
-    /// Gets a reference to the process manager.
-    #[must_use]
-    pub fn process_manager(&self) -> &ProcessManager { &self.process_manager }
-
-    /// Gets a mutable reference to the process manager.
-    pub fn process_manager_mut(&mut self) -> &mut ProcessManager {
-        &mut self.process_manager
-    }
-
-    /// Cleanup terminal state - always called on exit.
-    #[allow(clippy::too_many_lines)]
-    fn cleanup_terminal(&mut self) {
-        let start_time = std::time::Instant::now();
-        DEBUG_TUI_PTY_MUX.then(|| {
-            // % is Display, ? is Debug.
-            tracing::debug! {
-                message = "PTYMux::cleanup_terminal",
-                info = %crate::inline_string!("Starting cleanup - terminal size: {:?}", self.terminal_size)
-            };
-        });
-
-        // First, kill all running processes.
-        DEBUG_TUI_PTY_MUX.then(|| {
-            // % is Display, ? is Debug.
-            tracing::debug! {
-                message = "PTYMux::cleanup_terminal",
-                info = %crate::inline_string!("Step 1: Shutting down process manager")
-            };
-        });
-        self.process_manager.shutdown_all_processes();
-        DEBUG_TUI_PTY_MUX.then(|| {
-            // % is Display, ? is Debug.
-            tracing::debug! {
-                message = "PTYMux::cleanup_terminal",
-                info = %crate::inline_string!("Step 1 completed in {:?}", start_time.elapsed())
-            };
-        });
-
-        // Give processes a short time to terminate gracefully, then force exit.
-        DEBUG_TUI_PTY_MUX.then(|| {
-            // % is Display, ? is Debug.
-            tracing::debug! {
-                message = "PTYMux::cleanup_terminal",
-                info = %crate::inline_string!("Step 2: Waiting 100ms for processes to terminate gracefully")
-            };
-        });
-        std::thread::sleep(std::time::Duration::from_millis(100));
-        DEBUG_TUI_PTY_MUX.then(|| {
-            // % is Display, ? is Debug.
-            tracing::debug! {
-                message = "PTYMux::cleanup_terminal",
-                info = %crate::inline_string!("Step 2 completed in {:?}", start_time.elapsed())
-            };
-        });
-
-        // Force flush any pending output.
-        DEBUG_TUI_PTY_MUX.then(|| {
-            // % is Display, ? is Debug.
-            tracing::debug! {
-                message = "PTYMux::cleanup_terminal",
-                info = %crate::inline_string!("Step 3: Flushing pending output")
-            };
-        });
-        self.output_device.write(|out| match out.flush() {
-            Ok(()) => {
-                crate::DEBUG_TUI_PTY_MUX.then(|| {
-                    // % is Display, ? is Debug.
-                    tracing::debug! {
-                        message = "PTYMux::cleanup_terminal",
-                        info = "Step 3: Output flush successful"
-                    };
-                });
-            }
-            Err(e) => {
-                crate::DEBUG_TUI_PTY_MUX.then(|| {
-                    // % is Display, ? is Debug.
-                    tracing::warn! {
-                        message = "PTYMux::cleanup_terminal",
-                        info = %crate::inline_string!("Step 3: Output flush failed: {:?}", e)
-                    };
-                });
-            }
-        });
-        DEBUG_TUI_PTY_MUX.then(|| {
-            // % is Display, ? is Debug.
-            tracing::debug! {
-                message = "PTYMux::cleanup_terminal",
-                info = %crate::inline_string!("Step 3 completed in {:?}", start_time.elapsed())
-            };
-        });
-
-        // Clear screen
-        DEBUG_TUI_PTY_MUX.then(|| {
-            // % is Display, ? is Debug.
-            tracing::debug! {
-                message = "PTYMux::cleanup_terminal",
-                info = %crate::inline_string!("Step 4: Clearing screen and homing cursor")
-            };
-        });
-        self.output_device.write(|out| {
-            let _unused = out.write_all(AnsiSequenceGenerator::clear_screen().as_bytes());
-            let _unused = out.write_all(
-                AnsiSequenceGenerator::cursor_position(row(0), col(0)).as_bytes(),
-            );
-            let _unused = out.flush();
-        });
-        DEBUG_TUI_PTY_MUX.then(|| {
-            // % is Display, ? is Debug.
-            tracing::debug! {
-                message = "PTYMux::cleanup_terminal",
-                info = %crate::inline_string!("Step 4 completed in {:?}", start_time.elapsed())
-            };
-        });
-
-        // Force flush after escape sequences.
-        DEBUG_TUI_PTY_MUX.then(|| {
-            // % is Display, ? is Debug.
-            tracing::debug! {
-                message = "PTYMux::cleanup_terminal",
-                info = %crate::inline_string!("Step 5: Final output flush after escape sequences")
-            };
-        });
-        self.output_device.write(|out| match out.flush() {
-            Ok(()) => {
-                crate::DEBUG_TUI_PTY_MUX.then(|| {
-                    // % is Display, ? is Debug.
-                    tracing::debug! {
-                        message = "PTYMux::cleanup_terminal",
-                        info = "Step 5: Final flush successful"
-                    };
-                });
-            }
-            Err(e) => {
-                crate::DEBUG_TUI_PTY_MUX.then(|| {
-                    // % is Display, ? is Debug.
-                    tracing::warn! {
-                        message = "PTYMux::cleanup_terminal",
-                        info = %crate::inline_string!("Step 5: Final flush failed: {:?}", e)
-                    };
-                });
-            }
-        });
-        DEBUG_TUI_PTY_MUX.then(|| {
-            // % is Display, ? is Debug.
-            tracing::debug! {
-                message = "PTYMux::cleanup_terminal",
-                info = %crate::inline_string!("Step 5 completed in {:?}", start_time.elapsed())
-            };
-        });
-
-        // End raw mode
-        DEBUG_TUI_PTY_MUX.then(|| {
-            // % is Display, ? is Debug.
-            tracing::debug! {
-                message = "PTYMux::cleanup_terminal",
-                info = %crate::inline_string!("Step 6: Ending raw mode")
-            };
-        });
-        self.output_device.teardown_full_screen_tui().ok();
-        DEBUG_TUI_PTY_MUX.then(|| {
-            // % is Display, ? is Debug.
-            tracing::debug! {
-                message = "PTYMux::cleanup_terminal",
-                info = %crate::inline_string!("Step 6: Raw mode ended successfully")
-            };
-        });
-
-        let total_time = start_time.elapsed();
-        DEBUG_TUI_PTY_MUX.then(|| {
-            // % is Display, ? is Debug.
-            tracing::debug! {
-                message = "PTYMux::cleanup_terminal",
-                info = %crate::inline_string!("Cleanup completed successfully in {:?}", total_time)
-            };
-        });
-
-        if total_time > std::time::Duration::from_millis(500) {
             DEBUG_TUI_PTY_MUX.then(|| {
                 // % is Display, ? is Debug.
-                tracing::warn! {
-                    message = "PTYMux::cleanup_terminal",
-                    info = %crate::inline_string!("Cleanup took longer than expected: {:?}", total_time)
+                tracing::debug! {
+                    message = "PTYMux::run_event_loop",
+                    info = "Event loop completed - returning Ok(())"
                 };
             });
+
+            ok!()
         }
 
-        // If cleanup took too long, there might be zombie processes.
-        if total_time > std::time::Duration::from_secs(1) {
-            DEBUG_TUI_PTY_MUX.then(|| {
-                // % is Display, ? is Debug.
-                tracing::error! {
-                    message = "PTYMux::cleanup_terminal",
-                    info = %crate::inline_string!("Cleanup took over 1 second; check for potential zombie processes")
-                };
-            });
-        }
-    }
-}
-
-pub mod adaptive_render_budget {
-    #[allow(clippy::wildcard_imports)]
-    use super::*;
-    use crate::DEBUG_TUI_PTY_MUX;
-
-    /// Default render speed is ~60 FPS.
-    pub const DEFAULT_FRAME_DELAY_MS: Duration = Duration::from_millis(16);
-
-    /// Slowest render speed is ~10 FPS.
-    pub const MAX_FRAME_DELAY_MS: Duration = Duration::from_millis(100);
-
-    /// Min FPS is uncapped. If the terminal is fast enough, there is no throttling and it
-    /// will render as fast as possible.
-    pub const MIN_FRAME_DELAY_MS: Duration = Duration::from_millis(0);
-
-    /// Flush taking >5ms indicates pressure.
-    pub const RENDER_TIME_BACKPRESSURE_THRESHOLD_MS: Duration =
-        Duration::from_millis(RENDER_TIME_BASE * 5);
-
-    // Asymmetric backoff - penalty is 5 x higher than reward. If we detect backpressure,
-    // we backoff and hit the brakes hard.
-    pub const THROTTLE_PENALTY_MS: Duration =
-        Duration::from_millis(RENDER_TIME_BASE * 10);
-
-    // Asymmetric backoff - reward is 5 x lower than reward. If we detect flushing is
-    // getting faster, we are easy into the recovery, by getting back on the gas
-    // gradually.
-    pub const RECOVERY_REWARD_MS: Duration = Duration::from_millis(RENDER_TIME_BASE);
-
-    const RENDER_TIME_BASE: u64 = 1;
-
-    #[derive(Debug)]
-    pub enum AdaptiveRenderResult {
-        Skip,
-        Render,
-    }
-
-    #[derive(Debug)]
-    pub struct Budget {
-        pub last_render_time: Instant,
-        pub render_cooldown_delay: Duration,
-        pub maybe_render_start: Option<Instant>,
-    }
-
-    impl Default for Budget {
-        fn default() -> Self {
-            Self {
-                last_render_time: Instant::now(),
-                render_cooldown_delay: DEFAULT_FRAME_DELAY_MS,
-                maybe_render_start: None,
-            }
-        }
-    }
-
-    impl Budget {
-        /// Decides if we should render this frame based on output and budget.
-        pub fn should_render(
+        /// Updates the terminal title based on the currently active process.
+        fn update_terminal_title(
             &self,
-            process_manager: &mut ProcessManager,
-        ) -> AdaptiveRenderResult {
-            let process_had_output = process_manager.poll_all_processes();
-            if !process_had_output {
-                return AdaptiveRenderResult::Skip;
-            }
-            let time_since_last_render = self.last_render_time.elapsed();
-            if time_since_last_render >= self.render_cooldown_delay {
-                AdaptiveRenderResult::Render
+            osc: &mut OscController<'_>,
+            title_buffer: &mut String,
+        ) -> miette::Result<()> {
+            // Check if the active process has set a custom terminal title.
+            if let Some(custom_title) = self.process_manager.active_terminal_title() {
+                // Use the process's custom title.
+                format_no_alloc!(
+                    title_buffer,
+                    "PTYMux - {} - {}",
+                    self.process_manager.active_name(),
+                    custom_title
+                );
             } else {
-                AdaptiveRenderResult::Skip
+                // Use default title with just process name.
+                format_no_alloc!(
+                    title_buffer,
+                    "PTYMux - {}",
+                    self.process_manager.active_name()
+                );
             }
+
+            osc.set_title_and_tab(title_buffer)?;
+            ok!()
         }
 
-        /// Marks the start of a rendering pass. This timestamp is used to measure how
-        /// long the rendering operation takes, which informs the adaptive budget
-        /// calculation.
+        /// Updates terminal size for all components.
         ///
-        /// # Panics
-        ///
-        /// Panics if called twice without an intervening [`mark_end()`] call, enforcing
-        /// the strict [`mark_start()`] -> render -> [`mark_end()`] state machine.
-        ///
-        /// [`mark_end()`]: Self::mark_end
-        /// [`mark_start()`]: Self::mark_start
-        pub fn mark_start(&mut self) {
-            assert!(
-                self.maybe_render_start.is_none(),
-                "Can't call mark_start() more than once"
-            );
-            self.maybe_render_start = Some(Instant::now());
+        /// This method is called when the terminal is resized and ensures all components
+        /// are aware of the new size.
+        pub fn update_terminal_size(&mut self, new_size: Size) {
+            self.terminal_size = new_size;
+            self.process_manager.handle_terminal_resize(new_size);
+            self.output_renderer.update_terminal_size(new_size);
         }
 
-        /// Updates the budget based on how long the render actually took.
-        ///
-        /// # Panics
-        ///
-        /// Panics if called without a preceding [`mark_start()`] call, enforcing the
-        /// strict [`mark_start()`] -> render -> [`mark_end()`] state machine.
-        ///
-        /// [`mark_end()`]: Self::mark_end
-        /// [`mark_start()`]: Self::mark_start
-        pub fn mark_end(&mut self) {
-            // Mark the end of the render pass. This is how long a render pass took.
-            let render_duration = self
-                .maybe_render_start
-                .take()
-                .expect("Can't call mark_end() without calling mark_start() first")
-                .elapsed();
+        /// Gets the current terminal size.
+        #[must_use]
+        pub fn terminal_size(&self) -> Size { self.terminal_size }
 
-            // Mark the current time as the last render time. This will be used in the
-            // should_render() method.
-            self.last_render_time = Instant::now();
+        /// Gets a reference to the process manager.
+        #[must_use]
+        pub fn process_manager(&self) -> &ProcessManager { &self.process_manager }
 
-            // Adjust budget dynamically based on detected back pressure. We are
-            // implementing asymmetric backoff.
-            let backpressure_detected =
-                render_duration > RENDER_TIME_BACKPRESSURE_THRESHOLD_MS;
-            if backpressure_detected {
-                // Penalize render budget for backpressure.
-                self.render_cooldown_delay = self
-                    .render_cooldown_delay
-                    .saturating_add(THROTTLE_PENALTY_MS)
-                    .min(MAX_FRAME_DELAY_MS);
+        /// Gets a mutable reference to the process manager.
+        pub fn process_manager_mut(&mut self) -> &mut ProcessManager {
+            &mut self.process_manager
+        }
 
-                DEBUG_TUI_PTY_MUX.then(|| {
-                    // % is Display, ? is Debug.
-                    tracing::info! {
-                        message = "Budget::mark_end",
-                        info = %crate::inline_string!(
-                            "Render took {:?} (> {:?}). Throttling frame delay to {:?}",
-                            render_duration,
-                            RENDER_TIME_BACKPRESSURE_THRESHOLD_MS,
-                            self.render_cooldown_delay
-                        )
-                    };
-                });
-            } else {
-                // Used for logging.
-                let old_delay = self.render_cooldown_delay;
+        /// Cleanup terminal state - always called on exit.
+        #[allow(clippy::too_many_lines)]
+        fn cleanup_terminal(&mut self) {
+            let start_time = Instant::now();
+            DEBUG_TUI_PTY_MUX.then(|| {
+                // % is Display, ? is Debug.
+                tracing::debug! {
+                    message = "PTYMux::cleanup_terminal",
+                    info = %format!(
+                        "Starting cleanup - terminal size: {:?}",
+                        self.terminal_size)
+                };
+            });
 
-                // Reward render budget for smooth rendering.
-                self.render_cooldown_delay = self
-                    .render_cooldown_delay
-                    .saturating_sub(RECOVERY_REWARD_MS)
-                    .max(MIN_FRAME_DELAY_MS);
+            // First, kill all running processes.
+            DEBUG_TUI_PTY_MUX.then(|| {
+                // % is Display, ? is Debug.
+                tracing::debug! {
+                    message = "PTYMux::cleanup_terminal",
+                    info = "Step 1: Shutting down process manager"
+                };
+            });
+            self.process_manager.shutdown_all_processes();
+            DEBUG_TUI_PTY_MUX.then(|| {
+                // % is Display, ? is Debug.
+                tracing::debug! {
+                    message = "PTYMux::cleanup_terminal",
+                    info = %format!("Step 1 completed in {:?}", start_time.elapsed())
+                };
+            });
 
-                // Only log recovery if the delay actually changed to avoid spamming
-                // the logs
-                if old_delay != self.render_cooldown_delay {
+            // Give processes a short time to terminate gracefully, then force exit.
+            DEBUG_TUI_PTY_MUX.then(|| {
+                // % is Display, ? is Debug.
+                tracing::debug! {
+                    message = "PTYMux::cleanup_terminal",
+                    info = "Step 2: Waiting 100ms for processes to terminate gracefully"
+                };
+            });
+            sleep(Duration::from_millis(100));
+            DEBUG_TUI_PTY_MUX.then(|| {
+            // % is Display, ? is Debug.
+            tracing::debug! {
+                message = "PTYMux::cleanup_terminal",
+                info = %format!("Step 2 completed in {:?}", start_time.elapsed())
+            };
+        });
+
+            // Force flush any pending output.
+            DEBUG_TUI_PTY_MUX.then(|| {
+                // % is Display, ? is Debug.
+                tracing::debug! {
+                    message = "PTYMux::cleanup_terminal",
+                    info = "Step 3: Flushing pending output"
+                };
+            });
+            self.output_device.write(|out| match out.flush() {
+                Ok(()) => {
                     DEBUG_TUI_PTY_MUX.then(|| {
                         // % is Display, ? is Debug.
-                        tracing::info! {
-                            message = "Budget::mark_end",
-                            info = %crate::inline_string!(
-                                "Render took {:?}. Recovering frame delay to {:?}",
-                                render_duration,
-                                self.render_cooldown_delay
-                            )
+                        tracing::debug! {
+                            message = "PTYMux::cleanup_terminal",
+                            info = "Step 3: Output flush successful"
                         };
                     });
                 }
+                Err(e) => {
+                    DEBUG_TUI_PTY_MUX.then(|| {
+                        // % is Display, ? is Debug.
+                        tracing::warn! {
+                            message = "PTYMux::cleanup_terminal",
+                            info = %format!("Step 3: Output flush failed: {:?}", e)
+                        };
+                    });
+                }
+            });
+            DEBUG_TUI_PTY_MUX.then(|| {
+            // % is Display, ? is Debug.
+            tracing::debug! {
+                message = "PTYMux::cleanup_terminal",
+                info = %format!("Step 3 completed in {:?}", start_time.elapsed())
+            };
+        });
+
+            // Clear screen
+            DEBUG_TUI_PTY_MUX.then(|| {
+                // % is Display, ? is Debug.
+                tracing::debug! {
+                    message = "PTYMux::cleanup_terminal",
+                    info = "Step 4: Clearing screen and homing cursor"
+                };
+            });
+            self.output_device.write(|out| {
+                let _unused =
+                    out.write_all(AnsiSequenceGenerator::clear_screen().as_bytes());
+                let _unused = out.write_all(
+                    AnsiSequenceGenerator::cursor_position(row(0), col(0)).as_bytes(),
+                );
+                let _unused = out.flush();
+            });
+            DEBUG_TUI_PTY_MUX.then(|| {
+            // % is Display, ? is Debug.
+            tracing::debug! {
+                message = "PTYMux::cleanup_terminal",
+                info = %format!("Step 4 completed in {:?}", start_time.elapsed())
+            };
+        });
+
+            // Force flush after escape sequences.
+            DEBUG_TUI_PTY_MUX.then(|| {
+                // % is Display, ? is Debug.
+                tracing::debug! {
+                    message = "PTYMux::cleanup_terminal",
+                    info = "Step 5: Final output flush after escape sequences"
+                };
+            });
+            self.output_device.write(|out| match out.flush() {
+                Ok(()) => {
+                    DEBUG_TUI_PTY_MUX.then(|| {
+                        // % is Display, ? is Debug.
+                        tracing::debug! {
+                            message = "PTYMux::cleanup_terminal",
+                            info = "Step 5: Final flush successful"
+                        };
+                    });
+                }
+                Err(e) => {
+                    DEBUG_TUI_PTY_MUX.then(|| {
+                        // % is Display, ? is Debug.
+                        tracing::warn! {
+                            message = "PTYMux::cleanup_terminal",
+                            info = %format!("Step 5: Final flush failed: {:?}", e)
+                        };
+                    });
+                }
+            });
+            DEBUG_TUI_PTY_MUX.then(|| {
+            // % is Display, ? is Debug.
+            tracing::debug! {
+                message = "PTYMux::cleanup_terminal",
+                info = %format!("Step 5 completed in {:?}", start_time.elapsed())
+            };
+        });
+
+            // End raw mode
+            DEBUG_TUI_PTY_MUX.then(|| {
+                // % is Display, ? is Debug.
+                tracing::debug! {
+                    message = "PTYMux::cleanup_terminal",
+                    info = "Step 6: Ending raw mode"
+                };
+            });
+            self.output_device.teardown_full_screen_tui().ok();
+            DEBUG_TUI_PTY_MUX.then(|| {
+                // % is Display, ? is Debug.
+                tracing::debug! {
+                    message = "PTYMux::cleanup_terminal",
+                    info = "Step 6: Raw mode ended successfully"
+                };
+            });
+
+            let total_time = start_time.elapsed();
+            DEBUG_TUI_PTY_MUX.then(|| {
+            // % is Display, ? is Debug.
+            tracing::debug! {
+                message = "PTYMux::cleanup_terminal",
+                info = %format!("Cleanup completed successfully in {:?}", total_time)
+            };
+        });
+
+            if total_time > Duration::from_millis(500) {
+                DEBUG_TUI_PTY_MUX.then(|| {
+                // % is Display, ? is Debug.
+                tracing::warn! {
+                    message = "PTYMux::cleanup_terminal",
+                    info = %format!("Cleanup took longer than expected: {:?}", total_time)
+                };
+            });
+            }
+
+            // If cleanup took too long, there might be zombie processes.
+            if total_time > Duration::from_secs(1) {
+                DEBUG_TUI_PTY_MUX.then(|| {
+                // % is Display, ? is Debug.
+                tracing::error! {
+                    message = "PTYMux::cleanup_terminal",
+                    info = "Cleanup took over 1 second; check for potential zombie processes"
+                };
+            });
             }
         }
     }

--- a/tui/src/core/pty/pty_mux/output_renderer.rs
+++ b/tui/src/core/pty/pty_mux/output_renderer.rs
@@ -10,8 +10,8 @@
 //! [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
 
 use super::ProcessManager;
-use crate::{ArrayBoundsCheck, ArrayOverflowResult, CursorVisibilityState, FlushKind,
-            GCStringOwned, IndexOps, OffscreenBuffer, OutputDevice, PixelChar, RangeExt,
+use crate::{ArrayBoundsCheck, ArrayOverflowResult, CursorVisibilityMode, FlushKind,
+            GCStringOwned, IndexOps, OffscreenBuffer, OutputDevice, PixelChar, ProcessStatus, RangeExt,
             RenderOpsLocalData, SPACE_CHAR, Size, TuiStyle, col,
             core::coordinates::{idx, len},
             ok, print_text_with_attributes, row,
@@ -120,10 +120,10 @@ impl OutputRenderer {
     /// [segmentation]: crate::graphemes
     pub fn composite_virtual_cursor_into_buffer(
         ofs_buf: &mut OffscreenBuffer,
-        cursor_visibility: CursorVisibilityState,
+        cursor_visibility: CursorVisibilityMode,
     ) {
         // Only do something if the child process requested a visible cursor.
-        if cursor_visibility == CursorVisibilityState::Hidden {
+        if cursor_visibility == CursorVisibilityMode::Hidden {
             return;
         }
 
@@ -277,7 +277,8 @@ impl OutputRenderer {
 
         for (i, process) in process_manager.processes().iter().enumerate() {
             let is_active = i == process_manager.active_index();
-            let status_indicator = if process.is_running() { "🟢" } else { "🔴" };
+            let status_indicator =
+                if process.status() == ProcessStatus::Running { "🟢" } else { "🔴" };
 
             let tab_text = if is_active {
                 format!(" [{}:{}{}] ", i + 1, status_indicator, process.name)

--- a/tui/src/core/pty/pty_mux/process_manager.rs
+++ b/tui/src/core/pty/pty_mux/process_manager.rs
@@ -12,15 +12,30 @@
 //! [ANSI parser]: crate::AnsiToOfsBufPerformer
 
 use super::output_renderer::STATUS_BAR_HEIGHT;
-use crate::{OfsBufVT100, Size,
+use crate::{DEBUG_TUI_PTY_PROCESS_MANAGER, DefaultPtySessionConfig, OfsBufVT100,
+            PtyInputEvent, PtySessionConfigOption, Size,
             core::{osc::OscEvent,
-                   pty::{PtyInputEvent, PtyOutputEvent, PtySession, PtySessionBuilder}},
+                   pty::{PtyOutputEvent, PtySession, PtySessionBuilder}},
             height, ok};
 use std::fmt::{Debug, Formatter, Result};
 
 /// Manages multiple [`PTY`] processes and handles switching between them.
 ///
 /// [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ProcessStatus {
+    Running,
+    #[default]
+    NotRunning,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum UnrenderedOutput {
+    Available,
+    #[default]
+    NotAvailable,
+}
+
 #[derive(Debug)]
 pub struct ProcessManager {
     processes: Vec<Process>,
@@ -36,24 +51,30 @@ pub struct ProcessManager {
 ///
 /// [`ANSI parser`]: vte::Parser
 pub struct Process {
-    /// Display name for this process (shown in status bar)
+    /// Display name for this process (shown in status bar).
     pub name: String,
-    /// Command to execute
+
+    /// Command to execute.
     pub command: String,
-    /// Command line arguments
+
+    /// Command line arguments.
     pub args: Vec<String>,
-    /// Optional [`PTY`] session (None if not yet spawned)
+
+    /// Optional [`PTY`] session ([`None`] if not yet spawned).
     ///
     /// [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
     session: Option<PtySession>,
-    /// Whether the process is currently running
-    is_running: bool,
-    /// Virtual terminal buffer for this process (per-process buffer architecture)
+
+    /// Virtual terminal buffer for this process (per-process buffer architecture).
     pub terminal_state: OfsBufVT100,
 
+    /// Whether the process is currently running
+    pub status: ProcessStatus,
+
     /// Tracks if this process has unrendered output since last render
-    has_unrendered_output: bool,
-    /// Terminal title set by [`OSC`] sequences (None if not set)
+    pub unrendered_output: UnrenderedOutput,
+
+    /// Terminal title set by [`OSC`] sequences ([`None`] if not set).
     ///
     /// [`OSC`]: crate::osc_codes::OscSequence
     pub terminal_title: Option<String>,
@@ -83,17 +104,16 @@ impl Process {
             command: command.into(),
             args,
             session: None,
-            is_running: false,
+            status: ProcessStatus::NotRunning,
             terminal_state: OfsBufVT100::new_empty(buffer_size),
-
-            has_unrendered_output: false,
+            unrendered_output: UnrenderedOutput::NotAvailable,
             terminal_title: None,
         }
     }
 
     /// Returns whether this process is currently running.
     #[must_use]
-    pub fn is_running(&self) -> bool { self.is_running }
+    pub fn status(&self) -> ProcessStatus { self.status }
 
     /// Updates the process's virtual terminal buffer with new [`PTY`] output.
     ///
@@ -119,11 +139,15 @@ impl Process {
                 match event {
                     OscEvent::SetTitleAndTab(title) => {
                         self.terminal_title = Some(title.clone());
-                        tracing::debug!(
-                            "Process '{}' set terminal title: {}",
-                            self.name,
-                            title
-                        );
+                        DEBUG_TUI_PTY_PROCESS_MANAGER.then(|| {
+                            // % is Display, ? is Debug.
+                            tracing::debug! {
+                                message = "PtyProcess::process_pty_output_and_update_buffer",
+                                process_name = %self.name,
+                                title = %title,
+                                "Process set terminal title"
+                            };
+                        });
                     }
                     _ => {
                         // Other OSC events can be handled here in the future.
@@ -137,25 +161,33 @@ impl Process {
             {
                 for response_event in pty_response_events {
                     let response_bytes = response_event.to_string().into_bytes();
-                    tracing::debug!(
-                        "Process '{}' sending DSR response: {:?}",
-                        self.name,
-                        response_event
-                    );
+                    DEBUG_TUI_PTY_PROCESS_MANAGER.then(|| {
+                        // % is Display, ? is Debug.
+                        tracing::debug! {
+                            message = "PtyProcess::process_pty_output_and_update_buffer",
+                            process_name = %self.name,
+                            response = ?response_event,
+                            "Sending DSR response"
+                        };
+                    });
                     // Send the response back through the PTY input channel.
                     let _unused = session
                         .tx_input_event
-                        .try_send(crate::PtyInputEvent::Write(response_bytes));
+                        .try_send(PtyInputEvent::Write(response_bytes));
                 }
             }
-            self.has_unrendered_output = true;
+            self.unrendered_output = UnrenderedOutput::Available;
 
-            tracing::trace!(
-                "Process '{}' updated buffer with {} bytes, cursor at {:?}",
-                self.name,
-                output.len(),
-                self.terminal_state.cursor_pos
-            );
+            DEBUG_TUI_PTY_PROCESS_MANAGER.then(|| {
+                // % is Display, ? is Debug.
+                tracing::trace! {
+                    message = "PtyProcess::process_pty_output_and_update_buffer",
+                    process_name = %self.name,
+                    bytes = output.len(),
+                    cursor = ?self.terminal_state.cursor_pos,
+                    "Process updated buffer"
+                };
+            });
         }
     }
 
@@ -174,16 +206,27 @@ impl Process {
         {
             match event {
                 PtyOutputEvent::Output(data) => {
-                    tracing::trace!(
-                        "Process '{}' received {} bytes of output",
-                        self.name,
-                        data.len()
-                    );
+                    DEBUG_TUI_PTY_PROCESS_MANAGER.then(|| {
+                        // % is Display, ? is Debug.
+                        tracing::trace! {
+                            message = "PtyProcess::try_get_output",
+                            process_name = %self.name,
+                            bytes = data.len(),
+                            "Yielding accumulated output bytes"
+                        };
+                    });
                     return Some(data);
                 }
                 PtyOutputEvent::Exit(_status) => {
-                    self.is_running = false;
-                    tracing::debug!("Process '{}' has exited", self.name);
+                    self.status = ProcessStatus::NotRunning;
+                    DEBUG_TUI_PTY_PROCESS_MANAGER.then(|| {
+                        // % is Display, ? is Debug.
+                        tracing::debug! {
+                            message = "PtyProcess::try_get_output",
+                            process_name = %self.name,
+                            "Process has exited"
+                        };
+                    });
                     return None;
                 }
                 _ => {}
@@ -193,7 +236,9 @@ impl Process {
     }
 
     /// Marks this process as having been rendered (clear unrendered output flag).
-    pub fn mark_as_rendered(&mut self) { self.has_unrendered_output = false; }
+    pub fn mark_as_rendered(&mut self) {
+        self.unrendered_output = UnrenderedOutput::NotAvailable;
+    }
 }
 
 impl Debug for Process {
@@ -203,9 +248,9 @@ impl Debug for Process {
             .field("command", &self.command)
             .field("args", &self.args)
             .field("session", &self.session)
-            .field("is_running", &self.is_running)
+            .field("status", &self.status)
             .field("terminal_state", &self.terminal_state)
-            .field("has_unrendered_output", &self.has_unrendered_output)
+            .field("unrendered_output", &self.unrendered_output)
             .field("terminal_title", &self.terminal_title)
             .finish()
     }
@@ -271,13 +316,17 @@ impl ProcessManager {
         let old_index = self.active_index;
         self.active_index = index;
 
-        tracing::debug!(
-            "Switched from process {} ('{}') to process {} ('{}') - instant switch with per-process buffers",
-            old_index,
-            self.processes[old_index].name,
-            index,
-            self.processes[index].name
-        );
+        DEBUG_TUI_PTY_PROCESS_MANAGER.then(|| {
+            // % is Display, ? is Debug.
+            tracing::debug! {
+                message = "ProcessManager::switch_to",
+                old_index = %old_index,
+                old_name = %self.processes[old_index].name,
+                new_index = %index,
+                new_name = %self.processes[index].name,
+                "Instant switch with per-process buffers"
+            };
+        });
 
         Some(old_index)
     }
@@ -285,7 +334,15 @@ impl ProcessManager {
     /// Spawns a process at the given index.
     fn spawn_process(&mut self, index: usize) -> miette::Result<()> {
         let process = &mut self.processes[index];
-        tracing::debug!("Spawning process: {} ({})", process.name, process.command);
+        DEBUG_TUI_PTY_PROCESS_MANAGER.then(|| {
+            // % is Display, ? is Debug.
+            tracing::debug! {
+                message = "ProcessManager::spawn_process",
+                process_name = %process.name,
+                command = %process.command,
+                "Spawning process"
+            };
+        });
 
         // Reserve bottom row for status bar - PTY gets reduced height.
         let pty_size = Size {
@@ -300,14 +357,11 @@ impl ProcessManager {
         // Use existing PtySessionBuilder with reduced size.
         let session = PtySessionBuilder::new(&process.command)
             .cli_args(&process.args)
-            .with_config(
-                crate::DefaultPtySessionConfig
-                    + crate::PtySessionConfigOption::Size(pty_size),
-            )
+            .with_config(DefaultPtySessionConfig + PtySessionConfigOption::Size(pty_size))
             .start()?;
 
         process.session = Some(session);
-        process.is_running = true;
+        process.status = ProcessStatus::Running;
         ok!()
     }
 
@@ -348,12 +402,16 @@ impl ProcessManager {
                     active_had_output = true;
                 }
 
-                tracing::trace!(
-                    "Process {} ('{}') updated its virtual terminal buffer (active: {})",
-                    i,
-                    process.name,
-                    i == self.active_index
-                );
+                DEBUG_TUI_PTY_PROCESS_MANAGER.then(|| {
+                    // % is Display, ? is Debug.
+                    tracing::trace! {
+                        message = "ProcessManager::poll_all_processes",
+                        process_index = %i,
+                        process_name = %process.name,
+                        active = %(i == self.active_index),
+                        "Updated virtual terminal buffer"
+                    };
+                });
             }
         }
 
@@ -417,11 +475,15 @@ impl ProcessManager {
             col_width: new_size.col_width,
         };
 
-        tracing::debug!(
-            "Handling terminal resize to {:?}, PTY size: {:?}",
-            new_size,
-            pty_size,
-        );
+        DEBUG_TUI_PTY_PROCESS_MANAGER.then(|| {
+            // % is Display, ? is Debug.
+            tracing::debug! {
+                message = "ProcessManager::handle_terminal_resize",
+                new_size = ?new_size,
+                pty_size = ?pty_size,
+                "Handling terminal resize"
+            };
+        });
 
         // Update all processes with new buffers and parsers.
         for (i, process) in self.processes.iter_mut().enumerate() {
@@ -429,7 +491,7 @@ impl ProcessManager {
             process.terminal_state = OfsBufVT100::new_empty(pty_size);
 
             // Clear unrendered output flag since we're starting fresh.
-            process.has_unrendered_output = false;
+            process.unrendered_output = UnrenderedOutput::NotAvailable;
 
             // Send resize event to PTY session.
             if let Some(session) = &process.session {
@@ -437,19 +499,27 @@ impl ProcessManager {
                     .tx_input_event
                     .try_send(PtyInputEvent::Resize(pty_size));
 
-                tracing::debug!(
-                    "Sent resize event to process {} ('{}') with PTY size {:?}",
-                    i,
-                    process.name,
-                    pty_size
-                );
+                DEBUG_TUI_PTY_PROCESS_MANAGER.then(|| {
+                    // % is Display, ? is Debug.
+                    tracing::debug! {
+                        message = "ProcessManager::handle_terminal_resize",
+                        process_index = %i,
+                        process_name = %process.name,
+                        pty_size = ?pty_size,
+                        "Sent resize event to process"
+                    };
+                });
             }
         }
 
-        tracing::debug!(
-            "Terminal resize handling completed for {} processes",
-            self.processes.len()
-        );
+        DEBUG_TUI_PTY_PROCESS_MANAGER.then(|| {
+            // % is Display, ? is Debug.
+            tracing::debug! {
+                message = "ProcessManager::handle_terminal_resize",
+                num_processes = %self.processes.len(),
+                "Terminal resize handling completed"
+            };
+        });
     }
 
     /// Shuts down all running processes.
@@ -458,70 +528,139 @@ impl ProcessManager {
     /// the multiplexer is shutting down.
     ///
     /// [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
+    #[allow(clippy::too_many_lines)]
     pub fn shutdown_all_processes(&mut self) {
-        tracing::debug!(
-            "Shutting down all processes - starting cleanup of {} processes",
-            self.processes.len()
-        );
+        DEBUG_TUI_PTY_PROCESS_MANAGER.then(|| {
+            // % is Display, ? is Debug.
+            tracing::debug! {
+                message = "ProcessManager::shutdown_all_processes",
+                num_processes = %self.processes.len(),
+                "Shutting down all processes - starting cleanup"
+            };
+        });
 
         for (index, process) in self.processes.iter_mut().enumerate() {
-            tracing::debug!(
-                "Processing shutdown for process {}: '{}' (running: {})",
-                index,
-                process.name,
-                process.is_running
-            );
+            DEBUG_TUI_PTY_PROCESS_MANAGER.then(|| {
+                // % is Display, ? is Debug.
+                tracing::debug! {
+                    message = "ProcessManager::shutdown_all_processes",
+                    process_index = %index,
+                    process_name = %process.name,
+                    running = %(process.status == ProcessStatus::Running),
+                    "Processing shutdown for process"
+                };
+            });
 
             if let Some(mut session) = process.session.take() {
-                tracing::debug!(
-                    "Process '{}' has active session, forcefully terminating",
-                    process.name
-                );
+                DEBUG_TUI_PTY_PROCESS_MANAGER.then(|| {
+                    // % is Display, ? is Debug.
+                    tracing::debug! {
+                        message = "ProcessManager::shutdown_all_processes",
+                        process_name = %process.name,
+                        "Process has active session, forcefully terminating"
+                    };
+                });
 
                 // CRITICAL SHUTDOWN PATTERN: Kill child process THEN send Close event
                 // 1. First, kill the child process to ensure immediate termination.
                 match session.child_process_termination_handle.kill() {
-                    Ok(()) => tracing::debug!(
-                        "Successfully killed child process for '{}'",
-                        process.name
-                    ),
-                    Err(e) => tracing::warn!(
-                        "Failed to kill child process for '{}': {:?}",
-                        process.name,
-                        e
-                    ),
+                    Ok(()) => {
+                        DEBUG_TUI_PTY_PROCESS_MANAGER.then(|| {
+                            // % is Display, ? is Debug.
+                            tracing::debug! {
+                                message = "ProcessManager::shutdown_all_processes",
+                                process_name = %process.name,
+                                "Successfully killed child process"
+                            };
+                        });
+                    }
+                    Err(e) => {
+                        DEBUG_TUI_PTY_PROCESS_MANAGER.then(|| {
+                            // % is Display, ? is Debug.
+                            tracing::warn! {
+                                message = "ProcessManager::shutdown_all_processes",
+                                process_name = %process.name,
+                                error = ?e,
+                                "Failed to kill child process"
+                            };
+                        });
+                    }
                 }
 
                 // 2. Then, send Close event to stop input writer and signal EOF.
                 // Note: Close alone is insufficient - it only stops input, doesn't kill
-                // the process
+                // the process.
                 match session.tx_input_event.try_send(PtyInputEvent::Close) {
-                    Ok(()) => tracing::debug!(
-                        "Successfully sent Close event to process '{}'",
-                        process.name
-                    ),
-                    Err(e) => tracing::warn!(
-                        "Failed to send Close event to process '{}': {:?}",
-                        process.name,
-                        e
-                    ),
+                    Ok(()) => {
+                        DEBUG_TUI_PTY_PROCESS_MANAGER.then(|| {
+                            // % is Display, ? is Debug.
+                            tracing::debug! {
+                                message = "ProcessManager::shutdown_all_processes",
+                                process_name = %process.name,
+                                "Successfully sent Close event"
+                            };
+                        });
+                    }
+                    Err(e) => {
+                        DEBUG_TUI_PTY_PROCESS_MANAGER.then(|| {
+                            // % is Display, ? is Debug.
+                            tracing::warn! {
+                                message = "ProcessManager::shutdown_all_processes",
+                                process_name = %process.name,
+                                error = ?e,
+                                "Failed to send Close event"
+                            };
+                        });
+                    }
                 }
 
-                tracing::debug!("Dropping PTY session for process '{}'", process.name);
                 // Drop the session to clean up resources.
+                DEBUG_TUI_PTY_PROCESS_MANAGER.then(|| {
+                    // % is Display, ? is Debug.
+                    tracing::debug! {
+                        message = "ProcessManager::shutdown_all_processes",
+                        process_name = %process.name,
+                        "Dropping PTY session"
+                    };
+                });
                 drop(session);
-                tracing::debug!("PTY session dropped for process '{}'", process.name);
+                DEBUG_TUI_PTY_PROCESS_MANAGER.then(|| {
+                    // % is Display, ? is Debug.
+                    tracing::debug! {
+                        message = "ProcessManager::shutdown_all_processes",
+                        process_name = %process.name,
+                        "PTY session dropped"
+                    };
+                });
 
-                process.is_running = false;
-                tracing::debug!("Process '{}' marked as not running", process.name);
+                // Mark process as not running.
+                process.status = ProcessStatus::NotRunning;
+                DEBUG_TUI_PTY_PROCESS_MANAGER.then(|| {
+                    // % is Display, ? is Debug.
+                    tracing::debug! {
+                        message = "ProcessManager::shutdown_all_processes",
+                        process_name = %process.name,
+                        "Process marked as not running"
+                    };
+                });
             } else {
-                tracing::debug!(
-                    "Process '{}' has no active session, skipping",
-                    process.name
-                );
+                DEBUG_TUI_PTY_PROCESS_MANAGER.then(|| {
+                    // % is Display, ? is Debug.
+                    tracing::debug! {
+                        message = "ProcessManager::shutdown_all_processes",
+                        process_name = %process.name,
+                        "Process has no active session, skipping"
+                    };
+                });
             }
         }
 
-        tracing::debug!("Finished shutting down all processes");
+        DEBUG_TUI_PTY_PROCESS_MANAGER.then(|| {
+            // % is Display, ? is Debug.
+            tracing::debug! {
+                message = "ProcessManager::shutdown_all_processes",
+                "Finished shutting down all processes"
+            };
+        });
     }
 }

--- a/tui/src/core/pty/pty_session/pty_output_event.rs
+++ b/tui/src/core/pty/pty_session/pty_output_event.rs
@@ -1,7 +1,6 @@
 // Copyright (c) 2025 R3BL LLC. Licensed under Apache License, Version 2.0.
 
-use crate::{DECCKM_DISABLE_BYTES, DECCKM_ENABLE_BYTES, DECCKM_SEQ_LEN, OscEvent,
-            PtyControlledChildExitStatus};
+use crate::{OscEvent, PtyControlledChildExitStatus};
 use std::borrow::Cow;
 
 /// Events received from a [`PTY`] process.
@@ -29,12 +28,6 @@ pub enum PtyOutputEvent {
     ///
     /// This gives users a chance to understand why the session ended.
     WriteError(String),
-
-    /// Terminal cursor mode changed.
-    ///
-    /// More info about cursor modes (Application vs Normal) and their detection is in
-    /// [`CursorModeDetector`].
-    CursorModeChange(CursorKeyMode),
 }
 
 /// Cursor key mode for terminal compatibility.
@@ -160,65 +153,4 @@ impl ControlSequence {
             ControlSequence::RawSequence(bytes) => Cow::Owned(bytes.clone()),
         }
     }
-}
-
-/// Cursor mode detector for parsing [`PTY`] output streams.
-///
-/// Scans for terminal mode switching sequences and maintains a buffer for partial
-/// sequence detection across read boundaries.
-///
-/// [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
-#[derive(Debug)]
-pub struct CursorModeDetector {
-    buffer: Vec<u8>,
-}
-
-impl CursorModeDetector {
-    /// Creates a new cursor mode detector.
-    #[must_use]
-    pub fn new() -> Self { Self { buffer: Vec::new() } }
-
-    /// Scans incoming data for cursor mode change sequences.
-    ///
-    /// Maintains an internal buffer to handle sequences that span multiple reads.
-    ///
-    /// # Returns
-    ///
-    /// - `Some(mode)` if a mode change sequence is detected
-    /// - `None` otherwise
-    pub fn scan_for_mode_change(&mut self, data: &[u8]) -> Option<CursorKeyMode> {
-        // Add new data to buffer.
-        self.buffer.extend_from_slice(data);
-
-        // Look for application mode enable: ESC[?1h (DECCKM set).
-        if let Some(pos) = self
-            .buffer
-            .windows(DECCKM_SEQ_LEN)
-            .position(|w| w == DECCKM_ENABLE_BYTES)
-        {
-            self.buffer.drain(..pos + DECCKM_SEQ_LEN); // Remove processed bytes.
-            return Some(CursorKeyMode::Application);
-        }
-
-        // Look for application mode disable (normal mode): ESC[?1l (DECCKM reset).
-        if let Some(pos) = self
-            .buffer
-            .windows(DECCKM_SEQ_LEN)
-            .position(|w| w == DECCKM_DISABLE_BYTES)
-        {
-            self.buffer.drain(..pos + DECCKM_SEQ_LEN);
-            return Some(CursorKeyMode::Normal);
-        }
-
-        // Keep buffer reasonable size (prevent memory growth)
-        if self.buffer.len() > 100 {
-            self.buffer.drain(..50);
-        }
-
-        None
-    }
-}
-
-impl Default for CursorModeDetector {
-    fn default() -> Self { Self::new() }
 }

--- a/tui/src/core/pty/pty_session/pty_session_builder.rs
+++ b/tui/src/core/pty/pty_session/pty_session_builder.rs
@@ -2,7 +2,7 @@
 
 use super::tasks::orchestrator::spawn_orchestrator_task;
 use crate::{CaptureFlag, ControlledChildTerminationHandle, DefaultPtySize, DefaultSize,
-            DetectFlag, InputEventSenderHalf, OutputEventReceiverHalf, PtyCommand,
+            InputEventSenderHalf, OutputEventReceiverHalf, PtyCommand,
             PtyInputEvent, PtyOrchestratorHandle, PtyOutputEvent, PtyPair, Size};
 use miette::{IntoDiagnostic, miette};
 use std::{collections::HashMap,
@@ -66,7 +66,7 @@ pub struct PtySessionBuilder {
     /// The executable command to run (e.g., [`bash`] or [`ls`]).
     ///
     /// [`bash`]: https://en.wikipedia.org/wiki/Bash_(Unix_shell)
-    /// [`ls`]: https://en.wikipedia.org/wiki/Ls_(command)
+    /// [`ls`]: https://en.wikipedia.org/wiki/ls
     pub command: String,
 
     /// Command-line arguments to pass to the executable.
@@ -438,10 +438,6 @@ pub struct PtySessionConfig {
     /// See [`PtySessionConfigOption::CaptureOutput`] for details.
     pub capture_output: CaptureFlag,
 
-    /// Whether to detect terminal cursor mode changes.
-    ///
-    /// See [`PtySessionConfigOption::DetectCursorMode`] for details.
-    pub detect_cursor_mode: DetectFlag,
 
     /// The initial window size for the [`PTY`].
     ///
@@ -477,7 +473,6 @@ mod impl_default_pty_session_config {
             PtySessionConfig {
                 capture_osc: CaptureFlag::NoCapture,
                 capture_output: CaptureFlag::Capture,
-                detect_cursor_mode: DetectFlag::Detect,
                 pty_size: DefaultPtySize.into(),
             }
         }
@@ -539,18 +534,6 @@ pub enum PtySessionConfigOption {
     /// [`Exit`]: crate::PtyOutputEvent::Exit
     NoCaptureOutput,
 
-    /// Enable detection of terminal cursor mode changes.
-    ///
-    /// Intercepts escape sequences that change the cursor's behavior (e.g.,
-    /// showing/hiding the cursor, or changing the blinking mode) and emits them
-    /// as [`PtyOutputEvent::CursorModeChange`].
-    DetectCursorMode,
-
-    /// Disable terminal cursor mode detection.
-    ///
-    /// When disabled, cursor mode escape sequences are delivered as raw output
-    /// bytes via [`PtyOutputEvent::Output`].
-    NoDetectCursorMode,
 
     /// Specify the initial window size ([`rows`] and [`columns`]) for the [`PTY`].
     ///
@@ -599,12 +582,7 @@ mod impl_elegant_constructor_dsl_pattern {
                 PtySessionConfigOption::NoCaptureOutput => {
                     self.capture_output = CaptureFlag::NoCapture;
                 }
-                PtySessionConfigOption::DetectCursorMode => {
-                    self.detect_cursor_mode = DetectFlag::Detect;
-                }
-                PtySessionConfigOption::NoDetectCursorMode => {
-                    self.detect_cursor_mode = DetectFlag::NoDetect;
-                }
+
                 PtySessionConfigOption::Size(size) => self.pty_size = size,
             }
         }
@@ -658,9 +636,7 @@ mod tests {
     fn test_default_config() {
         let config = PtySessionConfig::from(DefaultPtySessionConfig);
         assert_eq!(config.capture_osc, CaptureFlag::NoCapture);
-        assert_eq!(config.capture_output, CaptureFlag::Capture);
-        assert_eq!(config.detect_cursor_mode, DetectFlag::Detect);
-    }
+        assert_eq!(config.capture_output, CaptureFlag::Capture);    }
 
     #[test]
     fn test_option_combination() {
@@ -681,10 +657,6 @@ mod tests {
             + PtySessionConfigOption::NoCaptureOutput;
         assert_eq!(config.capture_osc, CaptureFlag::Capture);
         assert_eq!(config.capture_output, CaptureFlag::NoCapture);
-
-        // DefaultPtySessionConfig + NoDetectCursorMode.
-        let config = DefaultPtySessionConfig + PtySessionConfigOption::NoDetectCursorMode;
-        assert_eq!(config.detect_cursor_mode, DetectFlag::NoDetect);
 
         // DefaultPtySessionConfig + three options.
         let sz = size(width(80) + height(24));

--- a/tui/src/core/pty/pty_session/tasks/reader_task.rs
+++ b/tui/src/core/pty/pty_session/tasks/reader_task.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2025 R3BL LLC. Licensed under Apache License, Version 2.0.
 
-use crate::{CaptureFlag, ControllerReader, CursorModeDetector, DetectFlag, OscBuffer,
+use crate::{CaptureFlag, ControllerReader, OscBuffer,
             PtyOutputEvent, PtySessionConfig, READ_BUFFER_SIZE, ok};
 use std::io::Read;
 use tokio::sync::mpsc::Sender;
@@ -46,7 +46,6 @@ pub fn spawn_blocking_reader_task(
     tokio::task::spawn_blocking(move || -> miette::Result<()> {
         let mut buf = [0u8; READ_BUFFER_SIZE];
         let mut osc_buffer = OscBuffer::new();
-        let mut cursor_detector = CursorModeDetector::new();
 
         loop {
             match reader.read(&mut buf) {
@@ -66,15 +65,6 @@ pub fn spawn_blocking_reader_task(
                             let _unused = output_event_ch_tx_half
                                 .blocking_send(PtyOutputEvent::Osc(event));
                         }
-                    }
-
-                    // 3. Detect cursor mode changes if enabled.
-                    if config.detect_cursor_mode == DetectFlag::Detect
-                        && let Some(mode) =
-                            cursor_detector.scan_for_mode_change(&buf[..n])
-                    {
-                        let _unused = output_event_ch_tx_half
-                            .blocking_send(PtyOutputEvent::CursorModeChange(mode));
                     }
                 }
                 Err(e) => {

--- a/tui/src/core/stack_alloc_types/into_existing.rs
+++ b/tui/src/core/stack_alloc_types/into_existing.rs
@@ -68,7 +68,7 @@
 //! 5. For repeated patterns, consider using the optimized macros in this module like
 //!    `pad_fmt!` which avoid formatting overhead
 //!
-//! [`fast_stringify`]: ../common/fast_stringify
+//! [`fast_stringify`]: mod@crate::core::common::fast_strings#string-allocation-performance-strategy
 //! [`FastStringify`]: crate::FastStringify
 
 use crate::{CommonResult, DEFAULT_READ_BUFFER_SIZE, ok};

--- a/tui/src/lib.rs
+++ b/tui/src/lib.rs
@@ -104,6 +104,9 @@
 //! - [Type-safe bounds checking](#type-safe-bounds-checking)
 //!   - [The Problem](#the-problem)
 //!   - [The Solution](#the-solution)
+//! - [Zero-Allocation String Formatting](#zero-allocation-string-formatting)
+//!   - [The Performance Challenge](#the-performance-challenge)
+//!   - [The `fast_strings` Solution](#the-fast_strings-solution)
 //! - [Terminal Restoration: Panic, Drop, and Mutex
 //!   Poison-Safety](#terminal-restoration-panic-drop-and-mutex-poison-safety)
 //!   - [Panic vs. Drop handling](#panic-vs-drop-handling)
@@ -908,6 +911,41 @@
 //!
 //! See the extensive and detailed [`bounds_check` module
 //! documentation](mod@crate::bounds_check).
+//!
+//! # Zero-Allocation String Formatting
+//!
+//! When rendering terminal UIs, especially at high frame rates or when parsing
+//! high-volume `VT-100` PTY output, generating strings and formatting ANSI escape
+//! sequences can quickly become a performance bottleneck due to excessive heap
+//! allocations and the overhead of the [`std::fmt::Formatter`] state machine.
+//!
+//! ## The Performance Challenge
+//!
+//! Standard formatting mechanisms like `format!()` or implementations of
+//! [`std::fmt::Display`] are versatile but carry hidden costs:
+//! 1. **Heap Allocations**: They frequently allocate new `String` objects on the heap.
+//! 2. **Formatter Overhead**: They rely on [`std::fmt::Formatter`], which maintains
+//!    internal state (padding, alignment) and adds computational overhead even for simple
+//!    strings.
+//! 3. **Indirection**: Output is often written to intermediate buffers before hitting the
+//!    actual destination.
+//!
+//! ## The `fast_strings` Solution
+//!
+//! The `r3bl_tui` crate includes the [`fast_strings`] architecture, which completely
+//! eliminates these bottlenecks for hot-path rendering.
+//!
+//! - **[`format_no_alloc`]**: Provides a drop-in replacement for `format!()` that
+//!   evaluates and joins string slices entirely on the stack, returning a `String` only
+//!   at the very end.
+//! - **[`FastStringify`]**: A trait that bypasses [`std::fmt::Formatter`] entirely,
+//!   writing bytes directly to a pre-allocated, resizable buffer ([`BufTextStorage`]).
+//! - **[`generate_impl_display_for_fast_stringify!`]**: A macro that automatically
+//!   bridges `FastStringify` back to [`std::fmt::Display`] for API compatibility when
+//!   performance isn't critical.
+//!
+//! See the [`fast_strings`] module documentation for detailed performance analysis and
+//! usage patterns.
 //!
 //! # Terminal Restoration: Panic, Drop, and Mutex Poison-Safety
 //!
@@ -1789,7 +1827,7 @@
 //! │ │             │  │             │ │                          │
 //! │ │      ───────┼──┼─────────────┼─┼────⟩ RenderPipeline ─╮   │
 //! │ │             │  │             │ │                      │   │
-//! │ │             │  │             │ │                      ⎩ ✚ ⎩
+//! │ │             │  │             │ │                      ⎩ + ⎩
 //! │ │             │  │             │ │       ╭─────────────────────╮
 //! │ └─────────────┘  └─────────────┘ │       │                     │
 //! │                                  │       │  OffscreenBuffer    │
@@ -2730,6 +2768,13 @@
 //!
 //! <!-- Type references for documentation links -->
 //!
+//! [`fast_strings`]:
+//!     mod@crate::core::common::fast_strings#string-allocation-performance-strategy
+//! [`format_no_alloc`]: macro@crate::format_no_alloc
+//! [`FastStringify`]: crate::core::common::fast_strings::fast_stringify::FastStringify
+//! [`generate_impl_display_for_fast_stringify!`]:
+//!     macro@crate::generate_impl_display_for_fast_stringify
+//! [`BufTextStorage`]: crate::core::common::fast_strings::fast_stringify::BufTextStorage
 //! [`TTY`]: https://en.wikipedia.org/wiki/Tty_(Unix)
 //! [`TerminalModeController`]: crate::TerminalModeController
 //! [`FullScreenTuiModeGuard`]: crate::FullScreenTuiModeGuard

--- a/tui/src/tui/mod.rs
+++ b/tui/src/tui/mod.rs
@@ -54,15 +54,20 @@ pub const DEBUG_TUI_SHOW_DIRECT_TO_ANSI: bool = false;
 /// [`mio-poller`]: crate::terminal_lib_backends::direct_to_ansi::input::mio_poller
 pub const DEBUG_TUI_SHOW_MIO_POLLER: bool = false;
 
-/// Controls whether desktop notifications are displayed by the [PTY multiplexer].
-///
-/// [PTY multiplexer]: crate::pty::pty_mux::PTYMux
-pub const DEBUG_TUI_SHOW_PTY_MUX_NOTIFICATIONS: bool = false;
-
 /// Controls debug logging for the [PTY multiplexer], including adaptive rendering.
 ///
 /// [PTY multiplexer]: crate::pty::pty_mux::PTYMux
 pub const DEBUG_TUI_PTY_MUX: bool = true;
+
+/// Controls high-volume debug logging for the [`ProcessManager`].
+///
+/// Logs continuous data polling events, byte output yielding, and terminal resizing
+/// within the active [`PTY`] sessions. Because of the extreme volume of bytes being
+/// parsed from the PTY event loop, this is separated from [`DEBUG_TUI_PTY_MUX`].
+///
+/// [`ProcessManager`]: crate::core::pty::pty_mux::ProcessManager
+/// [`PTY`]: https://en.wikipedia.org/wiki/Pseudoterminal
+pub const DEBUG_TUI_PTY_PROCESS_MANAGER: bool = false;
 
 /// Controls debug logging for the [VT100 PTY output parser].
 ///

--- a/tui/src/tui/terminal_lib_backends/offscreen_buffer/ofs_buf_core.rs
+++ b/tui/src/tui/terminal_lib_backends/offscreen_buffer/ofs_buf_core.rs
@@ -260,6 +260,42 @@ impl OffscreenBuffer {
         }
     }
 
+    /// Resize the buffer to a new window size, preserving as much content as fits.
+    /// Cursor position is clamped to the new bounds.
+    pub fn resize(&mut self, arg_new_size: impl Into<Size>) {
+        let new_size: Size = arg_new_size.into();
+        let old_height = self.buffer.len();
+        let old_width = self.buffer.first().map_or(0, |l| l.len());
+        let new_height = new_size.row_height.as_usize();
+        let new_width = new_size.col_width.as_usize();
+
+        let mut new_lines = PixelCharLines::new_empty(new_size);
+
+        let copy_rows = old_height.min(new_height);
+        let copy_cols = old_width.min(new_width);
+        for i in 0..copy_rows {
+            let src = &self.buffer[i].pixel_chars;
+            let dst = &mut new_lines[i].pixel_chars;
+            dst[..copy_cols].copy_from_slice(&src[..copy_cols]);
+        }
+
+        self.buffer = new_lines;
+        self.window_size = new_size;
+
+        let cur_row = self.cursor_pos.row_index.as_usize().min(new_height.saturating_sub(1));
+        let cur_col = self.cursor_pos.col_index.as_usize().min(new_width.saturating_sub(1));
+        self.cursor_pos = Pos {
+            row_index: row(cur_row),
+            col_index: col(cur_col),
+        };
+
+        self.cached_memory_size = MemorySize::new(
+            self.buffer.get_mem_size()
+                + std::mem::size_of::<Size>()
+                + std::mem::size_of::<Pos>(),
+        );
+    }
+
     // Make sure each line is full of empty chars.
     pub fn clear(&mut self) {
         for line in self.buffer.iter_mut() {

--- a/tui/src/tui/terminal_lib_backends/offscreen_buffer/pixel_char_line.rs
+++ b/tui/src/tui/terminal_lib_backends/offscreen_buffer/pixel_char_line.rs
@@ -307,9 +307,7 @@ mod tests {
         let mut line = PixelCharLine::new_empty(width);
 
         // Fill with voids.
-        for pixel_char in &mut line.pixel_chars {
-            *pixel_char = PixelChar::Void;
-        }
+        line.pixel_chars.fill(PixelChar::Void);
 
         let debug_output = format!("{line:?}");
         assert!(debug_output.contains("void"));


### PR DESCRIPTION
## Problem

Originally part of #456 but dropped when the PR was closed. r3bl's `ProcessManager::handle_terminal_resize` creates a fresh `OfsBufVT100::new_empty(size)`, losing all terminal content. This is bad UX when the terminal pane is resized (e.g., scrollbar toggle in alternate mode wipes vim buffer).

Alternatives considered in r3bl:
1. **Fresh buffer** (`new_empty`) — loses all terminal content. Unacceptable for explorer use case.
2. **No resize** — render ops at wrong dimensions cause panics or visual corruption.
3. **Manual copy** — equivalent to what `resize()` already does.

## Changes

Add `OffscreenBuffer::resize(&mut self, arg_new_size: impl Into<Size>)`:
- Copies overlapping content region from old buffer to new buffer
- Clamps cursor position to new bounds
- Updates `window_size` and `cached_memory_size`

## Usage

Explorer uses this when alternate mode activates: resizes the terminal pane to use extra space and hide the scrollbar, without wiping the program's buffer.

Related: #456

Verification:
- [ ] Cargo check passes
- [ ] Tests pass