### PR TITLE
feat: add Flat2DArray::{len, is_empty, get} accessors

### DIFF
--- a/tui/src/core/common/flat_2d_array/array_2d_access.rs
+++ b/tui/src/core/common/flat_2d_array/array_2d_access.rs
@@ -135,6 +135,18 @@ impl<T: Clone> Flat2DArray<T> {
 }
 
 impl<T> Flat2DArray<T> {
+    /// Returns the total number of elements in the flat array.
+    #[must_use]
+    pub fn len(&self) -> usize { self.data.len() }
+
+    /// Returns `true` if the array contains no elements.
+    #[must_use]
+    pub fn is_empty(&self) -> bool { self.data.is_empty() }
+
+    /// Returns a reference to an element by flat index, or `None` if out of bounds.
+    #[must_use]
+    pub fn get(&self, index: usize) -> Option<&T> { self.data.get(index) }
+
     /// Gets a reference to the element at the specified 2D coordinates.
     ///
     /// # Errors


### PR DESCRIPTION
Add flat-index accessors to `Flat2DArray` for direct access to the backing `Vec<T>` without needing row/column decomposition.

```
- `len() -> usize` — total element count
- `is_empty() -> bool` — whether empty  
- `get(index) -> Option<&T>` — get element by flat index
```

**Use cases:**

1. **External inspection/debugging**: Tools like an "explorer" that need to dump or snapshot buffer contents don't know (or care about) the 2D grid dimensions. Flat access avoids requiring the caller to compute row/col bounds.

2. **Total capacity query**: Without `len()`, callers have to multiply `get_width().as_usize() * get_height().as_usize()` themselves — error-prone and noisy.

3. **Cache-friendly iteration**: When iterating over the entire buffer, a single flat loop over `self.data` is more efficient than nested row/col loops. `get()` enables this without exposing the internal `data` field.

4. **Safe bounds-checked access**: `Flat2DArray` already has `Index`/\`IndexMut` impls but those panic on OOB. `get()` returns `Option` for safe fallback.

Cherry-picked from fork/main commit 6d92241 (slimmed down per agent feedback — only `Flat2DArray` methods retained).