### PR TITLE
fix(vt100): handle wide characters in PTY parser print_char

### DIFF
--- a/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_char_ops.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/ops_impl_ofs_buf/vt_100_impl_char_ops.rs
@@ -31,8 +31,8 @@
 
 #[allow(clippy::wildcard_imports)]
 use super::super::*;
-use crate::{ArrayBoundsCheck, ArrayOverflowResult, AutoWrapMode, ColIndex, Length,
-            NumericValue, OfsBufVT100, PixelChar,
+use crate::{ArrayBoundsCheck, ArrayOverflowResult, AutoWrapMode, ColIndex,
+            GCStringOwned, Length, NumericValue, OfsBufVT100, PixelChar,
             core::coordinates::bounds_check::{CursorBoundsCheck, LengthOps,
                                               RangeBoundsExt, RangeConvertExt},
             height, ok, width};
@@ -356,8 +356,31 @@ impl OfsBufVT100 {
                 return Err(miette::miette!("Operation failed"));
             }
 
-            // Move cursor forward.
-            let new_col: ColIndex = current_col + 1;
+            // Deal w/ wide characters (e.g. CJK, emoji) whose display width is > 1.
+            // A wide glyph occupies its own cell plus `width - 1` trailing cells. Those
+            // trailing cells must be filled with `PixelChar::Void` so downstream
+            // rendering (the main compositor + real terminals both advance the cursor
+            // by the glyph's display width) stays aligned with this buffer's columns.
+            // Without this, the cell after a wide glyph collides with the glyph's second
+            // column when it is painted, which swallows the following character and
+            // corrupts text selection overlays. This mirrors the `> 1` handling in
+            // `process_character_segments` in the compositor.
+            //
+            // Width is computed via `unicode_width` (`GCStringOwned::width_char`). A
+            // width of 0 (e.g. a stray combining mark arriving on its own) is treated as
+            // 1 so the cursor always advances and never stalls, matching the prior
+            // always-advance-by-1 behavior.
+            let char_width = GCStringOwned::width_char(display_char).as_usize().max(1);
+            for extra in 1..char_width {
+                let void_col = current_col + extra;
+                if void_col.overflows(col_max) == ArrayOverflowResult::Within {
+                    let _unused =
+                        self.set_char(current_row + void_col, PixelChar::Void);
+                }
+            }
+
+            // Move cursor forward by the glyph's display width.
+            let new_col: ColIndex = current_col + char_width;
 
             // Handle line wrap based on DECAWM (Auto Wrap Mode).
             //
@@ -1126,5 +1149,82 @@ mod tests_print_char {
             buffer.parser_global_state.get_pending_wrap(),
             PendingWrap::No
         );
+    }
+
+    #[test]
+    fn test_print_char_wide_emoji_injects_void() {
+        // A wide glyph (emoji '✨' is East-Asian-Wide => display width 2) must occupy
+        // its own cell plus a trailing `Void`, and advance the cursor by 2.
+        let mut buffer = create_vt100_test_buffer_with_size(width(10), height(3));
+        buffer.set_cursor_pos(row(0) + col(0));
+
+        let _unused = buffer.print_char('✨');
+
+        match buffer.get_char(row(0) + col(0)).unwrap() {
+            PixelChar::PlainText { display_char, .. } => assert_eq!(display_char, '✨'),
+            other => panic!("Expected PlainText with '✨', got {other:?}"),
+        }
+        assert_eq!(buffer.get_char(row(0) + col(1)).unwrap(), PixelChar::Void);
+        // Cursor advanced by the glyph's display width (2), not 1.
+        assert_eq!(buffer.get_cursor_pos(), row(0) + col(2));
+    }
+
+    #[test]
+    fn test_print_char_wide_cjk_injects_void() {
+        // CJK ideographs are also width 2.
+        let mut buffer = create_vt100_test_buffer_with_size(width(10), height(3));
+        buffer.set_cursor_pos(row(0) + col(0));
+
+        let _unused = buffer.print_char('好');
+
+        match buffer.get_char(row(0) + col(0)).unwrap() {
+            PixelChar::PlainText { display_char, .. } => assert_eq!(display_char, '好'),
+            other => panic!("Expected PlainText with '好', got {other:?}"),
+        }
+        assert_eq!(buffer.get_char(row(0) + col(1)).unwrap(), PixelChar::Void);
+        assert_eq!(buffer.get_cursor_pos(), row(0) + col(2));
+    }
+
+    #[test]
+    fn test_print_char_wide_then_narrow_not_swallowed() {
+        // Regression for the "swallowed character after emoji" bug: printing '✨'
+        // then '.' must yield [PlainText('✨'), Void, PlainText('.')] with the '.'
+        // landing in its own cell (column 2), not colliding with the emoji.
+        let mut buffer = create_vt100_test_buffer_with_size(width(10), height(3));
+        buffer.set_cursor_pos(row(0) + col(0));
+
+        let _unused = buffer.print_char('✨');
+        let _unused = buffer.print_char('.');
+
+        match buffer.get_char(row(0) + col(0)).unwrap() {
+            PixelChar::PlainText { display_char, .. } => assert_eq!(display_char, '✨'),
+            other => panic!("Expected PlainText with '✨', got {other:?}"),
+        }
+        assert_eq!(buffer.get_char(row(0) + col(1)).unwrap(), PixelChar::Void);
+        match buffer.get_char(row(0) + col(2)).unwrap() {
+            PixelChar::PlainText { display_char, .. } => assert_eq!(display_char, '.'),
+            other => panic!("Expected PlainText with '.', got {other:?}"),
+        }
+        assert_eq!(buffer.get_cursor_pos(), row(0) + col(3));
+    }
+
+    #[test]
+    fn test_print_char_narrow_still_advances_by_one() {
+        // Regression guard: an ordinary ASCII char advances by 1 and writes no Void.
+        let mut buffer = create_vt100_test_buffer_with_size(width(10), height(3));
+        buffer.set_cursor_pos(row(0) + col(0));
+
+        let _unused = buffer.print_char('a');
+        let _unused = buffer.print_char('b');
+
+        match buffer.get_char(row(0) + col(0)).unwrap() {
+            PixelChar::PlainText { display_char, .. } => assert_eq!(display_char, 'a'),
+            other => panic!("Expected PlainText with 'a', got {other:?}"),
+        }
+        match buffer.get_char(row(0) + col(1)).unwrap() {
+            PixelChar::PlainText { display_char, .. } => assert_eq!(display_char, 'b'),
+            other => panic!("Expected PlainText with 'b', got {other:?}"),
+        }
+        assert_eq!(buffer.get_cursor_pos(), row(0) + col(2));
     }
 }

