### PR TITLE
fix: parse modified Home/End CSI sequences, prevent unrecognized sequences from wedging input

### DIFF
--- a/tui/src/core/ansi/generator/ansi_input.rs
+++ b/tui/src/core/ansi/generator/ansi_input.rs
@@ -365,16 +365,24 @@ mod keyboard {
     ) -> Option<Vec<u8>> {
         match code {
             // Arrow keys: CSI [1;mod] A/B/C/D
-            VT100KeyCodeIR::Up => Some(generate_arrow_key(ARROW_UP_FINAL, modifiers)),
-            VT100KeyCodeIR::Down => Some(generate_arrow_key(ARROW_DOWN_FINAL, modifiers)),
-            VT100KeyCodeIR::Right => {
-                Some(generate_arrow_key(ARROW_RIGHT_FINAL, modifiers))
+            VT100KeyCodeIR::Up => Some(generate_modified_csi_key(ARROW_UP_FINAL, modifiers)),
+            VT100KeyCodeIR::Down => {
+                Some(generate_modified_csi_key(ARROW_DOWN_FINAL, modifiers))
             }
-            VT100KeyCodeIR::Left => Some(generate_arrow_key(ARROW_LEFT_FINAL, modifiers)),
+            VT100KeyCodeIR::Right => {
+                Some(generate_modified_csi_key(ARROW_RIGHT_FINAL, modifiers))
+            }
+            VT100KeyCodeIR::Left => {
+                Some(generate_modified_csi_key(ARROW_LEFT_FINAL, modifiers))
+            }
 
-            // Navigation keys: CSI H/F (no modifier support in this format)
-            VT100KeyCodeIR::Home => Some(generate_simple_csi(SPECIAL_HOME_FINAL)),
-            VT100KeyCodeIR::End => Some(generate_simple_csi(SPECIAL_END_FINAL)),
+            // Navigation keys: CSI [1;mod] H/F
+            VT100KeyCodeIR::Home => {
+                Some(generate_modified_csi_key(SPECIAL_HOME_FINAL, modifiers))
+            }
+            VT100KeyCodeIR::End => {
+                Some(generate_modified_csi_key(SPECIAL_END_FINAL, modifiers))
+            }
 
             // Special keys: CSI n [;mod] ~
             VT100KeyCodeIR::Insert => {
@@ -403,8 +411,13 @@ mod keyboard {
         }
     }
 
-    /// Generate arrow key sequence: `CSI [1;mod] final`.
-    fn generate_arrow_key(final_byte: u8, modifiers: VT100KeyModifiersIR) -> Vec<u8> {
+    /// Generate a modifier-aware [`CSI`] key sequence: `CSI [1;mod] final`.
+    ///
+    /// Used for arrow keys and Home/End, which share the same `CSI 1 ; mod final`
+    /// modifier encoding.
+    ///
+    /// [`CSI`]: crate::CsiSequence
+    fn generate_modified_csi_key(final_byte: u8, modifiers: VT100KeyModifiersIR) -> Vec<u8> {
         let mut bytes = CSI_PREFIX.to_vec();
         if encoding::has_modifiers(modifiers) {
             bytes.push(encoding::push_ascii_number(1));

--- a/tui/src/core/ansi/vt_100_terminal_input_parser/keyboard.rs
+++ b/tui/src/core/ansi/vt_100_terminal_input_parser/keyboard.rs
@@ -980,6 +980,21 @@ mod helpers {
                     modifiers,
                 })
             }
+            // Home/End keys with modifiers: CSI 1 ; m H/F (e.g. Ctrl+End = ESC[1;5F)
+            (2, SPECIAL_HOME_FINAL) if params[0] == 1 => {
+                let modifiers = decode_modifiers(extract_modifier_parameter(params[1]));
+                Some(VT100InputEventIR::Keyboard {
+                    code: VT100KeyCodeIR::Home,
+                    modifiers,
+                })
+            }
+            (2, SPECIAL_END_FINAL) if params[0] == 1 => {
+                let modifiers = decode_modifiers(extract_modifier_parameter(params[1]));
+                Some(VT100InputEventIR::Keyboard {
+                    code: VT100KeyCodeIR::End,
+                    modifiers,
+                })
+            }
             // Function keys and special keys: CSI n ~ or CSI n ; m ~
             (1, ANSI_FUNCTION_KEY_TERMINATOR) => {
                 parse_function_or_special_key(params[0], VT100KeyModifiersIR::default())
@@ -1538,6 +1553,112 @@ mod tests {
                 assert_eq!(modifiers.ctrl, KeyState::Pressed);
             }
             _ => panic!("Expected Shift+Alt+Ctrl+Left"),
+        }
+        assert_eq!(bytes_consumed.as_usize(), input.len());
+    }
+
+    // ==================== Home/End Keys with Modifiers ====================
+    // Regression tests: ESC[1;5H (Ctrl+Home) and ESC[1;5F (Ctrl+End) used to fall
+    // through to `_ => None` in parse_csi_parameters, which is indistinguishable from
+    // "incomplete sequence" to the caller's stateful byte accumulator - permanently
+    // wedging all future keyboard input once either combo was pressed.
+
+    #[test]
+    fn test_ctrl_home() {
+        // ESC[1;5H = Ctrl+Home (sent by xterm, alacritty, kitty, foot, wezterm, ...)
+        let input = special_key_sequence(
+            VT100KeyCodeIR::Home,
+            VT100KeyModifiersIR {
+                shift: KeyState::NotPressed,
+                alt: KeyState::NotPressed,
+                ctrl: KeyState::Pressed,
+            },
+        );
+        let (event, bytes_consumed) =
+            parse_keyboard_sequence(&input).expect("Should parse Ctrl+Home");
+        match event {
+            VT100InputEventIR::Keyboard {
+                code: VT100KeyCodeIR::Home,
+                modifiers,
+            } => {
+                assert_eq!(modifiers.shift, KeyState::NotPressed);
+                assert_eq!(modifiers.alt, KeyState::NotPressed);
+                assert_eq!(
+                    modifiers.ctrl,
+                    KeyState::Pressed,
+                    "Ctrl+Home should have ctrl modifier set"
+                );
+            }
+            _ => panic!("Expected Ctrl+Home"),
+        }
+        assert_eq!(bytes_consumed.as_usize(), input.len());
+    }
+
+    #[test]
+    fn test_ctrl_end() {
+        // ESC[1;5F = Ctrl+End (sent by xterm, alacritty, kitty, foot, wezterm, ...)
+        let input = special_key_sequence(
+            VT100KeyCodeIR::End,
+            VT100KeyModifiersIR {
+                shift: KeyState::NotPressed,
+                alt: KeyState::NotPressed,
+                ctrl: KeyState::Pressed,
+            },
+        );
+        let (event, bytes_consumed) =
+            parse_keyboard_sequence(&input).expect("Should parse Ctrl+End");
+        match event {
+            VT100InputEventIR::Keyboard {
+                code: VT100KeyCodeIR::End,
+                modifiers,
+            } => {
+                assert_eq!(modifiers.shift, KeyState::NotPressed);
+                assert_eq!(modifiers.alt, KeyState::NotPressed);
+                assert_eq!(
+                    modifiers.ctrl,
+                    KeyState::Pressed,
+                    "Ctrl+End should have ctrl modifier set"
+                );
+            }
+            _ => panic!("Expected Ctrl+End"),
+        }
+        assert_eq!(bytes_consumed.as_usize(), input.len());
+    }
+
+    #[test]
+    fn test_shift_home() {
+        // ESC[1;2H = Shift+Home
+        let input = &[0x1B, b'[', b'1', b';', b'2', b'H'];
+        let (event, bytes_consumed) =
+            parse_keyboard_sequence(input).expect("Should parse Shift+Home");
+        match event {
+            VT100InputEventIR::Keyboard {
+                code: VT100KeyCodeIR::Home,
+                modifiers,
+            } => {
+                assert_eq!(modifiers.shift, KeyState::Pressed);
+                assert_eq!(modifiers.ctrl, KeyState::NotPressed);
+            }
+            _ => panic!("Expected Shift+Home"),
+        }
+        assert_eq!(bytes_consumed.as_usize(), input.len());
+    }
+
+    #[test]
+    fn test_shift_end() {
+        // ESC[1;2F = Shift+End
+        let input = &[0x1B, b'[', b'1', b';', b'2', b'F'];
+        let (event, bytes_consumed) =
+            parse_keyboard_sequence(input).expect("Should parse Shift+End");
+        match event {
+            VT100InputEventIR::Keyboard {
+                code: VT100KeyCodeIR::End,
+                modifiers,
+            } => {
+                assert_eq!(modifiers.shift, KeyState::Pressed);
+                assert_eq!(modifiers.ctrl, KeyState::NotPressed);
+            }
+            _ => panic!("Expected Shift+End"),
         }
         assert_eq!(bytes_consumed.as_usize(), input.len());
     }

--- a/tui/src/tui/terminal_lib_backends/direct_to_ansi/input/stateful_parser.rs
+++ b/tui/src/tui/terminal_lib_backends/direct_to_ansi/input/stateful_parser.rs
@@ -6,6 +6,14 @@ use crate::core::ansi::vt_100_terminal_input_parser::{VT100InputEventIR,
                                                       try_parse_input_event};
 use std::collections::VecDeque;
 
+/// Upper bound on how many bytes a single escape sequence can accumulate to before
+/// [`StatefulInputParser::advance`] gives up on it and resyncs.
+///
+/// Comfortably larger than any sequence this parser recognizes (the longest is the
+/// `modifyOtherKeys` form `ESC[27;mod;codepoint~`, at ~15 bytes), so this only ever
+/// triggers on genuinely unrecognized/malformed input.
+const MAX_ESCAPE_SEQUENCE_LEN: usize = 64;
+
 /// Stateful parser for terminal input bytes.
 ///
 /// Accumulates bytes and parses them into [`VT100InputEventIR`] events using the
@@ -61,8 +69,20 @@ impl StatefulInputParser {
                     self.buffer.clear();
                 }
                 None => {
-                    // Incomplete sequence or waiting for more bytes.
-                    // Keep buffer and continue accumulating.
+                    // Incomplete sequence or waiting for more bytes. Keep buffer and
+                    // continue accumulating - UNLESS it has grown suspiciously long,
+                    // which means it's not actually incomplete but rather a complete
+                    // sequence this parser doesn't recognize. Without this check, such
+                    // a sequence would never clear the buffer, silently swallowing
+                    // every keystroke that follows it for the rest of the session.
+                    if self.buffer.len() > MAX_ESCAPE_SEQUENCE_LEN {
+                        tracing::warn!(
+                            bytes = ?self.buffer,
+                            "StatefulInputParser: discarding unrecognized escape \
+                             sequence that exceeded {MAX_ESCAPE_SEQUENCE_LEN} bytes"
+                        );
+                        self.buffer.clear();
+                    }
                 }
             }
         }
@@ -472,5 +492,50 @@ mod tests_utf8_input {
         let events: Vec<_> = (&mut parser).collect();
         assert_eq!(events.len(), 1);
         assert_eq!(events[0], keyboard_event(VT100KeyCodeIR::Char('é')));
+    }
+}
+
+/// Regression tests guarding against the whole bug class behind the Ctrl+End freeze:
+/// a complete-but-unrecognized escape sequence must never permanently wedge the parser,
+/// since `try_parse_input_event` returning `None` is otherwise indistinguishable from
+/// "incomplete, wait for more bytes".
+#[cfg(test)]
+mod tests_unrecognized_sequence_resilience {
+    use super::MAX_ESCAPE_SEQUENCE_LEN;
+    use super::test_fixtures::*;
+
+    #[test]
+    fn unrecognized_but_complete_sequence_does_not_block_subsequent_input() {
+        // A syntactically well-formed but unrecognized CSI sequence: ESC [ 1 ; 5 Q
+        // ('Q' is not a final byte this parser maps to anything). Before the fix, this
+        // would return None forever and every following byte would be silently
+        // swallowed into the same dead buffer.
+        let mut parser = StatefulInputParser::default();
+        parser.advance(&[ANSI_ESC, b'[', b'1', b';', b'5', b'Q'], false);
+        assert_eq!(
+            (&mut parser).collect::<Vec<_>>().len(),
+            0,
+            "unrecognized sequence should not itself produce an event"
+        );
+
+        // Padding to exceed MAX_ESCAPE_SEQUENCE_LEN so the safety valve kicks in and
+        // discards the stuck buffer. Once discarded, the padding bytes themselves get
+        // reparsed as plain characters (expected, not a bug) - drain and ignore those;
+        // what matters is that the parser is no longer wedged afterward.
+        let padding = vec![b'Q'; MAX_ESCAPE_SEQUENCE_LEN];
+        parser.advance(&padding, false);
+        (&mut parser).for_each(drop);
+
+        // A normal keystroke sent afterwards must still parse correctly - proving the
+        // parser resynced instead of staying wedged.
+        parser.advance(b"a", false);
+        let events: Vec<_> = parser.collect();
+        assert_eq!(
+            events.len(),
+            1,
+            "parser should recover and parse subsequent input after discarding \
+             an unrecognized sequence"
+        );
+        assert_eq!(events[0], keyboard_event(VT100KeyCodeIR::Char('a')));
     }
 }


### PR DESCRIPTION
## Problem

Modern terminal emulators (xterm, alacritty, kitty, foot, wezterm, ...) send Ctrl+Home / Ctrl+End as the two-parameter CSI form `ESC[1;5H` / `ESC[1;5F` (and Shift+Home/End as `ESC[1;2H` / `ESC[1;2F`). `parse_csi_parameters` in the VT100 input parser only had match arms for arrow keys (`CSI 1;mod A/B/C/D`) and the `~`-terminated function-key form — there was no arm for the 2-parameter `H`/`F` (Home/End) case, so the sequence fell through to `_ => None`.

That `None` is where this stops being a cosmetic gap and becomes a real bug: `StatefulInputParser::advance` treats `None` as "incomplete sequence, keep buffering and wait for more bytes" — it has no way to tell "incomplete" apart from "complete but unrecognized". So once a user pressed Ctrl+Home or Ctrl+End, the parser's byte accumulator got stuck on a sequence it could never resolve. Every subsequent keystroke was appended to that same dead buffer and re-parsed from the same failing prefix, forever — silently swallowing all future keyboard input. The only way out was killing the process.

## Fix

- Add `(2, SPECIAL_HOME_FINAL)` / `(2, SPECIAL_END_FINAL)` arms to `parse_csi_parameters`, mirroring the existing arrow-key modifier arms, so `ESC[1;mod H/F` decodes to `Home`/`End` with modifiers instead of falling through.
- Update the generator side (`generate_key_sequence` in `ansi_input.rs`) to emit the same modifier-aware `CSI 1;mod H/F` form for Home/End (previously it only emitted the bare `CSI H`/`CSI F` with no modifier support), and rename `generate_arrow_key` to `generate_modified_csi_key` since the helper is no longer arrow-specific.
- Defense in depth: cap `StatefulInputParser`'s accumulator at `MAX_ESCAPE_SEQUENCE_LEN` (64 bytes — comfortably larger than any sequence this parser recognizes). Any other complete-but-unrecognized escape sequence now discards the buffer and resyncs instead of wedging all future input forever. This turns "some other unmapped CSI sequence" from a permanent freeze into a one-time dropped sequence.

## Testing

Added regression tests for Ctrl+Home, Ctrl+End, Shift+Home, Shift+End, and a dedicated test (`unrecognized_but_complete_sequence_does_not_block_subsequent_input`) that reproduces the freeze class directly: feeds a well-formed-but-unmapped CSI sequence, pads past `MAX_ESCAPE_SEQUENCE_LEN`, and asserts the parser is still able to parse a normal keystroke afterward.

## Verification

`cargo check -p r3bl_tui` passes on this branch (verified in an isolated worktree off `main`; did not run the test suite per request).

Cherry-picked cleanly (no conflicts) from a fork branch where it was originally developed; this PR isolates just this fix, independent of other unrelated work in that fork.