--- a/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_protocol_char_encoding.rs
+++ b/tui/src/core/ansi/vt_100_pty_output_parser/vt_100_pty_output_conformance_tests/tests/vt_100_test_protocol_char_encoding.rs
@@ -5,7 +5,8 @@
 //! [`UTF-8`]: https://en.wikipedia.org/wiki/UTF-8
 
 use super::super::test_fixtures_vt_100_ansi_conformance::*;
-use crate::{AnsiToOfsBufPerformer, ofs_buf::test_fixtures_ofs_buf::*};
+use crate::{AnsiToOfsBufPerformer, PixelChar, col, ofs_buf::test_fixtures_ofs_buf::*,
+            row};
 use vte::Perform;
 
 #[test]
@@ -16,28 +17,44 @@ fn test_utf8_characters() {
     let mut performer = AnsiToOfsBufPerformer::new(&mut ofs_buf_vt_100);
 
     // Print various UTF-8 characters.
-    performer.print('H');
-    performer.print('é'); // Latin character with accent
-    performer.print('中'); // Chinese character
-    performer.print('🦀'); // Emoji (Rust crab)
-    performer.print('!');
+    performer.print('H'); // width 1
+    performer.print('é'); // Latin character with accent, width 1
+    performer.print('中'); // Chinese character, width 2
+    performer.print('🦀'); // Emoji (Rust crab), width 2
+    performer.print('!'); // width 1
 
-    // Verify all UTF-8 characters are in the buffer.
+    // Verify all UTF-8 characters are in the buffer. Wide characters (中, 🦀)
+    // occupy their own cell plus a trailing `PixelChar::Void` for the extra
+    // display column, so the narrow chars that follow them are pushed right.
     assert_plain_char_at(&ofs_buf_vt_100, 0, 0, 'H');
     assert_plain_char_at(&ofs_buf_vt_100, 0, 1, 'é');
     assert_plain_char_at(&ofs_buf_vt_100, 0, 2, '中');
-    assert_plain_char_at(&ofs_buf_vt_100, 0, 3, '🦀');
-    assert_plain_char_at(&ofs_buf_vt_100, 0, 4, '!');
+    assert!(
+        matches!(
+            ofs_buf_vt_100.get_char(row(0) + col(3)),
+            Some(PixelChar::Void)
+        ),
+        "expected Void trailing '中' at col 3"
+    );
+    assert_plain_char_at(&ofs_buf_vt_100, 0, 4, '🦀');
+    assert!(
+        matches!(
+            ofs_buf_vt_100.get_char(row(0) + col(5)),
+            Some(PixelChar::Void)
+        ),
+        "expected Void trailing '🦀' at col 5"
+    );
+    assert_plain_char_at(&ofs_buf_vt_100, 0, 6, '!');
 
     // Verify rest of line is empty.
-    for col in 5..10 {
-        assert_empty_at(&ofs_buf_vt_100, 0, col);
+    for col_idx in 7..10 {
+        assert_empty_at(&ofs_buf_vt_100, 0, col_idx);
     }
 
     // Verify the rest of the buffer is empty.
-    for row in 1..10 {
-        for col in 0..10 {
-            assert_empty_at(&ofs_buf_vt_100, row, col);
+    for row_idx in 1..10 {
+        for col_idx in 0..10 {
+            assert_empty_at(&ofs_buf_vt_100, row_idx, col_idx);
         }
     }
 }


### PR DESCRIPTION
`print_char` advanced the cursor by exactly 1 column for every glyph and
never wrote a trailing `PixelChar::Void`, even though the offscreen buffer
is designed to use `Void` placeholders for wide chars and both the main
compositor and real terminals render a wide glyph as 2 columns.

This column disagreement corrupted rendering of any line containing emoji
or CJK: the character after a wide glyph collided with the glyph's second
display column. It manifested as a swallowed character right after an emoji
(normal render) and as a broken/invisible emoji with the line shifted left
during text selection.

Fix: compute the glyph's display width via `GCStringOwned::width_char`
(unicode-width), fill the trailing `width - 1` cells with `PixelChar::Void`,
and advance the cursor by the full width, reusing the existing DECAWM wrap
logic. This mirrors `process_character_segments` in the compositor. A width
of 0 is treated as 1 so the cursor never stalls.

Add unit tests for wide-glyph Void injection, the emoji-then-narrow
no-swallow case, and a narrow-char regression guard. Update the
`test_utf8_characters` conformance test, which had asserted the old
(incorrect) 1-column-per-wide-char layout, to the correct Void-based layout.
